### PR TITLE
Comment Custom Post Type

### DIFF
--- a/enable-mastodon-apps.php
+++ b/enable-mastodon-apps.php
@@ -61,5 +61,6 @@ add_action(
 	function () {
 		new Enable_Mastodon_Apps\Mastodon_API();
 		new Enable_Mastodon_Apps\Integration\Pixelfed();
+		new Enable_Mastodon_Apps\Comment_CPT();
 	}
 );

--- a/includes/class-comment-cpt.php
+++ b/includes/class-comment-cpt.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Comment CPT.
+ *
+ * This contains the automatic mapping of comments to a custom post type.
+ *
+ * @package Enable_Mastodon_Apps
+ */
+
+namespace Enable_Mastodon_Apps;
+
+/**
+ * Comment Custom Post Type
+ *
+ * This class maps comments to a custom post type.
+ */
+class Comment_CPT {
+	const CPT = 'comment';
+	const META_KEY = 'comment_id';
+
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		$this->register_hooks();
+		$this->register_custom_post_type();
+	}
+
+	public function register_hooks() {
+		add_action( 'init', array( $this, 'register_custom_post_type' ) );
+		add_action( 'wp_insert_comment', array( $this, 'create_comment_post' ), 10, 2 );
+		add_action( 'delete_comment', array( $this, 'delete_comment_post' ) );
+		add_action( 'transition_comment_status', array( $this, 'update_comment_post_status' ), 10, 3 );
+		add_action( 'edit_comment', array( $this, 'update_comment_post' ), 10, 2 );
+	}
+
+	public function register_custom_post_type() {
+		$args = array(
+			'labels'       => array(
+				'name'          => 'Comment',
+				'singular_name' => 'Comment',
+				'menu_name'     => 'Comments',
+			),
+			'public'       => false,
+			'show_ui'      => false,
+			'show_in_menu' => false,
+			'show_in_rest' => false,
+			'rewrite'      => false,
+		);
+
+		register_post_type( self::CPT, $args );
+	}
+
+	public function remap_comment_id( $comment_id ) {
+		$remapped_comment_id = get_comment_meta( $comment_id, self::META_KEY, true );
+		if ( ! $remapped_comment_id ) {
+			$remapped_comment_id = $this->create_comment_post( $comment_id, get_comment( $comment_id ) );
+		}
+		return $remapped_comment_id;
+	}
+
+
+	public function create_comment_post( $comment_id, $comment ) {
+		$parent_post_id = $comment->comment_post_ID;
+		$post    = get_post( $parent_post_id );
+		if ( ! $post ) {
+			return;
+		}
+
+		if ( $comment->comment_parent ) {
+			$parent_comment = get_comment( $comment->comment_parent );
+			if ( ! $parent_comment ) {
+				return;
+			}
+			$parent_post_id = $this->remap_comment_id( $comment->comment_parent );
+		}
+
+		$post_data = array(
+			'post_title'    => 'Comment',
+			'post_content'  => $comment->comment_content,
+			'post_author'   => $comment->user_id,
+			'post_status'   => 'publish',
+			'post_type'     => self::CPT,
+			'post_parent'   => $parent_post_id,
+			'post_date'     => $comment->comment_date,
+			'post_date_gmt' => $comment->comment_date_gmt,
+			'meta_input'    => array(
+				self::META_KEY => $comment_id,
+			),
+		);
+
+		$post_id = wp_insert_post( $post_data );
+		return $post_id;
+	}
+
+	public function delete_comment_post( $comment_id ) {
+		$post_id = $this->remap_comment_id( $comment_id );
+		if ( ! $post_id ) {
+			return;
+		}
+
+		wp_delete_post( $post_id, true );
+	}
+
+	public function update_comment_post_status( $new_status, $old_status, $comment ) {
+		$post_id = $this->remap_comment_id( $comment->comment_ID );
+		if ( ! $post_id ) {
+			return;
+		}
+
+		$post_data = array(
+			'ID'          => $post_id,
+			'post_status' => 'publish' === $new_status ? 'publish' : 'private',
+		);
+
+		wp_update_post( $post_data );
+	}
+
+	public function update_comment_post( $comment_id, $comment ) {
+		$post_id = $this->remap_comment_id( $comment_id );
+		if ( ! $post_id ) {
+			return;
+		}
+
+		$post_data = array(
+			'ID'            => $post_id,
+			'post_content'  => $comment->comment_content,
+			'post_date'     => $comment->comment_date,
+			'post_date_gmt' => $comment->comment_date_gmt,
+		);
+
+		wp_update_post( $post_data );
+	}
+}

