### PR TITLE
Fix account statuses with a token and logged-in

### DIFF
--- a/includes/class-mastodon-api.php
+++ b/includes/class-mastodon-api.php
@@ -962,7 +962,7 @@ class Mastodon_API {
 	public function logged_in_for_private_permission( $request ) {
 		$post_id = $request->get_param( 'post_id' );
 		if ( ! $post_id ) {
-			return false;
+			return true;
 		}
 
 		if ( get_post_status( $post_id ) !== 'publish' ) {

--- a/includes/handler/class-status.php
+++ b/includes/handler/class-status.php
@@ -37,7 +37,7 @@ class Status extends Handler {
 	 * @param array      $data Additional status data.
 	 * @return array The status array
 	 */
-	public function api_status( ?array $status, int $object_id, array $data = array() ): array {
+	public function api_status( ?array $status, int $object_id, array $data = array() ): array|null {
 		$comment = get_comment( $object_id );
 
 		if ( $comment instanceof \WP_Comment ) {


### PR DESCRIPTION
In #76 there was a bug introduced for the `/accounts/{user_id}/statuses` endpoint where having a token was not enough.