### PR TITLE
Fix post search

### DIFF
--- a/includes/class-mastodon-api.php
+++ b/includes/class-mastodon-api.php
@@ -1574,10 +1574,16 @@ class Mastodon_API {
 						);
 					}
 				}
-			} elseif ( is_user_logged_in() ) {
-				$args['s'] = $request->get_param( 'q' );
-				$args['offset'] = $request->get_param( 'offset' );
-				$args['posts_per_page'] = $request->get_param( 'limit' );
+			} elseif ( is_user_logged_in() || $this->oauth->get_token() ) {
+				$q_param = $request->get_param( 'q' );
+				if( $q_param != null ) { $args['s'] = $q_param; }
+
+				$offset_param = $request->get_param( 'offset' );
+				if( $offset_param != null ) { $args['offset'] = $offset_param; }
+
+				$ppp_param = $request->get_param( 'limit' );
+				if( $ppp_param != null ) { $args['posts_per_page'] = $ppp_param; }
+
 				$ret['statuses'] = array_merge( $ret['statuses'], $this->get_posts( $args ) );
 			}
 		}


### PR DESCRIPTION
Search uses tokens for authentication so check to see if we have a current token in addition to a logged in user.

Cleanup the parameter passing to $this->get_posts() as well as otherwise some values can be set to null which break wp_getposts() in some circumstances.