### PR TITLE
Add scope adherence

### DIFF
--- a/includes/class-mastodon-api.php
+++ b/includes/class-mastodon-api.php
@@ -723,9 +723,10 @@ class Mastodon_API {
 			}
 
 			$has_scope = false;
-			if ( $this->app ) {
+			$token = $this->oauth->get_token();
+			if ( $token && isset( $token['scope'] ) ) {
 				foreach ( explode( ',', $scopes ) as $scope ) {
-					if ( $this->app->has_scope( $scope ) ) {
+					if ( Mastodon_App::check_scope( $token['scope'], $scope ) ) {
 						$has_scope = true;
 					}
 				}

--- a/includes/class-mastodon-api.php
+++ b/includes/class-mastodon-api.php
@@ -219,7 +219,7 @@ class Mastodon_API {
 			array(
 				'methods'             => 'POST',
 				'callback'            => array( $this, 'api_apps' ),
-				'permission_callback' => array( $this, 'public_api_permission' ),
+				'permission_callback' => $this->required_scope( false ),
 			)
 		);
 		register_rest_route(
@@ -228,7 +228,7 @@ class Mastodon_API {
 			array(
 				'methods'             => 'GET',
 				'callback'            => array( $this, 'api_announcements' ),
-				'permission_callback' => array( $this, 'logged_in_permission' ),
+				'permission_callback' => $this->required_scope( 'read:announcements' ),
 			)
 		);
 		register_rest_route(
@@ -237,7 +237,7 @@ class Mastodon_API {
 			array(
 				'methods'             => 'GET',
 				'callback'            => '__return_empty_array',
-				'permission_callback' => array( $this, 'public_api_permission' ),
+				'permission_callback' => $this->required_scope( false ),
 			)
 		);
 		register_rest_route(
@@ -246,7 +246,7 @@ class Mastodon_API {
 			array(
 				'methods'             => 'GET',
 				'callback'            => array( $this, 'api_instance' ),
-				'permission_callback' => array( $this, 'public_api_permission' ),
+				'permission_callback' => $this->required_scope( false ),
 			)
 		);
 
@@ -256,7 +256,7 @@ class Mastodon_API {
 			array(
 				'methods'             => 'GET',
 				'callback'            => array( $this, 'api_instance_v2' ),
-				'permission_callback' => array( $this, 'public_api_permission' ),
+				'permission_callback' => $this->required_scope( false ),
 			)
 		);
 		register_rest_route(
@@ -265,7 +265,7 @@ class Mastodon_API {
 			array(
 				'methods'             => 'GET',
 				'callback'            => array( $this, 'api_nodeinfo' ),
-				'permission_callback' => array( $this, 'public_api_permission' ),
+				'permission_callback' => $this->required_scope( false ),
 			)
 		);
 		register_rest_route(
@@ -274,7 +274,7 @@ class Mastodon_API {
 			array(
 				'methods'             => 'GET',
 				'callback'            => '__return_empty_array',
-				'permission_callback' => array( $this, 'logged_in_permission' ),
+				'permission_callback' => $this->required_scope( 'read:follows,follow' ),
 			)
 		);
 		register_rest_route(
@@ -283,7 +283,7 @@ class Mastodon_API {
 			array(
 				'methods'             => 'GET',
 				'callback'            => '__return_empty_array',
-				'permission_callback' => array( $this, 'logged_in_permission' ),
+				'permission_callback' => $this->required_scope( 'read:follows' ),
 			)
 		);
 		register_rest_route(
@@ -292,7 +292,7 @@ class Mastodon_API {
 			array(
 				'methods'             => 'GET',
 				'callback'            => '__return_empty_array',
-				'permission_callback' => array( $this, 'logged_in_permission' ),
+				'permission_callback' => $this->required_scope( 'read:bookmarks' ),
 			)
 		);
 		register_rest_route(
@@ -301,7 +301,7 @@ class Mastodon_API {
 			array(
 				'methods'             => 'GET',
 				'callback'            => '__return_empty_array',
-				'permission_callback' => array( $this, 'logged_in_permission' ),
+				'permission_callback' => $this->required_scope( 'read:statuses' ),
 			)
 		);
 
@@ -311,7 +311,7 @@ class Mastodon_API {
 			array(
 				'methods'             => 'GET',
 				'callback'            => '__return_empty_array',
-				'permission_callback' => array( $this, 'logged_in_permission' ),
+				'permission_callback' => $this->required_scope( 'read:favourites' ),
 			)
 		);
 		register_rest_route(
@@ -320,7 +320,7 @@ class Mastodon_API {
 			array(
 				'methods'             => 'GET',
 				'callback'            => '__return_empty_array',
-				'permission_callback' => array( $this, 'logged_in_permission' ),
+				'permission_callback' => $this->required_scope( 'read:filters' ),
 			)
 		);
 		register_rest_route(
@@ -329,7 +329,7 @@ class Mastodon_API {
 			array(
 				'methods'             => 'GET',
 				'callback'            => '__return_empty_array',
-				'permission_callback' => array( $this, 'logged_in_permission' ),
+				'permission_callback' => $this->required_scope( 'read:lists' ),
 			)
 		);
 
@@ -339,7 +339,7 @@ class Mastodon_API {
 			array(
 				'methods'             => 'GET',
 				'callback'            => '__return_empty_array',
-				'permission_callback' => array( $this, 'logged_in_permission' ),
+				'permission_callback' => $this->required_scope( 'read:statuses' ),
 			)
 		);
 
@@ -349,7 +349,7 @@ class Mastodon_API {
 			array(
 				'methods'             => 'GET',
 				'callback'            => '__return_empty_array',
-				'permission_callback' => array( $this, 'logged_in_permission' ),
+				'permission_callback' => $this->required_scope( 'read:mutes' ),
 			)
 		);
 
@@ -359,7 +359,7 @@ class Mastodon_API {
 			array(
 				'methods'             => array( 'POST', 'OPTIONS' ),
 				'callback'            => array( $this, 'api_notification_clear' ),
-				'permission_callback' => array( $this, 'logged_in_permission' ),
+				'permission_callback' => $this->required_scope( 'write:notifications' ),
 			)
 		);
 
@@ -369,7 +369,7 @@ class Mastodon_API {
 			array(
 				'methods'             => array( 'POST', 'OPTIONS' ),
 				'callback'            => array( $this, 'api_notification_dismiss' ),
-				'permission_callback' => array( $this, 'logged_in_permission' ),
+				'permission_callback' => $this->required_scope( 'write:notifications' ),
 			)
 		);
 
@@ -379,7 +379,7 @@ class Mastodon_API {
 			array(
 				'methods'             => array( 'GET', 'OPTIONS' ),
 				'callback'            => array( $this, 'api_notification_get' ),
-				'permission_callback' => array( $this, 'logged_in_permission' ),
+				'permission_callback' => $this->required_scope( 'read:notifications' ),
 			)
 		);
 
@@ -389,7 +389,7 @@ class Mastodon_API {
 			array(
 				'methods'             => 'GET',
 				'callback'            => array( $this, 'api_notifications' ),
-				'permission_callback' => array( $this, 'logged_in_permission' ),
+				'permission_callback' => $this->required_scope( 'read:notifications' ),
 			)
 		);
 
@@ -399,7 +399,7 @@ class Mastodon_API {
 			array(
 				'methods'             => 'GET',
 				'callback'            => array( $this, 'api_preferences' ),
-				'permission_callback' => array( $this, 'logged_in_permission' ),
+				'permission_callback' => $this->required_scope( 'read:accounts' ),
 			)
 		);
 
@@ -409,7 +409,7 @@ class Mastodon_API {
 			array(
 				'methods'             => 'GET',
 				'callback'            => '__return_empty_array',
-				'permission_callback' => array( $this, 'public_api_permission' ),
+				'permission_callback' => $this->required_scope( false ),
 			)
 		);
 		register_rest_route(
@@ -418,15 +418,17 @@ class Mastodon_API {
 			array(
 				'methods'             => 'GET',
 				'callback'            => '__return_empty_array',
-				'permission_callback' => array( $this, 'public_api_permission' ),
+				'permission_callback' => $this->required_scope( false ),
 			)
-		);      register_rest_route(
+		);
+
+		register_rest_route(
 			self::PREFIX,
 			'api/v1/accounts/familiar_followers',
 			array(
 				'methods'             => 'GET',
 				'callback'            => '__return_empty_array',
-				'permission_callback' => array( $this, 'logged_in_permission' ),
+				'permission_callback' => $this->required_scope( 'read:follows' ),
 			)
 		);
 
@@ -436,7 +438,7 @@ class Mastodon_API {
 			array(
 				'methods'             => array( 'GET', 'OPTIONS' ),
 				'callback'            => array( $this, 'api_verify_credentials' ),
-				'permission_callback' => array( $this, 'logged_in_permission' ),
+				'permission_callback' => $this->required_scope( 'read:accounts' ),
 			)
 		);
 
@@ -446,7 +448,7 @@ class Mastodon_API {
 			array(
 				'methods'             => array( 'GET', 'OPTIONS' ),
 				'callback'            => array( $this, 'api_accounts_search' ),
-				'permission_callback' => array( $this, 'logged_in_permission' ),
+				'permission_callback' => $this->required_scope( 'read:accounts' ),
 			)
 		);
 
@@ -456,7 +458,7 @@ class Mastodon_API {
 			array(
 				'methods'             => array( 'POST', 'OPTIONS' ),
 				'callback'            => array( $this, 'api_post_media' ),
-				'permission_callback' => array( $this, 'logged_in_permission' ),
+				'permission_callback' => $this->required_scope( 'write:media' ),
 			)
 		);
 
@@ -466,7 +468,7 @@ class Mastodon_API {
 			array(
 				'methods'             => array( 'GET', 'OPTIONS' ),
 				'callback'            => array( $this, 'api_get_media' ),
-				'permission_callback' => array( $this, 'logged_in_permission' ),
+				'permission_callback' => $this->required_scope( 'write:media' ),
 			)
 		);
 
@@ -476,7 +478,7 @@ class Mastodon_API {
 			array(
 				'methods'             => array( 'PUT', 'OPTIONS' ),
 				'callback'            => array( $this, 'api_update_media' ),
-				'permission_callback' => array( $this, 'logged_in_permission' ),
+				'permission_callback' => $this->required_scope( 'write:media' ),
 			)
 		);
 
@@ -486,7 +488,7 @@ class Mastodon_API {
 			array(
 				'methods'             => array( 'POST', 'OPTIONS' ),
 				'callback'            => array( $this, 'api_submit_post' ),
-				'permission_callback' => array( $this, 'logged_in_permission' ),
+				'permission_callback' => $this->required_scope( 'write:statuses' ),
 			)
 		);
 
@@ -496,7 +498,7 @@ class Mastodon_API {
 			array(
 				'methods'             => array( 'GET', 'OPTIONS' ),
 				'callback'            => array( $this, 'api_get_post_context' ),
-				'permission_callback' => array( $this, 'logged_in_for_private_permission' ),
+				'permission_callback' => $this->required_scope( 'read:statuses', true ),
 			)
 		);
 
@@ -506,7 +508,7 @@ class Mastodon_API {
 			array(
 				'methods'             => array( 'GET', 'OPTIONS' ),
 				'callback'            => '__return_empty_array',
-				'permission_callback' => array( $this, 'logged_in_permission' ),
+				'permission_callback' => $this->required_scope( 'read:statuses', true ),
 			)
 		);
 
@@ -516,7 +518,7 @@ class Mastodon_API {
 			array(
 				'methods'             => array( 'POST', 'OPTIONS' ),
 				'callback'            => array( $this, 'api_favourite_post' ),
-				'permission_callback' => array( $this, 'logged_in_permission' ),
+				'permission_callback' => $this->required_scope( 'write:favourites' ),
 			)
 		);
 
@@ -526,7 +528,7 @@ class Mastodon_API {
 			array(
 				'methods'             => array( 'POST', 'OPTIONS' ),
 				'callback'            => array( $this, 'api_unfavourite_post' ),
-				'permission_callback' => array( $this, 'logged_in_permission' ),
+				'permission_callback' => $this->required_scope( 'write:favourites' ),
 			)
 		);
 
@@ -536,7 +538,7 @@ class Mastodon_API {
 			array(
 				'methods'             => array( 'POST', 'OPTIONS' ),
 				'callback'            => array( $this, 'api_reblog_post' ),
-				'permission_callback' => array( $this, 'logged_in_permission' ),
+				'permission_callback' => $this->required_scope( 'write:statuses' ),
 			)
 		);
 
@@ -546,7 +548,7 @@ class Mastodon_API {
 			array(
 				'methods'             => array( 'POST', 'OPTIONS' ),
 				'callback'            => array( $this, 'api_unreblog_post' ),
-				'permission_callback' => array( $this, 'logged_in_permission' ),
+				'permission_callback' => $this->required_scope( 'write:statuses' ),
 			)
 		);
 
@@ -556,7 +558,7 @@ class Mastodon_API {
 			array(
 				'methods'             => array( 'DELETE', 'OPTIONS' ),
 				'callback'            => array( $this, 'api_delete_post' ),
-				'permission_callback' => array( $this, 'logged_in_permission' ),
+				'permission_callback' => $this->required_scope( 'write:statuses' ),
 			)
 		);
 
@@ -566,7 +568,7 @@ class Mastodon_API {
 			array(
 				'methods'             => array( 'GET', 'OPTIONS' ),
 				'callback'            => array( $this, 'api_get_post' ),
-				'permission_callback' => array( $this, 'logged_in_for_private_permission' ),
+				'permission_callback' => $this->required_scope( 'read:statuses', true ),
 			)
 		);
 
@@ -576,7 +578,7 @@ class Mastodon_API {
 			array(
 				'methods'             => array( 'GET', 'OPTIONS' ),
 				'callback'            => array( $this, 'api_timelines' ),
-				'permission_callback' => array( $this, 'logged_in_permission' ),
+				'permission_callback' => $this->required_scope( 'read:statuses' ),
 			)
 		);
 
@@ -586,7 +588,7 @@ class Mastodon_API {
 			array(
 				'methods'             => array( 'GET', 'OPTIONS' ),
 				'callback'            => array( $this, 'api_tag_timelines' ),
-				'permission_callback' => array( $this, 'logged_in_permission' ),
+				'permission_callback' => $this->required_scope( 'read:statuses' ),
 			)
 		);
 
@@ -596,7 +598,7 @@ class Mastodon_API {
 			array(
 				'methods'             => array( 'GET', 'OPTIONS' ),
 				'callback'            => array( $this, 'api_public_timeline' ),
-				'permission_callback' => array( $this, 'logged_in_permission' ),
+				'permission_callback' => $this->required_scope( false ),
 			)
 		);
 
@@ -606,7 +608,7 @@ class Mastodon_API {
 			array(
 				'methods'             => array( 'GET', 'OPTIONS' ),
 				'callback'            => '__return_empty_array',
-				'permission_callback' => array( $this, 'logged_in_permission' ),
+				'permission_callback' => $this->required_scope( 'read:statuses' ),
 			)
 		);
 
@@ -616,7 +618,7 @@ class Mastodon_API {
 			array(
 				'methods'             => array( 'GET', 'POST', 'OPTIONS' ),
 				'callback'            => array( $this, 'api_push_subscription' ),
-				'permission_callback' => array( $this, 'logged_in_permission' ),
+				'permission_callback' => $this->required_scope( 'push' ),
 			)
 		);
 
@@ -636,7 +638,7 @@ class Mastodon_API {
 			array(
 				'methods'             => array( 'GET', 'OPTIONS' ),
 				'callback'            => array( $this, 'api_account_relationships' ),
-				'permission_callback' => array( $this, 'logged_in_permission' ),
+				'permission_callback' => $this->required_scope( 'read:follows' ),
 			)
 		);
 
@@ -646,7 +648,7 @@ class Mastodon_API {
 			array(
 				'methods'             => array( 'GET', 'OPTIONS' ),
 				'callback'            => '__return_empty_array',
-				'permission_callback' => array( $this, 'logged_in_permission' ),
+				'permission_callback' => $this->required_scope( false ),
 			)
 		);
 
@@ -656,7 +658,7 @@ class Mastodon_API {
 			array(
 				'methods'             => array( 'GET', 'OPTIONS' ),
 				'callback'            => array( $this, 'api_account_followers' ),
-				'permission_callback' => array( $this, 'logged_in_permission' ),
+				'permission_callback' => $this->required_scope( false ),
 			)
 		);
 
@@ -666,7 +668,7 @@ class Mastodon_API {
 			array(
 				'methods'             => array( 'POST', 'OPTIONS' ),
 				'callback'            => array( $this, 'api_account_follow' ),
-				'permission_callback' => array( $this, 'logged_in_permission' ),
+				'permission_callback' => $this->required_scope( 'write:follows' ),
 			)
 		);
 
@@ -676,7 +678,7 @@ class Mastodon_API {
 			array(
 				'methods'             => array( 'POST', 'OPTIONS' ),
 				'callback'            => array( $this, 'api_account_unfollow' ),
-				'permission_callback' => array( $this, 'logged_in_permission' ),
+				'permission_callback' => $this->required_scope( 'write:follows' ),
 			)
 		);
 
@@ -686,7 +688,7 @@ class Mastodon_API {
 			array(
 				'methods'             => array( 'GET', 'OPTIONS' ),
 				'callback'            => array( $this, 'api_account_statuses' ),
-				'permission_callback' => array( $this, 'logged_in_permission' ),
+				'permission_callback' => $this->required_scope( 'read:statuses', true ),
 			)
 		);
 
@@ -696,7 +698,7 @@ class Mastodon_API {
 			array(
 				'methods'             => array( 'GET', 'OPTIONS' ),
 				'callback'            => array( $this, 'api_account' ),
-				'permission_callback' => array( $this, 'logged_in_permission' ),
+				'permission_callback' => $this->required_scope( false ),
 			)
 		);
 	}
@@ -704,6 +706,37 @@ class Mastodon_API {
 	public function query_vars( $query_vars ) {
 		$query_vars[] = 'enable-mastodon-apps';
 		return $query_vars;
+	}
+
+	public function required_scope( $scopes, $also_public = false ) {
+		if ( false === $scopes ) {
+			return array( $this, 'public_api_permission' );
+		}
+
+		return function ( $request ) use ( $scopes, $also_public ) {
+			if ( $also_public ) {
+				if ( ! $this->logged_in_for_private_permission( $request ) ) {
+					return new \WP_Error( 'token-required', 'Token required', array( 'status' => 401 ) );
+				}
+			} elseif ( ! $this->logged_in_permission( $request ) ) {
+				return new \WP_Error( 'token-required', 'Token required', array( 'status' => 401 ) );
+			}
+
+			$has_scope = false;
+			if ( $this->app ) {
+				foreach ( explode( ',', $scopes ) as $scope ) {
+					if ( $this->app->has_scope( $scope ) ) {
+						$has_scope = true;
+					}
+				}
+			}
+
+			if ( ! $has_scope && ! $also_public ) {
+				return new \WP_Error( 'insufficient-permissions', 'Insufficient permissions', array( 'status' => 401 ) );
+			}
+
+			return true;
+		};
 	}
 
 	public function public_api_permission( $request ) {
@@ -1018,7 +1051,7 @@ class Mastodon_API {
 
 	private function get_comment_status_array( \WP_Comment $comment ) {
 		if ( ! $comment ) {
-			return new \WP_Error( 'record-not-found', 'Record not found', array( 'status' => 404 ) );
+			return new \WP_Error( 'mastodon_' . __FUNCTION__, 'Record not found', array( 'status' => 404 ) );
 		}
 
 		$post = (object) array(
@@ -1304,12 +1337,12 @@ class Mastodon_API {
 
 	public function api_submit_post( $request ) {
 		if ( ! current_user_can( 'edit_posts' ) ) {
-			return new \WP_Error( 'mastodon_api_submit_post', 'The access token is invalid', array( 'status' => 401 ) );
+			return new \WP_Error( 'mastodon_' . __FUNCTION__, 'Insufficient permissions', array( 'status' => 401 ) );
 		}
 
 		$status = $request->get_param( 'status' );
 		if ( empty( $status ) ) {
-			return new \WP_Error( 'mastodon_api_submit_post', 'Validation failed: Text can\'t be blank', array( 'status' => 422 ) );
+			return new \WP_Error( 'mastodon_' . __FUNCTION__, 'Validation failed: Text can\'t be blank', array( 'status' => 422 ) );
 		}
 
 		$status = make_clickable( $status );
@@ -1396,10 +1429,10 @@ class Mastodon_API {
 			foreach ( $media_ids as $media_id ) {
 				$media = get_post( $media_id );
 				if ( ! $media ) {
-					return new \WP_Error( 'mastodon_api_submit_post', 'Media not found', array( 'status' => 400 ) );
+					return new \WP_Error( 'mastodon_' . __FUNCTION__, 'Media not found', array( 'status' => 400 ) );
 				}
 				if ( 'attachment' !== $media->post_type ) {
-					return new \WP_Error( 'mastodon_api_submit_post', 'Media not found', array( 'status' => 400 ) );
+					return new \WP_Error( 'mastodon_' . __FUNCTION__, 'Media not found', array( 'status' => 400 ) );
 				}
 				$attachment = \wp_get_attachment_metadata( $media_id );
 				$post_data['post_content'] .= PHP_EOL;
@@ -1838,6 +1871,10 @@ class Mastodon_API {
 	public function api_get_post( $request ) {
 		$post_id = $request->get_param( 'post_id' );
 		if ( ! $post_id ) {
+			return new \WP_REST_Response( array( 'error' => 'Record not found' ), 404 );
+		}
+
+		if ( get_post_status( $post_id ) !== 'publish' && ! current_user_can( 'edit_post', $post_id ) ) {
 			return new \WP_REST_Response( array( 'error' => 'Record not found' ), 404 );
 		}
 
@@ -2445,6 +2482,9 @@ class Mastodon_API {
 			preg_match( '/^@?' . self::ACTIVITYPUB_USERNAME_REGEXP . '$/i', $user_id )
 			|| $url
 		) {
+			if ( ! is_user_logged_in() ) {
+				return new \WP_Error( 'not-logged-in', 'Not logged in', array( 'status' => 401 ) );
+			}
 			$account = $this->get_acct( $user_id );
 
 			if ( $account ) {

--- a/includes/class-mastodon-api.php
+++ b/includes/class-mastodon-api.php
@@ -438,7 +438,7 @@ class Mastodon_API {
 			array(
 				'methods'             => array( 'GET', 'OPTIONS' ),
 				'callback'            => array( $this, 'api_verify_credentials' ),
-				'permission_callback' => $this->required_scope( 'read:accounts' ),
+				'permission_callback' => $this->required_scope( 'follow:accounts' ),
 			)
 		);
 
@@ -726,7 +726,7 @@ class Mastodon_API {
 			$token = $this->oauth->get_token();
 			if ( $token && isset( $token['scope'] ) ) {
 				foreach ( explode( ',', $scopes ) as $scope ) {
-					if ( Mastodon_App::check_scope( $token['scope'], $scope ) ) {
+					if ( OAuth2\Scope_Util::checkSingleScope( $scope, $token['scope'] ) ) {
 						$has_scope = true;
 					}
 				}

--- a/includes/class-mastodon-api.php
+++ b/includes/class-mastodon-api.php
@@ -219,7 +219,7 @@ class Mastodon_API {
 			array(
 				'methods'             => 'POST',
 				'callback'            => array( $this, 'api_apps' ),
-				'permission_callback' => $this->required_scope( false ),
+				'permission_callback' => array( $this, 'public_api_permission' ),
 			)
 		);
 		register_rest_route(
@@ -237,7 +237,7 @@ class Mastodon_API {
 			array(
 				'methods'             => 'GET',
 				'callback'            => '__return_empty_array',
-				'permission_callback' => $this->required_scope( false ),
+				'permission_callback' => array( $this, 'public_api_permission' ),
 			)
 		);
 		register_rest_route(
@@ -246,7 +246,7 @@ class Mastodon_API {
 			array(
 				'methods'             => 'GET',
 				'callback'            => array( $this, 'api_instance' ),
-				'permission_callback' => $this->required_scope( false ),
+				'permission_callback' => array( $this, 'public_api_permission' ),
 			)
 		);
 
@@ -256,7 +256,7 @@ class Mastodon_API {
 			array(
 				'methods'             => 'GET',
 				'callback'            => array( $this, 'api_instance_v2' ),
-				'permission_callback' => $this->required_scope( false ),
+				'permission_callback' => array( $this, 'public_api_permission' ),
 			)
 		);
 		register_rest_route(
@@ -265,7 +265,7 @@ class Mastodon_API {
 			array(
 				'methods'             => 'GET',
 				'callback'            => array( $this, 'api_nodeinfo' ),
-				'permission_callback' => $this->required_scope( false ),
+				'permission_callback' => array( $this, 'public_api_permission' ),
 			)
 		);
 		register_rest_route(
@@ -409,7 +409,7 @@ class Mastodon_API {
 			array(
 				'methods'             => 'GET',
 				'callback'            => '__return_empty_array',
-				'permission_callback' => $this->required_scope( false ),
+				'permission_callback' => array( $this, 'public_api_permission' ),
 			)
 		);
 		register_rest_route(
@@ -418,7 +418,7 @@ class Mastodon_API {
 			array(
 				'methods'             => 'GET',
 				'callback'            => '__return_empty_array',
-				'permission_callback' => $this->required_scope( false ),
+				'permission_callback' => array( $this, 'public_api_permission' ),
 			)
 		);
 
@@ -598,7 +598,7 @@ class Mastodon_API {
 			array(
 				'methods'             => array( 'GET', 'OPTIONS' ),
 				'callback'            => array( $this, 'api_public_timeline' ),
-				'permission_callback' => $this->required_scope( false ),
+				'permission_callback' => array( $this, 'public_api_permission' ),
 			)
 		);
 
@@ -648,7 +648,7 @@ class Mastodon_API {
 			array(
 				'methods'             => array( 'GET', 'OPTIONS' ),
 				'callback'            => '__return_empty_array',
-				'permission_callback' => $this->required_scope( false ),
+				'permission_callback' => array( $this, 'public_api_permission' ),
 			)
 		);
 
@@ -658,7 +658,7 @@ class Mastodon_API {
 			array(
 				'methods'             => array( 'GET', 'OPTIONS' ),
 				'callback'            => array( $this, 'api_account_followers' ),
-				'permission_callback' => $this->required_scope( false ),
+				'permission_callback' => array( $this, 'public_api_permission' ),
 			)
 		);
 
@@ -698,7 +698,7 @@ class Mastodon_API {
 			array(
 				'methods'             => array( 'GET', 'OPTIONS' ),
 				'callback'            => array( $this, 'api_account' ),
-				'permission_callback' => $this->required_scope( false ),
+				'permission_callback' => array( $this, 'public_api_permission' ),
 			)
 		);
 	}
@@ -709,10 +709,6 @@ class Mastodon_API {
 	}
 
 	public function required_scope( $scopes, $also_public = false ) {
-		if ( false === $scopes ) {
-			return array( $this, 'public_api_permission' );
-		}
-
 		return function ( $request ) use ( $scopes, $also_public ) {
 			if ( $also_public ) {
 				if ( ! $this->logged_in_for_private_permission( $request ) ) {

--- a/includes/class-mastodon-app.php
+++ b/includes/class-mastodon-app.php
@@ -495,24 +495,8 @@ class Mastodon_App {
 		return $args;
 	}
 
-	public static function check_scope( $existing_scopes, $requested_scope ) {
-		$requested_main_scope = strtok( $requested_scope, ':' );
-
-		foreach ( explode( ' ', $existing_scopes ) as $scope ) {
-			if ( $scope === $requested_scope ) {
-				return true;
-			}
-
-			if ( $scope === $requested_main_scope ) {
-				return true;
-			}
-		}
-
-		return false;
-	}
-
 	public function has_scope( $requested_scope ) {
-		return self::check_scope( $this->get_scopes(), $requested_scope );
+		return OAuth2\Scope_Util::checkSingleScope( $requested_scope, $this->get_scopes() );
 	}
 
 	/**

--- a/includes/class-mastodon-app.php
+++ b/includes/class-mastodon-app.php
@@ -118,23 +118,6 @@ class Mastodon_App {
 		return false;
 	}
 
-	public function check_scopes( $requested_scopes ) {
-		$allowed_scopes = explode( ' ', $this->get_scopes() );
-
-		foreach ( explode( ' ', $requested_scopes ) as $s ) {
-			if ( false !== strpos( $s, ':' ) ) {
-				list( $scope, $subscope ) = explode( ':', $s, 2 );
-			} else {
-				$scope = $s;
-			}
-			if ( ! in_array( $scope, $allowed_scopes, true ) ) {
-				return false;
-			}
-		}
-
-		return false;
-	}
-
 	public function delete_last_requests() {
 		return delete_metadata( 'term', $this->term->term_id, 'request' );
 	}
@@ -512,10 +495,10 @@ class Mastodon_App {
 		return $args;
 	}
 
-	public function has_scope( $requested_scope ) {
+	public static function check_scope( $existing_scopes, $requested_scope ) {
 		$requested_main_scope = strtok( $requested_scope, ':' );
 
-		foreach ( explode( ' ', $this->get_scopes() ) as $scope ) {
+		foreach ( explode( ' ', $existing_scopes ) as $scope ) {
 			if ( $scope === $requested_scope ) {
 				return true;
 			}
@@ -526,6 +509,10 @@ class Mastodon_App {
 		}
 
 		return false;
+	}
+
+	public function has_scope( $requested_scope ) {
+		return self::check_scope( $this->get_scopes(), $requested_scope );
 	}
 
 	/**

--- a/includes/class-mastodon-app.php
+++ b/includes/class-mastodon-app.php
@@ -512,6 +512,22 @@ class Mastodon_App {
 		return $args;
 	}
 
+	public function has_scope( $requested_scope ) {
+		$requested_main_scope = strtok( $requested_scope, ':' );
+
+		foreach ( explode( ' ', $this->get_scopes() ) as $scope ) {
+			if ( $scope === $requested_scope ) {
+				return true;
+			}
+
+			if ( $scope === $requested_main_scope ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	/**
 	 * Get an app via client_id.
 	 *

--- a/includes/class-mastodon-oauth.php
+++ b/includes/class-mastodon-oauth.php
@@ -44,6 +44,7 @@ class Mastodon_OAuth {
 		$this->server = new Server( new Oauth2\Authorization_Code_Storage(), $config );
 		$this->server->addStorage( new Oauth2\Mastodon_App_Storage(), 'client_credentials' );
 		$this->server->addStorage( new Oauth2\Access_Token_Storage(), 'access_token' );
+		$this->server->setScopeUtil( new Oauth2\Scope_Util() );
 
 		if ( '/oauth/token' === strtok( $_SERVER['REQUEST_URI'], '?' ) ) {
 			// Avoid interference with private site plugins.

--- a/includes/oauth2/class-access-token-storage.php
+++ b/includes/oauth2/class-access-token-storage.php
@@ -167,14 +167,8 @@ class Access_Token_Storage implements AccessTokenInterface {
 			$access_token = array(
 				'access_token' => $oauth_token,
 			);
-			foreach ( array(
-				'client_id'    => 'client_id',
-				'user_id'      => 'user_id',
-				'expires'      => 'expires',
-				'redirect_uri' => 'redirect_uri',
-				'scope'        => 'scope',
-			) as $key => $meta_key ) {
-				$access_token[ $key ] = get_term_meta( $term->term_id, $meta_key, true );
+			foreach ( array_keys( self::$access_token_data ) as $meta_key ) {
+				$access_token[ $meta_key ] = get_term_meta( $term->term_id, $meta_key, true );
 			}
 
 			$access_token['created_at'] = $access_token['expires'] - YEAR_IN_SECONDS * 2;

--- a/includes/oauth2/class-authenticate-handler.php
+++ b/includes/oauth2/class-authenticate-handler.php
@@ -168,17 +168,21 @@ class Authenticate_Handler {
 							if ( ! isset( $scope_explanations[ $main_scope ] ) ) {
 								continue;
 							}
-							echo '<li style="margin-top: .5em" title="', esc_attr( $main_scope ), '">', esc_html( $scope_explanations[ $main_scope ] ), '</li>';
-							if ( ! empty( $subscopes ) ) {
+							echo '<li style="margin-top: .5em" title="', esc_attr( $main_scope ), '">', esc_html( $scope_explanations[ $main_scope ] );
+							$all = isset( $subscopes['all'] ) && $subscopes['all'];
+							unset( $subscopes['all'] );
+							if ( ! empty( $subscopes ) && ! $all ) {
+								echo ' ', __( 'Only the following sub-permissions:', 'enable-mastodon-apps' );
 								echo '<ul style="margin-left: 1em">';
 								foreach ( $subscopes as $subscope => $true ) {
 									if ( ! isset( $scope_explanations[ $main_scope . ':' . $subscope ] ) ) {
-										$scope_explanations[ $main_scope . ':' . $subscope ] = $main_scope . ':' . $subscope;
+										$scope_explanations[ $main_scope . ':' . $subscope ] = ucwords( $subscope ) . ' (' . $main_scope . ':' . $subscope . ')';
 									}
 									echo '<li style="margin-top: .5em" title="', esc_attr( $main_scope . ':' . $subscope ), '">', esc_html( $scope_explanations[ $main_scope . ':' . $subscope ] ), '</li>';
 								}
 								echo '</ul>';
 							}
+							echo '</li>';
 						}
 						?>
 					</ul>

--- a/includes/oauth2/class-authenticate-handler.php
+++ b/includes/oauth2/class-authenticate-handler.php
@@ -35,14 +35,21 @@ class Authenticate_Handler {
 			return $redirect_uri;
 		}
 
-		$scopes = $app->check_scopes( $_GET['scope'] );
-		if ( is_wp_error( $scopes ) ) {
-			return $scopes;
+		$scopes = array();
+		foreach ( explode( ' ', $_GET['scope'] ) as $scope ) {
+			if ( $app->has_scope( $scope ) ) {
+				$scopes[] = $scope;
+			}
+		}
+		if ( empty( $scopes ) ) {
+			$response->setError( 403, 'invalid_scopes', 'Invalid scope was requested.' );
+			return $response;
 		}
 
 		$data = array(
 			'user'            => wp_get_current_user(),
 			'client_name'     => $client_name,
+			'scopes'          => implode( ' ', $scopes ),
 			'body_class_attr' => implode( ' ', array_diff( get_body_class(), array( 'error404' ) ) ),
 			'cancel_url'      => $this->get_cancel_url( $request ),
 			'form_url'        => home_url( '/oauth/authorize' ),
@@ -96,6 +103,13 @@ class Authenticate_Handler {
 	}
 
 	private function render_consent_screen( $data ) {
+		$scope_explanations = array(
+			'read'   => __( 'Read information from your account, for example read your statuses.', 'enable-mastodon-apps' ),
+			'write'  => __( 'Write information to your account, for example post a status on your behalf.', 'enable-mastodon-apps' ),
+			'follow' => __( 'Follow other accounts using your account.', 'enable-mastodon-apps' ),
+			'push'   => __( 'Subscribe to push events for your account.', 'enable-mastodon-apps' ),
+		);
+
 		?>
 		<div id="openid-connect-authenticate">
 			<div id="openid-connect-authenticate-form-container" class="login">
@@ -113,22 +127,37 @@ class Authenticate_Handler {
 					</h2>
 					<br/>
 					<p>
-						<label>
-							<?php
-							echo wp_kses(
-								sprintf(
+						<?php
+						echo wp_kses(
+							sprintf(
 								// translators: %1$s is the site name, %2$s is the username.
-									__( 'Do you want to log in to <em>%1$s</em> with your <em>%2$s</em> account?', 'enable-mastodon-apps' ),
-									$data['client_name'],
-									get_bloginfo( 'name' )
-								),
-								array(
-									'em' => array(),
-								)
-							);
-							?>
-						</label>
+								__( 'Do you want to log in to <strong>%1$s</strong> with your <strong>%2$s</strong> account?', 'enable-mastodon-apps' ),
+								$data['client_name'],
+								get_bloginfo( 'name' )
+							),
+							array(
+								'strong' => array(),
+							)
+						);
+						?>
 					</p>
+					<br/>
+					<p>
+					<?php
+					esc_html_e( 'Requested permissions:', 'enable-mastodon-apps' );
+					?>
+						</p>
+					<ul style="margin-left: 1em">
+
+						<?php
+						foreach ( array_unique( explode( ' ', $data['scopes'] ) ) as $scope ) {
+							if ( ! isset( $scope_explanations[ $scope ] ) ) {
+								continue;
+							}
+							echo '<li style="margin-top: .5em" title="', esc_attr( $scope ), '">', esc_html( $scope_explanations[ $scope ] ), '</li>';
+						}
+						?>
+					</ul>
 					<br/>
 					<?php wp_nonce_field( 'wp_rest' ); /* The nonce will give the REST call the userdata. */ ?>
 					<?php foreach ( $data['form_fields'] as $key => $value ) : ?>

--- a/includes/oauth2/class-scope-util.php
+++ b/includes/oauth2/class-scope-util.php
@@ -1,6 +1,15 @@
 <?php
+/**
+ * OAuth2 Scope Util
+ *
+ * @package Friends
+ */
+
 namespace Enable_Mastodon_Apps\OAuth2;
 
+/**
+ * This class overrides the scope checking to allow for fine grained scopes.
+ */
 class Scope_Util extends \OAuth2\Scope {
 	public static function checkSingleScope( $required_scope, $available_scope ) {
 		$required_main_scope = strtok( $required_scope, ':' );

--- a/includes/oauth2/class-scope-util.php
+++ b/includes/oauth2/class-scope-util.php
@@ -1,0 +1,27 @@
+<?php
+namespace Enable_Mastodon_Apps\OAuth2;
+
+class Scope_Util extends \OAuth2\Scope {
+	public static function checkSingleScope( $required_scope, $available_scope ) {
+		$required_main_scope = strtok( $required_scope, ':' );
+		foreach ( explode( ' ', $available_scope ) as $scope ) {
+			if ( $scope === $required_scope ) {
+				return true;
+			}
+
+			if ( $scope === $required_main_scope ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+	public function checkScope( $required_scope, $available_scope ) {
+		foreach ( explode( ' ', $required_scope ) as $scope ) {
+			if ( ! self::checkSingleScope( $scope, $available_scope ) ) {
+				return false;
+			}
+		}
+		return true;
+	}
+}

--- a/tests/class-mastodon-api-testcase.php
+++ b/tests/class-mastodon-api-testcase.php
@@ -16,6 +16,7 @@ class Mastodon_API_TestCase extends \WP_UnitTestCase {
 	protected $token;
 	protected $post;
 	protected $friend_post;
+	protected $private_post;
 	protected $administrator;
 	protected $friend;
 	protected $app;
@@ -44,6 +45,18 @@ class Mastodon_API_TestCase extends \WP_UnitTestCase {
 				'post_content' => 'Test post',
 				'post_title'   => '',
 				'post_status'  => 'publish',
+				'post_type'    => 'post',
+				'post_date'    => '2023-01-03 00:00:00',
+			)
+		);
+		set_post_format( $this->post, 'status' );
+
+		$this->private_post = wp_insert_post(
+			array(
+				'post_author'  => $this->administrator,
+				'post_content' => 'Private post',
+				'post_title'   => '',
+				'post_status'  => 'private',
 				'post_type'    => 'post',
 				'post_date'    => '2023-01-03 00:00:00',
 			)

--- a/tests/test-mastodon-app.php
+++ b/tests/test-mastodon-app.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Class Test_Apps_Endpoint
+ *
+ * @package Enable_Mastodon_Apps
+ */
+
+namespace Enable_Mastodon_Apps;
+
+/**
+ * A testcase for the apps endpoint.
+ *
+ * @package
+ */
+class MastodonApp_Test extends \WP_UnitTestCase {
+	public function test_create_app() {
+		$app = Mastodon_App::save( 'test', array( Mastodon_OAuth::OOB_REDIRECT_URI ), 'read', '' );
+		$this->assertInstanceOf( Mastodon_App::class, $app );
+	}
+
+	public function test_create_app_with_empty_scope() {
+		$this->expectException( \Exception::class );
+		$app = Mastodon_App::save( 'test', array( Mastodon_OAuth::OOB_REDIRECT_URI ), '', '' );
+	}
+
+	/**
+	 * Scopes to test
+	 *
+	 * @param      string $app_scopes     The application scopes.
+	 * @param      string $scope_to_test  The scope to test.
+	 * @param      bool   $has_scope      Indicates if the test should assume the scope to be existent.
+	 * @dataProvider scopes
+	 */
+	public function test_scope_given( $app_scopes, $scope_to_test, $has_scope ) {
+		$app = Mastodon_App::save( 'test', array( Mastodon_OAuth::OOB_REDIRECT_URI ), $app_scopes, '' );
+		$this->assertEquals( $has_scope, $app->has_scope( $scope_to_test ) );
+	}
+
+	public function scopes() {
+		return array(
+			array( 'read', 'read', true ),
+			array( 'read', 'read:accounts', true ),
+			array( 'read:accounts', 'read:accounts', true ),
+			array( 'read:accounts', 'read', false ),
+			array( 'write', 'read', false ),
+			array( 'read', 'write', false ),
+			array( 'read write', 'write', true ),
+			array( 'read write push', 'write', true ),
+			array( 'read', 'write:accounts', false ),
+		);
+	}
+}

--- a/tests/test-statuses-endpoint.php
+++ b/tests/test-statuses-endpoint.php
@@ -47,6 +47,18 @@ class StatusesEndpoint_Test extends Mastodon_API_TestCase {
 		$this->assertIsInt( $data['favourites_count'] );
 	}
 
+	public function test_statuses_private_id() {
+		global $wp_rest_server;
+
+		$request = new \WP_REST_Request( 'GET', '/' . Mastodon_API::PREFIX . '/api/v1/statuses/' . $this->private_post );
+		$response = $wp_rest_server->dispatch( $request );
+		$this->assertEquals( 401, $response->get_status() );
+
+		$_SERVER['HTTP_AUTHORIZATION'] = 'Bearer ' . $this->token;
+		$response = $wp_rest_server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
 	public function test_statuses_delete() {
 		global $wp_rest_server;
 		$request = new \WP_REST_Request( 'DELETE', '/' . Mastodon_API::PREFIX . '/api/v1/statuses/' . $this->post );


### PR DESCRIPTION
When authorizing an app, we now display the requested scopes on the login screen:
![Screenshot 2024-02-14 at 14 40 16](https://github.com/akirk/enable-mastodon-apps/assets/203408/8ed94db6-741b-40f5-8bab-384baa91b966)

Subscopes are displayed like this:

![Screenshot 2024-02-14 at 14 40 46](https://github.com/akirk/enable-mastodon-apps/assets/203408/53fdcde2-e581-43af-95d4-336c13d0db1d)

The scopes are now also enforced: If an app then tried to request an api endpoint where it doesn't have permission, and api based error will be returned, for example (screenshot from the [Mastodon API Tester](https://akirk.github.io/mastodon-api-tester/)):

![Screenshot 2024-02-14 at 14 12 06](https://github.com/akirk/enable-mastodon-apps/assets/203408/32269792-30fe-456d-b036-3e9cd69599f3)

Thanks @thisismissem for pointing out this missing part of the plugin!