### PR TITLE
WIP Improve comment reply handling

### DIFF
--- a/includes/class-mastodon-api.php
+++ b/includes/class-mastodon-api.php
@@ -2370,10 +2370,21 @@ class Mastodon_API {
 		return $remapped_post_id;
 	}
 
+	public static function maybe_get_remapped_comment_id( $remapped_post_id ) {
+		$post_id = get_post_meta( $remapped_post_id, 'mastodon_comment_id', true );
+		if ( $post_id ) {
+			return $post_id;
+		}
+		return $remapped_post_id;
+	}
+
 	public static function remap_comment_id( $comment_id ) {
 		$remapped_comment_id = get_comment_meta( $comment_id, 'mastodon_comment_id', true );
 		if ( ! $remapped_comment_id ) {
 			$comment = get_comment( $comment_id );
+			if ( ! $comment ) {
+				return $comment_id;
+			}
 			if ( $comment->comment_parent ) {
 				$post_parent = self::remap_comment_id( $comment->comment_parent );
 			} else {

--- a/includes/entity/class-account.php
+++ b/includes/entity/class-account.php
@@ -238,4 +238,11 @@ class Account extends Entity {
 		'note'      => '',
 		'fields'    => array(),
 	);
+
+	public function __get( $k ) {
+		if ( 'created_at' === $k && ! isset( $this->$k ) ) {
+			return new \DateTime( 'now' );
+		}
+		return parent::__get( $k );
+	}
 }

--- a/includes/entity/class-status.php
+++ b/includes/entity/class-status.php
@@ -286,6 +286,10 @@ class Status extends Entity {
 			return $this->normalize_whitespace( $this->content );
 		}
 
+		if ( 'created_at' === $k && ! isset( $this->$k ) ) {
+			return new \DateTime( 'now' );
+		}
+
 		return parent::__get( $k );
 	}
 

--- a/includes/handler/class-status.php
+++ b/includes/handler/class-status.php
@@ -30,6 +30,7 @@ class Status extends Handler {
 	public function register_hooks() {
 		add_filter( 'mastodon_api_status', array( $this, 'api_status' ), 10, 3 );
 		add_filter( 'mastodon_api_status', array( $this, 'api_status_account_ensure_numeric_id' ), 100 );
+		add_filter( 'mastodon_api_comment_parent_post_id', array( Mastodon_API::class, 'maybe_get_remapped_comment_id' ), 30 );
 		add_filter( 'mastodon_api_account_statuses_args', array( $this, 'mastodon_api_account_statuses_args' ), 10, 2 );
 		add_filter( 'mastodon_api_statuses', array( $this, 'api_statuses' ), 10, 4 );
 		add_filter( 'mastodon_api_submit_status', array( $this, 'api_submit_comment' ), 10, 7 );
@@ -300,14 +301,28 @@ class Status extends Handler {
 		}
 		$comment_data = array();
 
+		/**
+		 * Get the post id that is being responded to.
+		 *
+		 * @param int $in_reply_to_id The post ID that is being responded to.
+		 * @param string $status_text The status text.
+		 * @return int The post ID that is being responded to.
+		 */
+		$parent_post_id = apply_filters( 'mastodon_api_comment_parent_post_id', $in_reply_to_id, $status_text );
+
 		$comment_data['comment_content'] = $status_text;
 		$comment_data['comment_post_ID'] = $in_reply_to_id;
 		$comment_data['comment_parent']  = 0;
 		$comment_data['comment_author'] = get_current_user_id();
+		$comment_data['user_id'] = get_current_user_id();
 		$comment_data['comment_approved'] = 1;
 
-		if ( $in_reply_to_id ) {
-			$comment_data['comment_parent'] = $in_reply_to_id;
+		$parent_comment_id = Mastodon_API::maybe_get_remapped_comment_id( $in_reply_to_id );
+		if ( intval( $parent_comment_id ) !== intval( $in_reply_to_id ) ) {
+			$parent_comment = get_comment( $parent_comment_id );
+			if ( $parent_comment ) {
+				$comment_data['comment_parent'] = $parent_comment_id;
+			}
 		}
 
 		if ( ! empty( $media_ids ) ) {

--- a/includes/handler/class-status.php
+++ b/includes/handler/class-status.php
@@ -29,12 +29,13 @@ class Status extends Handler {
 
 	public function register_hooks() {
 		add_filter( 'mastodon_api_status', array( $this, 'api_status' ), 10, 3 );
-		add_filter( 'mastodon_api_status', array( $this, 'api_status_account_ensure_numeric_id' ), 100 );
+		add_filter( 'mastodon_api_status', array( $this, 'api_status_ensure_numeric_id' ), 100 );
 		add_filter( 'mastodon_api_comment_parent_post_id', array( Mastodon_API::class, 'maybe_get_remapped_comment_id' ), 30 );
 		add_filter( 'mastodon_api_account_statuses_args', array( $this, 'mastodon_api_account_statuses_args' ), 10, 2 );
 		add_filter( 'mastodon_api_statuses', array( $this, 'api_statuses' ), 10, 4 );
+		add_filter( 'mastodon_api_statuses', array( $this, 'api_statuses_ensure_numeric_id' ), 100 );
 		add_filter( 'mastodon_api_submit_status', array( $this, 'api_submit_comment' ), 10, 7 );
-		add_filter( 'mastodon_api_submit_status', array( $this, 'api_submit_post' ), 10, 7 );
+		add_filter( 'mastodon_api_submit_status', array( $this, 'api_submit_post' ), 15, 7 );
 		add_filter( 'mastodon_api_status_context', array( $this, 'api_status_context' ), 10, 3 );
 	}
 
@@ -188,6 +189,7 @@ class Status extends Handler {
 			}
 			return $statuses;
 		}
+
 		return $this->get_posts( $args, $min_id, $max_id );
 	}
 
@@ -195,14 +197,51 @@ class Status extends Handler {
 		return $this->get_posts_query_args( $args, $request );
 	}
 
+	public function api_statuses_ensure_numeric_id( $statuses ) {
+		$response = null;
+		if ( $statuses instanceof \WP_REST_Response ) {
+			$response = $statuses;
+			$statuses = $response->data;
+		}
+		if ( ! is_array( $statuses ) ) {
+			return $statuses;
+		}
 
-	public function api_status_account_ensure_numeric_id( $status ) {
+		foreach ( $statuses as $k => $status ) {
+			$statuses[ $k ] = $this->api_status_ensure_numeric_id( $status );
+		}
+
+		if ( $response ) {
+			$response->data = $statuses;
+			return $response;
+		}
+
+		return $statuses;
+	}
+
+	public function api_status_ensure_numeric_id( $status ) {
+		if ( ! $status instanceof Status_Entity ) {
+			return $status;
+		}
+
+		if ( isset( $status->id ) && ! is_numeric( $status->id ) ) {
+			$status->id = \Enable_Mastodon_Apps\Mastodon_API::remap_url( $status->id );
+		}
+
 		if ( isset( $status->account->id ) && ! is_numeric( $status->account->id ) ) {
 			$status->account->id = \Enable_Mastodon_Apps\Mastodon_API::remap_user_id( $status->account->id );
 		}
+
 		if ( isset( $status->reblog->account->id ) && ! is_numeric( $status->reblog->account->id ) ) {
 			$status->reblog->account->id = \Enable_Mastodon_Apps\Mastodon_API::remap_user_id( $status->reblog->account->id );
 		}
+
+		foreach ( $status->media_attachments as $media_attachment ) {
+			if ( isset( $media_attachment->id ) && ! is_numeric( $media_attachment->id ) ) {
+				$media_attachment->id = \Enable_Mastodon_Apps\Mastodon_API::remap_url( $media_attachment->id );
+			}
+		}
+
 		return $status;
 	}
 
@@ -311,7 +350,7 @@ class Status extends Handler {
 		$parent_post_id = apply_filters( 'mastodon_api_comment_parent_post_id', $in_reply_to_id, $status_text );
 
 		$comment_data['comment_content'] = $status_text;
-		$comment_data['comment_post_ID'] = $in_reply_to_id;
+		$comment_data['comment_post_ID'] = $parent_post_id;
 		$comment_data['comment_parent']  = 0;
 		$comment_data['comment_author'] = get_current_user_id();
 		$comment_data['user_id'] = get_current_user_id();

--- a/tests/test-statuses-endpoint.php
+++ b/tests/test-statuses-endpoint.php
@@ -164,7 +164,6 @@ class StatusesEndpoint_Test extends Mastodon_API_TestCase {
 		$request = $this->api_request( 'POST', '/api/v1/statuses' );
 		$request->set_param( 'status', 'reply' );
 		$request->set_param( 'in_reply_to_id', $this->post );
-		var_dump( $this->post );
 		$response = $this->dispatch_authenticated( $request );
 		$this->assertEquals( 200, $response->get_status() );
 

--- a/tests/test-statuses-endpoint.php
+++ b/tests/test-statuses-endpoint.php
@@ -176,7 +176,6 @@ class StatusesEndpoint_Test extends Mastodon_API_TestCase {
 				'count' => true,
 			)
 		);
-		echo json_encode( $data, JSON_PRETTY_PRINT );
 
 		$this->assertTrue( $new_count > $count );
 	}


### PR DESCRIPTION
This adds a number of other changes in coordination with https://github.com/Automattic/wordpress-activitypub/pull/766 and https://github.com/akirk/friends/pull/318:

- Numeric ids are automatically ensured for accounts and media attachments,
- This is now also done for multiple statuses (i.e. the `mastodon_api_statuses` filter),
- `created_at` on Account and Status will default to `now` when not specified,
- The rewritten `in_reply_to_id` is actually used as `comment_post_ID`,
- adds a test to ensure that a `in_reply_to_id` arrives as a comment.