--- a/includes/class-mastodon-api.php
+++ b/includes/class-mastodon-api.php
@@ -878,7 +878,7 @@ class Mastodon_API {
 			'api/v1/statuses/(?P<post_id>[0-9]+)/context',
 			array(
 				'methods'             => array( 'GET', 'OPTIONS' ),
-				'callback'            => array( $this, 'api_get_post_context' ),
+				'callback'            => array( $this, 'api_get_status_context' ),
 				'permission_callback' => $this->required_scope( 'read:statuses', true ),
 			)
 		);
@@ -1604,8 +1604,8 @@ class Mastodon_API {
 			return new \WP_Error( 'mastodon_' . __FUNCTION__, 'Insufficient permissions', array( 'status' => 401 ) );
 		}
 
-		$status = $request->get_param( 'status' );
-		if ( empty( $status ) ) {
+		$status_text = $request->get_param( 'status' );
+		if ( empty( $status_text ) ) {
 			return new \WP_Error( 'mastodon_' . __FUNCTION__, 'Validation failed: Text can\'t be blank', array( 'status' => 422 ) );
 		}
 
@@ -1616,67 +1616,16 @@ class Mastodon_API {
 		 * @param WP_REST_Request $request The REST request object.
 		 * @return string The potentially modified status text.
 		 */
-		$status = apply_filters( 'mastodon_api_submit_status_text', $status, $request );
+		$status_text = apply_filters( 'mastodon_api_submit_status_text', $status_text, $request );
 
 		$visibility = $request->get_param( 'visibility' );
 		if ( empty( $visibility ) ) {
 			$visibility = 'public';
 		}
-		$post_data = array();
 
-		$parent_post    = false;
-		$parent_post_id = self::maybe_get_remapped_reblog_id( $request->get_param( 'in_reply_to_id' ) );
-		if ( ! empty( $parent_post_id ) ) {
-			$parent_post = get_post( $parent_post_id );
-			if ( $parent_post ) {
-				$user = wp_get_current_user();
-
-				$commentdata = array(
-					'comment_post_ID'      => $parent_post_id,
-					'comment_author'       => $user->user_nicename,
-					'user_id'              => $user->ID,
-					'comment_author_email' => $user->user_email,
-					'comment_author_url'   => $user->user_url,
-					'comment_content'      => $status,
-					'comment_type'         => 'comment',
-					'comment_parent'       => 0,
-				);
-
-				\remove_action( 'check_comment_flood', 'check_comment_flood_db', 10 );
-
-				$id = \wp_new_comment( $commentdata, true );
-				if ( is_wp_error( $id ) ) {
-					return $id;
-				}
-
-				\add_action( 'check_comment_flood', 'check_comment_flood_db', 10, 4 );
-				$comment = get_comment( $id );
-				/**
-				 * Modify the status data.
-				 *
-				 * @param array|null $account The status data.
-				 * @param int $post_id The object ID to get the status from.
-				 * @param array $data Additional status data.
-				 * @return array|null The modified status data.
-				 */
-				$status = apply_filters(
-					'mastodon_api_status',
-					null,
-					$comment->comment_post_ID,
-					array(
-						'in_reply_to_id' => $comment->comment_post_ID,
-						'comment'        => $comment,
-					)
-				);
-
-				return $status;
-			}
-		}
-
-		$post_data['post_content'] = $status;
-		$post_data['post_status']  = 'public' === $visibility ? 'publish' : 'private';
-		$post_data['post_type']    = 'post';
-		$post_data['post_title']   = '';
+		$in_reply_to_id = self::maybe_get_remapped_reblog_id( $request->get_param( 'in_reply_to_id' ) );
+		$media_ids = $request->get_param( 'media_ids' );
+		$scheduled_at = $request->get_param( 'scheduled_at' );
 
 		$app = Mastodon_App::get_current_app();
 		$app_post_formats = array();
@@ -1687,84 +1636,10 @@ class Mastodon_API {
 			$app_post_formats = array( 'status' );
 		}
 		$post_format = apply_filters( 'mastodon_api_new_post_format', $app_post_formats[0] );
-		if ( 'standard' === $post_format ) {
-			// Use the first line of a post as the post title if we're using a standard post format.
-			list( $post_title, $post_content ) = explode( PHP_EOL, $post_data['post_content'], 2 );
-			$post_data['post_title']   = $post_title;
-			$post_data['post_content'] = trim( $post_content );
-		}
 
-		if ( $parent_post_id ) {
-			$post_data['post_parent'] = $parent_post_id;
-		}
+		$status = apply_filters( 'mastodon_api_submit_status', null, $status_text, $in_reply_to_id, $media_ids, $post_format, $visibility, $scheduled_at, $request );
 
-		$scheduled_at = $request->get_param( 'scheduled_at' );
-		if ( $scheduled_at ) {
-			$post_data['post_status'] = 'future';
-			$post_data['post_date'] = $scheduled_at;
-		}
-
-		$media_ids = $request->get_param( 'media_ids' );
-		if ( ! empty( $media_ids ) ) {
-			foreach ( $media_ids as $media_id ) {
-				$media = get_post( $media_id );
-				if ( ! $media ) {
-					return new \WP_Error( 'mastodon_' . __FUNCTION__, 'Media not found', array( 'status' => 400 ) );
-				}
-				if ( 'attachment' !== $media->post_type ) {
-					return new \WP_Error( 'mastodon_' . __FUNCTION__, 'Media not found', array( 'status' => 400 ) );
-				}
-				$attachment = \wp_get_attachment_metadata( $media_id );
-				$post_data['post_content'] .= PHP_EOL;
-				$post_data['post_content'] .= '<!-- wp:image -->';
-				$post_data['post_content'] .= '<p><img src="' . esc_url( wp_get_attachment_url( $media_id ) ) . '" width="' . esc_attr( $attachment['width'] ) . '"  height="' . esc_attr( $attachment['height'] ) . '" class="size-full" /></p>';
-				$post_data['post_content'] .= '<!-- /wp:image -->';
-			}
-		}
-
-		$post_id = wp_insert_post( $post_data );
-		if ( is_wp_error( $post_id ) ) {
-			return $post_id;
-		}
-
-		if ( 'standard' !== $post_format ) {
-			set_post_format( $post_id, $post_format );
-		}
-
-		if ( ! empty( $media_ids ) ) {
-			foreach ( $media_ids as $media_id ) {
-				wp_update_post(
-					array(
-						'ID'          => $media_id,
-						'post_parent' => $post_id,
-					)
-				);
-			}
-		}
-
-		if ( $scheduled_at ) {
-			return array(
-				'id'           => $post_id,
-				'scheduled_at' => $scheduled_at,
-				'params'       => array(
-					'text'         => $status,
-					'visibility'   => $visibility,
-					'scheduled_at' => $scheduled_at,
-				),
-			);
-		}
-
-		/**
-		 * Modify the status data.
-		 *
-		 * @param array|null $account The status data.
-		 * @param int $post_id The object ID to get the status from.
-		 * @param array $data Additional status data.
-		 * @return array|null The modified status data.
-		 */
-		$status = apply_filters( 'mastodon_api_status', null, $post_id, array() );
-
-		return $status;
+		return $this->validate_entity( $status, Entity\Status::class );
 	}
 
 	/**
@@ -1941,89 +1816,20 @@ class Mastodon_API {
 		return array();
 	}
 
-	public function api_get_post_context( $request ) {
-		$post_id = $request->get_param( 'post_id' );
-		if ( ! $post_id ) {
+	public function api_get_status_context( $request ) {
+		$context_post_id = $request->get_param( 'post_id' );
+		if ( ! $context_post_id ) {
 			return false;
 		}
 
-		$post_id = self::maybe_get_remapped_reblog_id( $post_id );
+		$context_post_id = self::maybe_get_remapped_reblog_id( $context_post_id );
 
 		$context = array(
 			'ancestors'   => array(),
 			'descendants' => array(),
 		);
 
-		$compare_id = $post_id;
-		$comment_id = self::get_remapped_comment_id( $post_id );
-		if ( $comment_id ) {
-			$comment = get_comment( $comment_id );
-			$post_id = $comment->comment_post_ID;
-
-			/**
-			 * Modify the status data.
-			 *
-			 * @param array|null $account The status data.
-			 * @param int $post_id The object ID to get the status from.
-			 * @param array $data Additional status data.
-			 * @return array|null The modified status data.
-			 */
-			$status = apply_filters(
-				'mastodon_api_status',
-				null,
-				$post_id,
-				array()
-			);
-			if ( $status ) {
-				$context['ancestors'][ $status->id ] = $status;
-			}
-		}
-		foreach ( array_merge(
-			get_comments( array( 'post_id' => $post_id ) ),
-			get_comments( array( 'parent__in' => $comment_id ) )
-		) as $comment ) {
-			if (
-				intval( $comment->comment_ID ) === intval( $comment_id )
-				|| intval( $comment->comment_ID ) === intval( $post_id )
-				|| isset( $context['ancestors'][ $comment->comment_ID ] )
-				|| isset( $context['descendants'][ $comment->comment_ID ] )
-			) {
-				continue;
-			}
-
-			/**
-			 * Modify the status data.
-			 *
-			 * @param array|null $account The status data.
-			 * @param int $post_id The object ID to get the status from.
-			 * @param array $data Additional status data.
-			 * @return array|null The modified status data.
-			 */
-			$status = apply_filters(
-				'mastodon_api_status',
-				null,
-				$post_id,
-				array(
-					'in_reply_to_id' => $comment->comment_post_ID,
-					'comment'        => $comment,
-				)
-			);
-			if ( $status ) {
-				if ( intval( $status->id ) < intval( $compare_id ) ) {
-					$context['ancestors'][ $status->id ] = $status;
-				} else {
-					$context['descendants'][ $status->id ] = $status;
-				}
-			}
-		}
-		ksort( $context['ancestors'] );
-
-		ksort( $context['descendants'] );
-
-		$context['ancestors'] = array_values( $context['ancestors'] );
-		$context['descendants'] = array_values( $context['descendants'] );
-
-		return $context;
+		return apply_filters( 'mastodon_api_status_context', $context, $context_post_id );
 	}
 
 	public function api_favourite_post( $request ) {
@@ -2523,13 +2329,16 @@ class Mastodon_API {
 	public static function remap_reblog_id( $post_id ) {
 		$remapped_post_id = get_post_meta( $post_id, 'mastodon_reblog_id', true );
 		if ( ! $remapped_post_id ) {
+			$post = get_post( $post_id );
 			$remapped_post_id = wp_insert_post(
 				array(
-					'post_type'   => self::CPT,
-					'post_author' => 0,
-					'post_status' => 'publish',
-					'post_title'  => 'Reblog of ' . $post_id,
-					'meta_input'  => array(
+					'post_type'     => self::CPT,
+					'post_author'   => 0,
+					'post_status'   => 'publish',
+					'post_title'    => 'Reblog of ' . $post_id,
+					'post_date'     => $post->post_date,
+					'post_date_gmt' => $post->post_date_gmt,
+					'meta_input'    => array(
 						'mastodon_reblog_id' => $post_id,
 					),
 				)
@@ -2551,13 +2360,22 @@ class Mastodon_API {
 	public static function remap_comment_id( $comment_id ) {
 		$remapped_comment_id = get_comment_meta( $comment_id, 'mastodon_comment_id', true );
 		if ( ! $remapped_comment_id ) {
+			$comment = get_comment( $comment_id );
+			if ( $comment->comment_parent ) {
+				$post_parent = self::remap_comment_id( $comment->comment_parent );
+			} else {
+				$post_parent = self::remap_reblog_id( $comment->comment_post_ID );
+			}
 			$remapped_comment_id = wp_insert_post(
 				array(
-					'post_type'   => self::CPT,
-					'post_author' => 0,
-					'post_status' => 'publish',
-					'post_title'  => 'Comment ' . $comment_id,
-					'meta_input'  => array(
+					'post_type'     => self::CPT,
+					'post_author'   => 0,
+					'post_status'   => 'publish',
+					'post_title'    => 'Comment ' . $comment_id,
+					'post_date'     => $comment->comment_date,
+					'post_date_gmt' => $comment->comment_date_gmt,
+					'post_parent'   => $post_parent,
+					'meta_input'    => array(
 						'mastodon_comment_id' => $comment_id,
 					),
 				)

--- a/includes/handler/class-handler.php
+++ b/includes/handler/class-handler.php
@@ -16,7 +16,7 @@ use Enable_Mastodon_Apps\Mastodon_App;
  * This is the generic handler to provide needed helper functions.
  */
 class Handler {
-	protected function get_posts_query_args( $args = array(), $request ) {
+	protected function get_posts_query_args( $args, $request ) {
 		$limit = $request->get_param( 'limit' );
 		if ( $limit < 1 ) {
 			$limit = 20;

--- a/includes/handler/class-handler.php
+++ b/includes/handler/class-handler.php
@@ -23,7 +23,7 @@ class Handler {
 		}
 
 		$args['posts_per_page']   = $limit;
-		$args['post_type']        = array( 'post' );
+		$args['post_type']        = array( 'post', Mastodon_API::CPT );
 		$args['suppress_filters'] = false;
 		$args['post_status']      = array( 'publish', 'private' );
 
@@ -93,7 +93,7 @@ class Handler {
 				remove_filter( 'posts_where', $max_filter_handler );
 			}
 		}
-		$k = 0;
+
 		$statuses = array();
 		foreach ( $posts as $post ) {
 			/**
@@ -120,38 +120,9 @@ class Handler {
 				continue;
 			}
 
-			$statuses[ $post->post_date . '.' . ++$k ] = $status;
+			$statuses[ $status->id ] = $status;
 		}
-		if ( ! isset( $args['pinned'] ) || ! $args['pinned'] ) {
-			// Comments cannot be pinned for now.
-			$comments = get_comments(
-				array(
-					'meta_key'   => 'protocol',
-					'meta_value' => 'activitypub',
-				)
-			);
 
-			foreach ( $comments as $comment ) {
-				$post_id = Mastodon_API::remap_comment_id( $comment->comment_ID );
-
-				/**
-				 * Documented in this file already.
-				 */
-				$status = apply_filters(
-					'mastodon_api_status',
-					null,
-					$post_id,
-					array(
-						'comment'        => $comment,
-						'in_reply_to_id' => $comment->comment_post_ID,
-					)
-				);
-
-				if ( $status && ! is_wp_error( $status ) ) {
-					$statuses[ $comment->comment_date . '.' . ++$k ] = $status;
-				}
-			}
-		}
 		krsort( $statuses );
 
 		$response = new \WP_REST_Response( array_values( $statuses ) );

--- a/includes/handler/class-status.php
+++ b/includes/handler/class-status.php
@@ -9,6 +9,7 @@
 
 namespace Enable_Mastodon_Apps\Handler;
 
+use Enable_Mastodon_Apps\Entity\Entity;
 use Enable_Mastodon_Apps\Handler\Handler;
 use Enable_Mastodon_Apps\Mastodon_API;
 use Enable_Mastodon_Apps\Entity\Status as Status_Entity;
@@ -31,6 +32,9 @@ class Status extends Handler {
 		add_filter( 'mastodon_api_status', array( $this, 'api_status_account_ensure_numeric_id' ), 100 );
 		add_filter( 'mastodon_api_account_statuses_args', array( $this, 'mastodon_api_account_statuses_args' ), 10, 2 );
 		add_filter( 'mastodon_api_statuses', array( $this, 'api_statuses' ), 10, 4 );
+		add_filter( 'mastodon_api_submit_status', array( $this, 'api_submit_comment' ), 10, 7 );
+		add_filter( 'mastodon_api_submit_status', array( $this, 'api_submit_post' ), 10, 7 );
+		add_filter( 'mastodon_api_status_context', array( $this, 'api_status_context' ), 10, 3 );
 	}
 
 	/**
@@ -199,5 +203,210 @@ class Status extends Handler {
 			$status->reblog->account->id = \Enable_Mastodon_Apps\Mastodon_API::remap_user_id( $status->reblog->account->id );
 		}
 		return $status;
+	}
+
+	public function api_submit_post( $status, $status_text, $in_reply_to_id, $media_ids, $post_format, $visibility, $scheduled_at ) {
+		if ( $status instanceof \WP_Error || $status instanceof Status_Entity ) {
+			return $status;
+		}
+		$post_data = array();
+
+		$post_data['post_content'] = $status_text;
+		$post_data['post_status']  = 'public' === $visibility ? 'publish' : 'private';
+		$post_data['post_type']    = 'post';
+		$post_data['post_title']   = '';
+
+		if ( 'standard' === $post_format ) {
+			// Use the first line of a post as the post title if we're using a standard post format.
+			list( $post_title, $post_content ) = explode( PHP_EOL, $post_data['post_content'], 2 );
+			$post_data['post_title']   = $post_title;
+			$post_data['post_content'] = trim( $post_content );
+		}
+
+		if ( $in_reply_to_id ) {
+			$post_data['post_parent'] = $in_reply_to_id;
+		}
+
+		if ( $scheduled_at ) {
+			$post_data['post_status'] = 'future';
+			$post_data['post_date'] = $scheduled_at;
+		}
+
+		if ( ! empty( $media_ids ) ) {
+			foreach ( $media_ids as $media_id ) {
+				$media = get_post( $media_id );
+				if ( ! $media ) {
+					return new \WP_Error( 'mastodon_' . __FUNCTION__, 'Media not found', array( 'status' => 400 ) );
+				}
+				if ( 'attachment' !== $media->post_type ) {
+					return new \WP_Error( 'mastodon_' . __FUNCTION__, 'Media not found', array( 'status' => 400 ) );
+				}
+				$attachment = \wp_get_attachment_metadata( $media_id );
+				$post_data['post_content'] .= PHP_EOL;
+				$post_data['post_content'] .= '<!-- wp:image -->';
+				$post_data['post_content'] .= '<p><img src="' . esc_url( wp_get_attachment_url( $media_id ) ) . '" width="' . esc_attr( $attachment['width'] ) . '"  height="' . esc_attr( $attachment['height'] ) . '" class="size-full" /></p>';
+				$post_data['post_content'] .= '<!-- /wp:image -->';
+			}
+		}
+
+		$post_id = wp_insert_post( $post_data );
+		if ( is_wp_error( $post_id ) ) {
+			return $post_id;
+		}
+
+		if ( 'standard' !== $post_format ) {
+			set_post_format( $post_id, $post_format );
+		}
+
+		if ( ! empty( $media_ids ) ) {
+			foreach ( $media_ids as $media_id ) {
+				wp_update_post(
+					array(
+						'ID'          => $media_id,
+						'post_parent' => $post_id,
+					)
+				);
+			}
+		}
+
+		if ( $scheduled_at ) {
+			return array(
+				'id'           => $post_id,
+				'scheduled_at' => $scheduled_at,
+				'params'       => array(
+					'text'         => $status,
+					'visibility'   => $visibility,
+					'scheduled_at' => $scheduled_at,
+				),
+			);
+		}
+
+		/**
+		 * Modify the status data.
+		 *
+		 * @param array|null $account The status data.
+		 * @param int $post_id The object ID to get the status from.
+		 * @param array $data Additional status data.
+		 * @return array|null The modified status data.
+		 */
+		$status = apply_filters( 'mastodon_api_status', null, $post_id, array() );
+
+		return $status;
+	}
+
+	public function api_submit_comment( $status, $status_text, $in_reply_to_id, $media_ids, $post_format, $visibility, $scheduled_at ) {
+		if ( $status instanceof \WP_Error || $status instanceof Status_Entity ) {
+			return $status;
+		}
+		$comment_data = array();
+
+		$comment_data['comment_content'] = $status_text;
+		$comment_data['comment_post_ID'] = $in_reply_to_id;
+		$comment_data['comment_parent']  = 0;
+		$comment_data['comment_author'] = get_current_user_id();
+		$comment_data['comment_approved'] = 1;
+
+		if ( $in_reply_to_id ) {
+			$comment_data['comment_parent'] = $in_reply_to_id;
+		}
+
+		if ( ! empty( $media_ids ) ) {
+			foreach ( $media_ids as $media_id ) {
+				$media = get_post( $media_id );
+				if ( ! $media ) {
+					return new \WP_Error( 'mastodon_' . __FUNCTION__, 'Media not found', array( 'status' => 400 ) );
+				}
+				if ( 'attachment' !== $media->post_type ) {
+					return new \WP_Error( 'mastodon_' . __FUNCTION__, 'Media not found', array( 'status' => 400 ) );
+				}
+				$attachment = \wp_get_attachment_metadata( $media_id );
+				$comment_data['comment_content'] .= PHP_EOL;
+				$comment_data['comment_content'] .= '<!-- wp:image -->';
+				$comment_data['comment_content'] .= '<p><img src="' . esc_url( wp_get_attachment_url( $media_id ) ) . '" width="' . esc_attr( $attachment['width'] ) . '"  height="' . esc_attr( $attachment['height'] ) . '" class="size-full" /></p>';
+				$comment_data['comment_content'] .= '<!-- /wp:image -->';
+			}
+		}
+
+		$comment_id = wp_insert_comment( $comment_data );
+
+		/**
+		 * Modify the status data.
+		 *
+		 * @param array|null $account The status data.
+		 * @param int $post_id The object ID to get the status from.
+		 * @param array $data Additional status data.
+		 * @return array|null The modified status data.
+		 */
+		$status = apply_filters(
+			'mastodon_api_status',
+			null,
+			$in_reply_to_id,
+			array(
+				'comment' => get_comment( $comment_id ),
+			)
+		);
+
+		return $status;
+	}
+
+	public function api_status_context( $context, $context_post_id ) {
+		foreach ( get_post_ancestors( $context_post_id ) as $post_id ) {
+			$args = array();
+
+			/**
+			 * Modify the status data.
+			 *
+			 * @param array|null $account The status data.
+			 * @param int $post_id The object ID to get the status from.
+			 * @param array $data Additional status data.
+			 * @return array|null The modified status data.
+			 */
+			$status = apply_filters(
+				'mastodon_api_status',
+				null,
+				$post_id,
+				$args
+			);
+			if ( $status ) {
+				$context['ancestors'][ $status->id ] = $status;
+			}
+		}
+
+		$children = get_children(
+			array(
+				'post_parent' => $context_post_id,
+				'post_type'   => 'any',
+			)
+		);
+		foreach ( $children as $post ) {
+			$post = get_post( $post->post_parent );
+			$post_id = $post->ID;
+			$args = array();
+			/**
+			 * Modify the status data.
+			 *
+			 * @param array|null $account The status data.
+			 * @param int $post_id The object ID to get the status from.
+			 * @param array $data Additional status data.
+			 * @return array|null The modified status data.
+			 */
+			$status = apply_filters(
+				'mastodon_api_status',
+				null,
+				$post_id,
+				$args
+			);
+			if ( $status ) {
+				$context['descendants'][ $status->id ] = $status;
+			}
+		}
+
+		ksort( $context['ancestors'] );
+
+		ksort( $context['descendants'] );
+
+		$context['ancestors'] = array_values( $context['ancestors'] );
+		$context['descendants'] = array_values( $context['descendants'] );
+		return $context;
 	}
 }

--- a/includes/handler/class-status.php
+++ b/includes/handler/class-status.php
@@ -295,7 +295,7 @@ class Status extends Handler {
 	}
 
 	public function api_submit_comment( $status, $status_text, $in_reply_to_id, $media_ids, $post_format, $visibility, $scheduled_at ) {
-		if ( $status instanceof \WP_Error || $status instanceof Status_Entity ) {
+		if ( $status instanceof \WP_Error || $status instanceof Status_Entity || ! $in_reply_to_id ) {
 			return $status;
 		}
 		$comment_data = array();


### PR DESCRIPTION
In order to provide a timeline that conists of both posts and comments (now that the ActivityPub plugin can create comments for incoming replies), we're using a custom post type that act as proxies so that the comments get their own mapped post id which fits into the sequence of posts.