### PR TITLE
Register OAuth Rewrite Path

### DIFF
--- a/includes/class-mastodon-api.php
+++ b/includes/class-mastodon-api.php
@@ -71,7 +71,7 @@ class Mastodon_API {
 		add_action( 'query_vars', array( $this, 'query_vars' ) );
 		add_action( 'rest_api_init', array( $this, 'add_rest_routes' ) );
 		add_filter( 'rest_pre_serve_request', array( $this, 'allow_cors' ), 10, 0 );
-		add_filter( 'rest_post_dispatch', array( $this, 'send_http_links' ), 10, 1 );
+		add_filter( 'rest_post_dispatch', array( $this, 'send_http_links' ), 10, 3 );
 		add_filter( 'rest_pre_echo_response', array( $this, 'reformat_error_response' ), 10, 3 );
 		add_filter( 'template_include', array( $this, 'log_404s' ) );
 		add_filter( 'rest_json_encode_options', array( $this, 'rest_json_encode_options' ), 10, 2 );
@@ -90,8 +90,15 @@ class Mastodon_API {
 		}
 	}
 
-	public function send_http_links( \WP_REST_Response $response ) {
+	public function send_http_links( \WP_REST_Response $response, \WP_REST_Server $server, \WP_REST_Request $request ) {
+		if ( 0 !== strpos( $request->get_route(), '/' . self::PREFIX ) ) {
+			return $response;
+		}
+
 		foreach ( $response->get_links() as $rel => $link ) {
+			if ( ! in_array( $rel, array( 'prev', 'next' ) ) ) {
+				continue;
+			}
 			$response->link_header( $rel, $link[0]['href'] );
 			$response->remove_link( $rel );
 		}
@@ -104,13 +111,13 @@ class Mastodon_API {
 	 *
 	 * @see https://docs.joinmastodon.org/entities/Error/
 	 *
-	 * @param array           $result  The API result.
-	 * @param WP_REST_Server  $server  The REST server instance.
-	 * @param WP_REST_Request $request The REST request instance.
+	 * @param mixed            $result  The API result.
+	 * @param \WP_REST_Server  $server  The REST server instance.
+	 * @param \WP_REST_Request $request The REST request instance.
 	 *
 	 * @return array The reformatted result.
 	 */
-	public function reformat_error_response( $result, $server, $request ) {
+	public function reformat_error_response( $result, \WP_REST_Server $server, \WP_REST_Request $request ) {
 		if ( 0 !== strpos( $request->get_route(), '/' . self::PREFIX ) ) {
 			return $result;
 		}
@@ -239,7 +246,7 @@ class Mastodon_API {
 		);
 
 		foreach ( $generic as $rule ) {
-			if ( empty( $existing_rules[ $rule ] ) ) {
+			if ( empty( $existing_rules[ '^' . $rule ] ) ) {
 				// Add a specific rewrite rule so that we can also catch requests without our prefix.
 				$needs_flush = true;
 			}
@@ -247,7 +254,7 @@ class Mastodon_API {
 		}
 
 		foreach ( $parametrized as $rule => $rewrite ) {
-			if ( empty( $existing_rules[ $rule ] ) ) {
+			if ( empty( $existing_rules[ '^' . $rule ] ) ) {
 				// Add a specific rewrite rule so that we can also catch requests without our prefix.
 				$needs_flush = true;
 			}
@@ -259,6 +266,7 @@ class Mastodon_API {
 			$wp_rewrite->flush_rules();
 		}
 	}
+
 	public function add_rest_routes() {
 		register_rest_route(
 			self::PREFIX,

--- a/includes/class-mastodon-oauth.php
+++ b/includes/class-mastodon-oauth.php
@@ -101,7 +101,6 @@ class Mastodon_OAuth {
 			$_POST = $_REQUEST;
 		}
 		if ( ! isset( $wp_query->query['mastodon-oauth'] ) ) {
-			exit;
 			return null;
 		}
 


### PR DESCRIPTION
When a post exists on the WordPress site that includes the word "authorize", WordPress redirects there instead of letting EMA handle the path.

This adds the necessary rewrite routing for this. In the course I fixed two more bugs:
- We always flushed the rewrite on every request because we were not properly checking for the registered route (added the `'^'`
- We removed link headers from Gutenberg REST requests, this now limits that link removal to the `prev` and `next` as intended and also only for our own REST requests.
 
Fixes #129.

