### PR TITLE
Fix float conversion to integer

### DIFF
--- a/includes/class-mastodon-admin.php
+++ b/includes/class-mastodon-admin.php
@@ -538,7 +538,7 @@ class Mastodon_Admin {
 						$date = \DateTimeImmutable::createFromFormat( 'U.u', $request['timestamp'] );
 						if ( $date > $debug_start_time ) {
 							$request['app'] = $app;
-							$all_last_requests[ $request['timestamp'] * 10000 ] = $request;
+							$all_last_requests[ intval( $request['timestamp'] * 10000 ) ] = $request;
 						}
 					}
 				}

--- a/includes/class-mastodon-app.php
+++ b/includes/class-mastodon-app.php
@@ -131,7 +131,7 @@ class Mastodon_App {
 				delete_metadata( 'term', $this->term->term_id, 'request', $request );
 				continue;
 			}
-			$requests[ $request['timestamp'] * 10000 ] = $request;
+			$requests[ intval( $request['timestamp'] * 10000 ) ] = $request;
 		}
 
 		ksort( $requests );


### PR DESCRIPTION
Implicit conversion from float to integer is prohibited in newer PHP versions. Use an explicit `intval` instead.