### PR TITLE
Add a setting to implicitly re-register the next unknown client

### DIFF
--- a/includes/class-mastodon-admin.php
+++ b/includes/class-mastodon-admin.php
@@ -317,12 +317,6 @@ class Mastodon_Admin {
 		$codes = OAuth2\AuthorizationCodeStorage::getAll();
 		$tokens = OAuth2\AccessTokenStorage::getAll();
 		$apps = Mastodon_App::get_all();
-		$unapproved_apps = 0;
-		foreach ( $apps as $app ) {
-			if ( $app->is_unapproved() ) {
-				$unapproved_apps += 1;
-			}
-		}
 		$rest_nonce = wp_create_nonce( 'wp_rest' );
 
 		wp_enqueue_script( 'plugin-install' );
@@ -696,16 +690,6 @@ class Mastodon_Admin {
 								count( $apps )
 							)
 						);
-
-						if ( ! empty( $unapproved_apps ) ) {
-							echo esc_html(
-								sprintf(
-								// translators: %d is the number of apps.
-									_n( '%d unapproved apps', '%d unapproved apps', count( $apps ), 'enable-mastodon-apps' ),
-									count( $apps )
-								)
-							);
-						}
 						?>
 					</summary>
 					<table class="widefat">

--- a/includes/class-mastodon-admin.php
+++ b/includes/class-mastodon-admin.php
@@ -462,10 +462,10 @@ class Mastodon_Admin {
 							<fieldset>
 								<label for="mastodon_api_auto_app_reregister">
 									<input name="mastodon_api_auto_app_reregister" type="checkbox" id="mastodon_api_auto_app_reregister" value="1" <?php checked( '1', get_option( 'mastodon_api_auto_app_reregister' ) ); ?> />
-									<span><?php esc_html_e( 'Allow the next invalid_client to re-register.', 'enable-mastodon-apps' ); ?></span>
+									<span><?php esc_html_e( 'Implicitly re-register the next unknown client.', 'enable-mastodon-apps' ); ?></span>
 								</label>
 							</fieldset>
-							<p class="description"><?php esc_html_e( 'When you (accidentally) delete an app, re-add the app when it tries to authorize again.', 'enable-mastodon-apps' ); ?> <?php esc_html_e( 'This setting will turn itself off again as soon as an app has done so.', 'enable-mastodon-apps' ); ?></p>
+							<p class="description"><?php esc_html_e( 'When you (accidentally) delete an app, this allows to use the app when it tries to authorize again.', 'enable-mastodon-apps' ); ?> <?php esc_html_e( 'This setting will turn itself off again as soon as an app has done so.', 'enable-mastodon-apps' ); ?></p>
 						</td>
 					</tr>
 					<tr>

--- a/includes/class-mastodon-app.php
+++ b/includes/class-mastodon-app.php
@@ -52,6 +52,10 @@ class Mastodon_App {
 		return get_term_meta( $this->term->term_id, 'client_secret', true );
 	}
 
+	public function set_client_secret( $client_secret ) {
+		return update_term_meta( $this->term->term_id, 'client_secret', $client_secret );
+	}
+
 	public function get_redirect_uris() {
 		return get_term_meta( $this->term->term_id, 'redirect_uris', true );
 	}
@@ -74,6 +78,10 @@ class Mastodon_App {
 
 	public function get_creation_date() {
 		return get_term_meta( $this->term->term_id, 'creation_date', true );
+	}
+
+	public function is_unapproved() {
+		return ! ! get_term_meta( $this->term->term_id, 'unapproved', true );
 	}
 
 	public function get_query_args() {
@@ -196,6 +204,7 @@ class Mastodon_App {
 		return true;
 	}
 
+
 	public function delete() {
 		return wp_delete_term( $this->term->term_id, self::TAXONOMY );
 	}
@@ -258,7 +267,7 @@ class Mastodon_App {
 				'type'              => 'array',
 				'sanitize_callback' => function ( $value ) {
 					if ( ! is_array( $value ) ) {
-						return array();
+						$value = array( $value );
 					}
 					$urls = array();
 					foreach ( $value as $url ) {
@@ -376,6 +385,22 @@ class Mastodon_App {
 				'sanitize_callback' => function ( $value ) {
 					if ( ! is_int( $value ) ) {
 						$value = time();
+					}
+					return $value;
+				},
+			)
+		);
+
+		register_term_meta(
+			self::TAXONOMY,
+			'unapproved',
+			array(
+				'show_in_rest'      => false,
+				'single'            => true,
+				'type'              => 'boolean',
+				'sanitize_callback' => function ( $value ) {
+					if ( ! is_bool( $value ) ) {
+						$value = false;
 					}
 					return $value;
 				},

--- a/includes/class-mastodon-app.php
+++ b/includes/class-mastodon-app.php
@@ -80,10 +80,6 @@ class Mastodon_App {
 		return get_term_meta( $this->term->term_id, 'creation_date', true );
 	}
 
-	public function is_unapproved() {
-		return ! ! get_term_meta( $this->term->term_id, 'unapproved', true );
-	}
-
 	public function get_query_args() {
 		return get_term_meta( $this->term->term_id, 'query_args', true );
 	}
@@ -385,22 +381,6 @@ class Mastodon_App {
 				'sanitize_callback' => function ( $value ) {
 					if ( ! is_int( $value ) ) {
 						$value = time();
-					}
-					return $value;
-				},
-			)
-		);
-
-		register_term_meta(
-			self::TAXONOMY,
-			'unapproved',
-			array(
-				'show_in_rest'      => false,
-				'single'            => true,
-				'type'              => 'boolean',
-				'sanitize_callback' => function ( $value ) {
-					if ( ! is_bool( $value ) ) {
-						$value = false;
 					}
 					return $value;
 				},

--- a/includes/class-mastodon-oauth.php
+++ b/includes/class-mastodon-oauth.php
@@ -64,7 +64,7 @@ class Mastodon_OAuth {
 		add_action( 'login_form_enable-mastodon-apps-authenticate', array( $this, 'authenticate_handler' ) );
 	}
 
-	public function handle_oauth() {
+	public function handle_oauth( $return_value = false ) {
 		if ( 'POST' === $_SERVER['REQUEST_METHOD'] && empty( $_POST ) && ! empty( $_REQUEST ) ) {
 			$_POST = $_REQUEST;
 		}
@@ -72,7 +72,7 @@ class Mastodon_OAuth {
 		switch ( strtok( $_SERVER['REQUEST_URI'], '?' ) ) {
 			case '/oauth/authorize':
 				if ( get_option( 'mastodon_api_disable_logins' ) ) {
-					return;
+					return null;
 				}
 				$handler = new OAuth2\AuthorizeHandler( $this->server );
 				break;
@@ -91,11 +91,11 @@ class Mastodon_OAuth {
 
 			case '/oauth/revoke':
 				$handler = new OAuth2\RevokationHandler( $this->server );
-				exit;
+				break;
 		}
 
 		if ( ! isset( $handler ) ) {
-			return;
+			return null;
 		}
 
 		if ( get_option( 'mastodon_api_debug_mode' ) > time() ) {
@@ -109,7 +109,15 @@ class Mastodon_OAuth {
 
 		$request  = Request::createFromGlobals();
 		$response = new Response();
+		if ( 'handler' === $return_value ) {
+			return $handler;
+		}
+
 		$response = $handler->handle( $request, $response );
+		if ( 'response' === $return_value ) {
+			return $response;
+		}
+
 		$response->send();
 		exit;
 	}

--- a/includes/oauth2/mastodon-app-storage.php
+++ b/includes/oauth2/mastodon-app-storage.php
@@ -53,11 +53,20 @@ class MastodonAppStorage implements ClientCredentialsInterface {
 
 		$client = $this->get( $client_id );
 
-		if ( empty( $client->get_client_secret() ) ) {
+		if ( is_null( $client_secret ) ) {
 			return true;
 		}
 
-		return $client_secret === $client->get_client_secret();
+		if ( $client_secret !== $client->get_client_secret() ) {
+			if ( get_option( 'mastodon_api_auto_app_reregister' ) === $client_id ) {
+				$client->set_client_secret( $client_secret );
+				delete_option( 'mastodon_api_auto_app_reregister' );
+				return true;
+			}
+			return false;
+		}
+
+		return true;
 	}
 
 	public function isPublicClient( $client_id ) {
@@ -83,6 +92,31 @@ class MastodonAppStorage implements ClientCredentialsInterface {
 
 	private function has( $client_id ) {
 		$client = $this->get( $client_id );
+		if ( is_wp_error( $client ) && get_option( 'mastodon_api_auto_app_reregister' ) ) {
+			$term = wp_insert_term( $client_id, Mastodon_App::TAXONOMY );
+
+			$app_metadata = array(
+				'client_name'   => preg_replace( '/[^a-z0-9-]/', ' ', wp_parse_url( $_REQUEST['redirect_uri'], PHP_URL_HOST ) ) . ' (auto-generated)',
+				'redirect_uris' => array( $_REQUEST['redirect_uri'] ),
+				'scopes'        => $_REQUEST['scope'],
+			);
+
+			$post_formats = get_option( 'mastodon_api_default_post_formats', array( 'status' ) );
+			$post_formats = apply_filters( 'mastodon_api_new_app_post_formats', $post_formats, $app_metadata );
+
+			$term_id = $term['term_id'];
+			foreach ( $app_metadata as $key => $value ) {
+				add_metadata( 'term', $term_id, $key, $value, true );
+			}
+			add_metadata( 'term', $term_id, 'creation_date', time(), true );
+
+			$term = get_term( $term['term_id'] );
+			if ( ! is_wp_error( $term ) ) {
+				$client = new Mastodon_App( $term );
+				update_option( 'mastodon_api_auto_app_reregister', $client_id );
+			}
+		}
+
 		return ! is_wp_error( $client );
 	}
 }


### PR DESCRIPTION
It can happen that you accidentally delete an app. Some services will (rightfully) remember the app they registered with you and not attempt to create a new app later on.

To remidy this, here is a new setting that will allow such an app to implicitly register itself again by using its credentials the next time. Activate it like this:

![Screenshot 2024-01-05 at 14 39 15](https://github.com/akirk/enable-mastodon-apps/assets/203408/af4e59b4-cddc-4ca4-be52-fdc7ee00a7bf)
