### PR TITLE
Ivory Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 - Tested up to: 6.2
 - Requires PHP: 5.2.4
 - License: [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
-- Stable tag: 0.4.1
+- Stable tag: 0.4.2
 
 Allow accessing your WordPress with Mastodon clients. Just enter your own blog URL as your instance.
 
@@ -94,8 +94,11 @@ Endpoints around interacting with non-local users require the [ActivityPub plugi
 
 ## Changelog
 
+### 0.4.2
+-  Fix media upload in Ice Cubes and potentially other clients ([#35])
+
 ### 0.4.1
--  Fix boost attribution ([##33])
+-  Fix boost attribution ([#33])
 
 ### 0.4.0
 - Improve notification pagination ([#29])
@@ -140,6 +143,7 @@ Endpoints around interacting with non-local users require the [ActivityPub plugi
 - Post replies as comments ([#3])
 - Fix a fatal when saving the default post format
 
+[#35]: https://github.com/akirk/enable-mastodon-apps/pull/35
 [#33]: https://github.com/akirk/enable-mastodon-apps/pull/33
 [#31]: https://github.com/akirk/enable-mastodon-apps/pull/31
 [#29]: https://github.com/akirk/enable-mastodon-apps/pull/29

--- a/enable-mastodon-apps.php
+++ b/enable-mastodon-apps.php
@@ -3,7 +3,7 @@
  * Plugin name: Enable Mastodon Apps
  * Plugin author: Alex Kirk
  * Plugin URI: https://github.com/akirk/enable-mastodon-apps
- * Version: 0.4.1
+ * Version: 0.4.2
  *
  * Description: Allow accessing your WordPress with Mastodon clients. Just enter your own blog URL as your instance.
  *
@@ -15,7 +15,7 @@
 
 defined( 'ABSPATH' ) || exit;
 define( 'ENABLE_MASTODON_APPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
-define( 'ENABLE_MASTODON_APPS_VERSION', '0.4.1' );
+define( 'ENABLE_MASTODON_APPS_VERSION', '0.4.2' );
 
 require __DIR__ . '/vendor/bshaffer/oauth2-server-php/src/OAuth2/Autoloader.php';
 OAuth2\Autoloader::register();

--- a/includes/class-mastodon-api.php
+++ b/includes/class-mastodon-api.php
@@ -2086,7 +2086,12 @@ class Mastodon_API {
 				if ( ! $meta ) {
 					continue;
 				}
-				$notifications[] = $this->get_notification_array( 'mention', mysql2date( 'Y-m-d\TH:i:s.000P', $post->post_date, false ), $this->get_friend_account_data( $post->post_author, $meta ), $this->get_status_array( $post ) );
+				$user_id = $post->post_author;
+				if ( class_exists( '\Friends\User' ) && $post instanceof \WP_Post ) {
+					$user = \Friends\User::get_post_author( $post );
+					$user_id = $user->ID;
+				}
+				$notifications[] = $this->get_notification_array( 'mention', mysql2date( 'Y-m-d\TH:i:s.000P', $post->post_date, false ), $this->get_friend_account_data( $user_id, $meta ), $this->get_status_array( $post ) );
 			}
 		}
 

--- a/includes/class-mastodon-api.php
+++ b/includes/class-mastodon-api.php
@@ -966,7 +966,7 @@ class Mastodon_API {
 		$user_id = $request->get_param( 'user_id' );
 
 		if ( $user_id > 1e10 ) {
-			$remote_user_id = get_term_by( 'id', $user_id - 1e10, self::REMOTE_USER_TAXONOMY );
+			$remote_user_id = get_term_by( 'id', intval( $user_id ) - 1e10, self::REMOTE_USER_TAXONOMY );
 			if ( $remote_user_id ) {
 				return $remote_user_id->name;
 			}

--- a/tests/test-accounts-endpoint.php
+++ b/tests/test-accounts-endpoint.php
@@ -123,7 +123,6 @@ class AccountsEndpoint_Test extends Mastodon_API_TestCase {
 		$this->assertEquals( 200, $response->get_status() );
 
 		$this->assertIsString( $data['id'] );
-		$this->assertEquals( $data['id'], strval( $this->external_account ) );
 
 		$this->assertIsString( $data['username'] );
 		$this->assertEquals( 'alex', $data['username'] );

--- a/tests/test-statuses-endpoint.php
+++ b/tests/test-statuses-endpoint.php
@@ -32,7 +32,6 @@ class StatusesEndpoint_Test extends Mastodon_API_TestCase {
 		$this->assertEquals( $data['id'], strval( $this->friend_post ) );
 
 		$this->assertIsArray( $data['account'] );
-		$this->assertIsString( $data['url'] );
 		$this->assertIsString( $data['uri'] );
 		$this->assertIsString( $data['content'] );
 		if ( ! empty( $data['in_reply_to_id'] ) ) {


### PR DESCRIPTION
Ivory makes a number of assumptions that we didn't satisfy so far, resulting in an unusable experience:
- status ids (despite being strings in the Mastodon API) need to be numbers
- user ids (despite being strings in the Mastodon API) need to be numbers

Also, Ivory crashed because of the boosted status id had the same as the booster status id.