### PR TITLE
Fix duplicate line generation in whitespace code.

### DIFF
--- a/includes/class-mastodon-api.php
+++ b/includes/class-mastodon-api.php
@@ -1027,8 +1027,6 @@ class Mastodon_API {
 		// Finally remove all remaining line breaks.
 		$post_content = str_replace( PHP_EOL, '', $post_content );
 
-		$post_content = str_replace( '&#039;', "'", $post_content );
-
 		return trim( $post_content );
 	}
 

--- a/includes/class-mastodon-api.php
+++ b/includes/class-mastodon-api.php
@@ -1027,7 +1027,6 @@ class Mastodon_API {
 		// Finally remove all remaining line breaks.
 		$post_content = str_replace( PHP_EOL, '', $post_content );
 
-		// Decode single quotes?  Is this necessary?  HTML entities should be fine in content.
 		$post_content = str_replace( '&#039;', "'", $post_content );
 
 		return trim( $post_content );

--- a/includes/class-mastodon-api.php
+++ b/includes/class-mastodon-api.php
@@ -1018,8 +1018,16 @@ class Mastodon_API {
 	 * @return     string  The normalized content.
 	 */
 	private function normalize_whitespace( $post_content ) {
-		$post_content = preg_replace( '#<!-- /?wp:paragraph -->\s*<!-- /?wp:paragraph -->#', PHP_EOL, $post_content );
-		$post_content = preg_replace( '#\n\s*\n+#', PHP_EOL, $post_content );
+		// First remove any Gutenberg tags with whitespace between them.
+		$post_content = preg_replace( '#<!-- /?wp:paragraph -->\s*<!-- /?wp:paragraph -->#', '', $post_content );
+		// Then remove *all* remaining Gutenberg tags.
+		$post_content = preg_replace( '#<!-- /?wp:[a-zA-Z]+? -->#', '', $post_content );
+		// Now remove any line breaks with whitespaces between them.
+		$post_content = preg_replace( '#' . PHP_EOL . '\s*' . PHP_EOL . '+#', '', $post_content );
+		// Finally remove all remaining line breaks.
+		$post_content = str_replace( PHP_EOL, '', $post_content );
+
+		// Decode single quotes?  Is this necessary?  HTML entities should be fine in content.
 		$post_content = str_replace( '&#039;', "'", $post_content );
 
 		return trim( $post_content );


### PR DESCRIPTION
Mastodon clients do not expect newlines and some convert them into hard breaks, creating duplicate space between paragraphs.