### PR TITLE
Fix interoperability with WPS Hide Login

### DIFF
--- a/includes/class-mastodon-oauth.php
+++ b/includes/class-mastodon-oauth.php
@@ -68,12 +68,13 @@ class Mastodon_OAuth {
 		if ( 'POST' === $_SERVER['REQUEST_METHOD'] && empty( $_POST ) && ! empty( $_REQUEST ) ) {
 			$_POST = $_REQUEST;
 		}
-
 		switch ( strtok( $_SERVER['REQUEST_URI'], '?' ) ) {
 			case '/oauth/authorize':
 				if ( get_option( 'mastodon_api_disable_logins' ) ) {
 					return null;
 				}
+				global $wp_query;
+				$wp_query->is_404 = false;
 				$handler = new OAuth2\AuthorizeHandler( $this->server );
 				break;
 
@@ -86,10 +87,14 @@ class Mastodon_OAuth {
 					exit;
 				}
 				header( 'Access-Control-Allow-Origin: *' );
+				global $wp_query;
+				$wp_query->is_404 = false;
 				$handler = new OAuth2\TokenHandler( $this->server );
 				break;
 
 			case '/oauth/revoke':
+				global $wp_query;
+				$wp_query->is_404 = false;
 				$handler = new OAuth2\RevokationHandler( $this->server );
 				break;
 		}


### PR DESCRIPTION
Without this fix, you get into a redirect loop. See https://wordpress.org/support/topic/error-trying-to-log-in-2/