### PR TITLE
Allow Editing Statuses

### DIFF
--- a/includes/entity/class-status-source.php
+++ b/includes/entity/class-status-source.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Status entity.
+ *
+ * This contains the Status entity.
+ *
+ * @package Enable_Mastodon_Apps
+ */
+
+namespace Enable_Mastodon_Apps\Entity;
+
+/**
+ * This is the class that implements the Status entity.
+ *
+ * @since 0.7.0
+ *
+ * @package Enable_Mastodon_Apps
+ */
+class Status_Source extends Entity {
+	protected $_types = array(
+		'id'           => 'string',
+		'spoiler_text' => 'string',
+		'text'         => 'string',
+	);
+
+	/**
+	 * The status ID.
+	 *
+	 * @var string
+	 */
+	public string $id;
+
+	/**
+	 * The plain text used to compose the status’s subject or content warning.
+	 *
+	 * @var string
+	 */
+	public string $spoiler_text = '';
+
+	/**
+	 * The plain text used to compose the status
+	 *
+	 * @var string
+	 */
+	public string $text;
+}

--- a/includes/handler/class-media-attachment.php
+++ b/includes/handler/class-media-attachment.php
@@ -156,7 +156,7 @@ class Media_Attachment extends Handler {
 
 		foreach ( $matches as $match ) {
 			$status->content = str_replace( $match[0], '', $status->content );
-			if ( ! preg_match( '/<img\b([^>]+)>/', $match[2], $img ) ) {
+			if ( ! preg_match( '/<img\b([^>]+)>/', $match[0], $img ) ) {
 				continue;
 			}
 			$block = array();

--- a/includes/handler/class-status-source.php
+++ b/includes/handler/class-status-source.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Status Source handler.
+ *
+ * This contains the default Status Source handlers.
+ *
+ * @package Enable_Mastodon_Apps
+ */
+
+namespace Enable_Mastodon_Apps\Handler;
+
+use Enable_Mastodon_Apps\Entity\Status_Source as Status_Source_Entity;
+use Enable_Mastodon_Apps\Mastodon_API;
+
+/**
+ * This is the class that implements the default handler for all Status Source endpoints.
+ *
+ * @since 0.7.0
+ *
+ * @package Enable_Mastodon_Apps
+ */
+class Status_Source extends Status {
+	public function __construct() {
+		$this->register_hooks();
+	}
+
+	public function register_hooks() {
+		add_filter( 'mastodon_api_status_source', array( $this, 'api_status_source' ), 10, 3 );
+	}
+
+	/**
+	 * Get a status source array.
+	 *
+	 * @param Status_Source_Entity $status_source Current status source array.
+	 * @param int                  $object_id The object ID to get the status from.
+	 * @return Status_Source_Entity The status source entity
+	 */
+	public function api_status_source( ?Status_Source_Entity $status_source, int $object_id ): ?Status_Source_Entity {
+		if ( $status_source instanceof Status_Source_Entity ) {
+			return $status_source;
+		}
+		$post = get_post( $object_id );
+		if ( ! $post ) {
+			$comment = get_comment( $object_id );
+			if ( isset( $comment ) && $comment instanceof \WP_Comment ) {
+				$status_source = new Status_Source_Entity();
+				$status_source->id = strval( Mastodon_API::remap_comment_id( $comment->comment_ID ) );
+				$status_source->text = trim( wp_strip_all_tags( $comment->comment_content ) );
+			}
+
+			return $status_source;
+		}
+
+		if ( $post instanceof \WP_Post ) {
+			$status_source = new Status_Source_Entity();
+			$status_source->id = strval( $post->ID );
+			$status_source->text = trim( wp_strip_all_tags( $post->post_title . PHP_EOL . $post->post_content ) );
+		}
+
+		return $status_source;
+	}
+}

--- a/includes/handler/class-status.php
+++ b/includes/handler/class-status.php
@@ -285,13 +285,12 @@ class Status extends Handler {
 				$attachment = \wp_get_attachment_metadata( $media_id );
 				if ( \wp_attachment_is( 'image', $media_id ) ) {
 					$post_data['post_content'] .= PHP_EOL;
-					$post_data['post_content'] .= '<!-- wp:image ' . json_encode(
-						array(
-							'id'       => $media_id,
-							'sizeSlug' => 'large',
-						)
-					) . ' -->' . PHP_EOL;
-					$post_data['post_content'] .= '<figure class="wp-block-image"><img src="' . esc_url( wp_get_attachment_url( $media_id ) ) . '" width="' . esc_attr( $attachment['width'] ) . '" height="' . esc_attr( $attachment['height'] ) . '" class="wp-image-' . esc_attr( $media_id ) . '"/></figure>' . PHP_EOL;
+					$meta_json = array(
+						'id'       => $media_id,
+						'sizeSlug' => 'large',
+					);
+					$post_data['post_content'] .= '<!-- wp:image ' . json_encode( $meta_json ) . ' -->' . PHP_EOL;
+					$post_data['post_content'] .= '<figure class="wp-block-image"><img src="' . esc_url( wp_get_attachment_url( $media_id ) ) . '" width="' . esc_attr( $attachment['width'] ) . '" height="' . esc_attr( $attachment['height'] ) . '" alt="' . esc_attr( $meta[''] ) . '" class="wp-image-' . esc_attr( $media_id ) . '"/></figure>' . PHP_EOL;
 					$post_data['post_content'] .= '<!-- /wp:image -->' . PHP_EOL;
 				} elseif ( \wp_attachment_is( 'video', $media_id ) ) {
 					$post_data['post_content'] .= PHP_EOL;


### PR DESCRIPTION
This adds:
- [a source endpoint](https://docs.joinmastodon.org/methods/statuses/#source)
- Support for the `PUT` HTTP method on a status, see [Edit a status](https://docs.joinmastodon.org/methods/statuses/#edit)