### PR TITLE
Hide debug tabs unless debug setting is turned on

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,6 @@ jobs:
         env:
           MYSQL_ROOT_PASSWORD: wordpress
           MYSQL_DATABASE: wordpress_test
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
     name: "Tests: PHP ${{ matrix.php }} - PHPUnit: ${{matrix.phpunit}} - WordPress: ${{matrix.wordpress}}"
     steps:

--- a/admin.css
+++ b/admin.css
@@ -205,7 +205,7 @@ summary {
 
 .settings_page_enable-mastodon-apps .pill-outdated {
 	color: #fff;
-	background-color: #266430;
+	background-color: #c05621;
 }
 
 

--- a/admin.css
+++ b/admin.css
@@ -192,6 +192,27 @@ summary {
 	margin-bottom: 0;
 }
 
+.settings_page_enable-mastodon-apps .pill {
+	font-weight: 500;
+	font-size: .7em;
+	margin-right: 0.3em;
+	width: 6em;
+	text-align: center;
+	padding: 0.2em 0.5em;
+	border-radius: 1em;
+	text-transform: capitalize;
+}
+
+.settings_page_enable-mastodon-apps .pill-outdated {
+	color: #fff;
+	background-color: #266430;
+}
+
+
+.settings_page_enable-mastodon-apps .disable-debug .debug-hide {
+	display: none;
+}
+
 .settings_page_enable-mastodon-apps details.tt {
 	font-family: monospace;
 	word-wrap: break-word;
@@ -199,6 +220,26 @@ summary {
 
 .settings_page_enable-mastodon-apps summary {
 	cursor: pointer;
+}
+
+.settings_page_enable-mastodon-apps button.button-destructive {
+	border-color: #b32d2e;
+	color: #b32d2e;
+}
+
+.settings_page_enable-mastodon-apps button.button-destructive:hover {
+
+	border-color: #a00;
+	background-color: #b32d2e;
+	box-shadow: none;
+	color: #fff;
+}
+
+.settings_page_enable-mastodon-apps button.button-destructive:focus {
+	border-color: #000;
+	background-color: #b32d2e;
+	box-shadow: none;
+	color: #fff;
 }
 
 .settings_page_enable-mastodon-apps table.widefat td:last-child {
@@ -212,6 +253,10 @@ summary {
 .enable-mastodon-apps-settings.enable-mastodon-apps-registered-apps-page span.count {
 	float: right;
 	margin-right: .5em;
+}
+
+.enable-mastodon-apps-settings.enable-mastodon-apps-registered-apps-page .save-app {
+	display: none;
 }
 
 .enable-mastodon-apps-settings h2 {

--- a/admin.js
+++ b/admin.js
@@ -33,4 +33,22 @@ jQuery( function( $ ) {
 		}, 1000 );
 	}
 
+	$(document).on( 'change', '.enable-mastodon-apps-settings .appformats', function( event, response ) {
+		$( this ).parent().find( '.save-app' ).show();
+	} );
+
+	$(document).on( 'click', '.enable-mastodon-apps-settings button[name=delete-app]', function( event, response ) {
+		if ( ! confirm( this.dataset.confirm ) ) {
+			event.preventDefault();
+			return false;
+		}
+	} );
+
+	$(document).on( 'click', '.enable-mastodon-apps-settings button[name=clear-app-logs]', function( event, response ) {
+		if ( ! confirm( this.dataset.confirm ) ) {
+			event.preventDefault();
+			return false;
+		}
+	} );
+
 } );

--- a/admin.js
+++ b/admin.js
@@ -34,7 +34,7 @@ jQuery( function( $ ) {
 	}
 
 	$(document).on( 'change', '.enable-mastodon-apps-settings .appformats', function( event, response ) {
-		$( this ).parent().find( '.save-app' ).show();
+		$( this ).closest('tr').find( '[name=save-app]' ).show();
 	} );
 
 	$(document).on( 'click', '.enable-mastodon-apps-settings button[name=delete-app]', function( event, response ) {

--- a/includes/class-mastodon-app.php
+++ b/includes/class-mastodon-app.php
@@ -182,13 +182,14 @@ class Mastodon_App {
 	}
 
 	public function is_outdated() {
+		$now = time();
 		foreach ( OAuth2\Access_Token_Storage::getAll() as $token ) {
-			if ( $token['client_id'] === $this->get_client_id() && ! $token['expired'] ) {
+			if ( $token['client_id'] === $this->get_client_id() && $token['expires'] > $now ) {
 				return false;
 			}
 		}
 		foreach ( OAuth2\Authorization_Code_Storage::getAll() as $code ) {
-			if ( $code['client_id'] === $this->get_client_id() && ! $code['expired'] ) {
+			if ( $code['client_id'] === $this->get_client_id() && $code['expires'] > $now ) {
 				return false;
 			}
 		}

--- a/includes/oauth2/class-access-token-storage.php
+++ b/includes/oauth2/class-access-token-storage.php
@@ -270,6 +270,10 @@ class Access_Token_Storage implements AccessTokenInterface {
 			)
 		);
 
+		if ( ! $terms ) {
+			return;
+		}
+
 		foreach ( $terms->terms as $term_id ) {
 			wp_delete_term( $term_id, self::TAXONOMY );
 		}
@@ -286,6 +290,10 @@ class Access_Token_Storage implements AccessTokenInterface {
 				'fields'     => 'ids',
 			)
 		);
+
+		if ( ! $terms ) {
+			return;
+		}
 
 		foreach ( $terms->terms as $term_id ) {
 			wp_delete_term( $term_id, self::TAXONOMY );

--- a/includes/oauth2/class-authorization-code-storage.php
+++ b/includes/oauth2/class-authorization-code-storage.php
@@ -253,10 +253,14 @@ class Authorization_Code_Storage implements AuthorizationCodeInterface {
 			)
 		);
 
+		if ( ! $terms ) {
+			return;
+		}
 		foreach ( $terms->terms as $term_id ) {
 			wp_delete_term( $term_id, self::TAXONOMY );
 		}
 	}
+
 
 	/**
 	 * Delete all auth codes when the plugin is uninstalled.
@@ -269,7 +273,9 @@ class Authorization_Code_Storage implements AuthorizationCodeInterface {
 				'fields'     => 'ids',
 			)
 		);
-
+		if ( ! $terms ) {
+			return;
+		}
 		foreach ( $terms->terms as $term_id ) {
 			wp_delete_term( $term_id, self::TAXONOMY );
 		}

--- a/templates/admin-header.php
+++ b/templates/admin-header.php
@@ -95,6 +95,7 @@ function td_timestamp( $timestamp, $strikethrough_past = false ) {
 			<?php \esc_html_e( 'Registered Apps', 'enable-mastodon-apps' ); ?>
 		</a>
 
+		<?php if ( $args['enable_debug'] ) : ?>
 		<a href="<?php echo \esc_url_raw( admin_url( 'options-general.php?page=enable-mastodon-apps&tab=tester' ) ); ?>" class="enable-mastodon-apps-settings-tab <?php echo \esc_attr( 'tester' === ( $args['active'] ?? '' ) ? 'active' : '' ); ?>">
 			<?php \esc_html_e( 'Tester', 'enable-mastodon-apps' ); ?>
 		</a>
@@ -102,6 +103,7 @@ function td_timestamp( $timestamp, $strikethrough_past = false ) {
 		<a href="<?php echo \esc_url_raw( admin_url( 'options-general.php?page=enable-mastodon-apps&tab=debug' ) ); ?>" class="enable-mastodon-apps-settings-tab <?php echo \esc_attr( 'debug' === ( $args['active'] ?? '' ) ? 'active' : '' ); ?>">
 			<?php \esc_html_e( 'Debug', 'enable-mastodon-apps' ); ?>
 		</a>
+		<?php endif; ?>
 
 	</nav>
 </div>

--- a/templates/debug.php
+++ b/templates/debug.php
@@ -3,7 +3,8 @@
 	__DIR__ . '/admin-header.php',
 	true,
 	array(
-		'active' => 'debug',
+		'active'       => 'debug',
+		'enable_debug' => true,
 	)
 );
 $rest_nonce = wp_create_nonce( 'wp_rest' );

--- a/templates/registered-apps.php
+++ b/templates/registered-apps.php
@@ -174,9 +174,14 @@ function post_format_select( $name, $selected = array() ) {
 								if ( isset( $args['apps'][ $data['client_id'] ] ) ) {
 									echo esc_html( $args['apps'][ $data['client_id'] ]->get_client_name() );
 								} else {
-									echo esc_html( 'Unknown: ' . $data['client_id'] );
-									echo ' <span class="pill pill-unknown" title="' . esc_html__( 'Associated with an app that no longer exists.', 'enable-mastodon-apps' ) . '">' . esc_html__( 'Outdated', 'enable-mastodon-apps' ) . '</span>';
-
+									echo esc_html(
+										sprintf(
+										// Translators: %s is the app ID.
+											__( 'Unknown App: %s', 'enable-mastodon-apps' ),
+											$data['client_id']
+										)
+									);
+									echo ' <span class="pill pill-outdated" title="' . esc_html__( 'Associated with an app that no longer exists.', 'enable-mastodon-apps' ) . '">' . esc_html__( 'Outdated', 'enable-mastodon-apps' ) . '</span>';
 								}
 
 								?>
@@ -245,6 +250,7 @@ function post_format_select( $name, $selected = array() ) {
 											$data['client_id']
 										)
 									);
+									echo ' <span class="pill pill-outdated" title="' . esc_html__( 'Associated with an app that no longer exists.', 'enable-mastodon-apps' ) . '">' . esc_html__( 'Outdated', 'enable-mastodon-apps' ) . '</span>';
 								}
 								?>
 							</td>

--- a/templates/registered-apps.php
+++ b/templates/registered-apps.php
@@ -1,9 +1,13 @@
 <?php
+
+use Enable_Mastodon_Apps\Mastodon_App;
+
 \load_template(
 	__DIR__ . '/admin-header.php',
 	true,
 	array(
-		'active' => 'registered-apps',
+		'active'       => 'registered-apps',
+		'enable_debug' => $args['enable_debug'],
 	)
 );
 
@@ -11,7 +15,7 @@ $rest_nonce = wp_create_nonce( 'wp_rest' );
 
 function post_format_select( $name, $selected = array() ) {
 	?>
-		<select name="<?php echo esc_attr( $name ); ?>[]" id="<?php echo esc_attr( $name ); ?>" size="10" multiple>
+		<select name="<?php echo esc_attr( $name ); ?>[]" id="<?php echo esc_attr( $name ); ?>" size="10" multiple class="appformats">
 		<?php
 		foreach ( get_post_format_slugs() as $format ) {
 			?>
@@ -20,107 +24,129 @@ function post_format_select( $name, $selected = array() ) {
 		}
 		?>
 		</select>
-		<?php
+	<?php
 }
 
 ?>
-<div class="enable-mastodon-apps-settings enable-mastodon-apps-registered-apps-page">
+<div class="enable-mastodon-apps-settings enable-mastodon-apps-registered-apps-page <?php echo $args['enable_debug'] ? 'enable-debug' : 'disable-debug'; ?>">
 	<form method="post">
 		<?php wp_nonce_field( 'enable-mastodon-apps' ); ?>
-			<h2><?php esc_html_e( 'Apps', 'enable-mastodon-apps' ); ?></h2>
-				<span class="count">
-					<?php
-					echo esc_html(
+		<h2><?php esc_html_e( 'Apps', 'enable-mastodon-apps' ); ?></h2>
+		<span class="count">
+			<?php
+			echo esc_html(
+				sprintf(
+				// translators: %d is the number of apps.
+					_n( '%d apps', '%d apps', count( $args['apps'] ), 'enable-mastodon-apps' ),
+					count( $args['apps'] )
+				)
+			);
+			?>
+		</span>
+		<table class="widefat">
+			<thead>
+				<th><?php esc_html_e( 'Name', 'enable-mastodon-apps' ); ?></th>
+				<th class="debug-hide"><?php esc_html_e( 'Redirect URI', 'enable-mastodon-apps' ); ?></th>
+				<th><?php esc_html_e( 'Scope', 'enable-mastodon-apps' ); ?></th>
+				<th class="debug-hide"><?php esc_html_e( 'Post Formats', 'enable-mastodon-apps' ); ?></th>
+				<th><?php esc_html_e( 'Last Used', 'enable-mastodon-apps' ); ?></th>
+				<th><?php esc_html_e( 'Created', 'enable-mastodon-apps' ); ?></th>
+				<th><?php esc_html_e( 'Actions', 'enable-mastodon-apps' ); ?></th>
+			</thead>
+			<tbody>
+				<?php
+				$alternate = true;
+				foreach ( $args['apps'] as $app ) {
+					$alternate = ! $alternate;
+					$confirm = esc_html(
 						sprintf(
-						// translators: %d is the number of apps.
-							_n( '%d apps', '%d apps', count( $args['apps'] ), 'enable-mastodon-apps' ),
-							count( $args['apps'] )
+						// translators: %s is the app name.
+							__( 'Are you sure you want to delete %s?', 'enable-mastodon-apps' ),
+							$app->get_client_name()
 						)
 					);
+
 					?>
-				</span>
-				<table class="widefat">
-					<thead>
-						<th><?php esc_html_e( 'Name', 'enable-mastodon-apps' ); ?></th>
-						<th><?php esc_html_e( 'Redirect URI', 'enable-mastodon-apps' ); ?></th>
-						<th><?php esc_html_e( 'Scope', 'enable-mastodon-apps' ); ?></th>
-						<th><?php esc_html_e( 'Post Formats', 'enable-mastodon-apps' ); ?></th>
-						<th><?php esc_html_e( 'Last Used', 'enable-mastodon-apps' ); ?></th>
-						<th><?php esc_html_e( 'Created', 'enable-mastodon-apps' ); ?></th>
-						<th><?php esc_html_e( 'Actions', 'enable-mastodon-apps' ); ?></th>
-					</thead>
-					<tbody>
-						<?php
-						$alternate = true;
-						foreach ( $args['apps'] as $app ) {
-							$alternate = ! $alternate;
+					<tr id='app-<?php echo esc_attr( $app->get_client_id() ); ?>' class="<?php echo $alternate ? 'alternate' : ''; ?>">
+						<td title='<?php echo esc_attr( $app->get_client_id() ); ?>'>
+							<?php
+							if ( $app->get_website() ) {
+								?>
+								<a href="<?php echo esc_url( $app->get_website() ); ?>"><?php echo esc_html( $app->get_client_name() ); ?></a>
+								<?php
+							} else {
+								echo esc_html( $app->get_client_name() );
+							}
+
+							if ( $app->is_outdated() && Mastodon_App::DEBUG_CLIENT_ID !== $app->get_client_id() ) {
+								echo ' <span class="pill pill-outdated" title="' . esc_html__( 'No tokens or authorization codes associated with this app.', 'enable-mastodon-apps' ) . '">' . esc_html__( 'Outdated', 'enable-mastodon-apps' ) . '</span>';
+							}
 							?>
-							<tr id='app-<?php echo esc_attr( $app->get_client_id() ); ?>' class="<?php echo $alternate ? 'alternate' : ''; ?>">
-								<td title='<?php echo esc_attr( $app->get_client_id() ); ?>'>
+						</td>
+						<td class="debug-hide"><?php echo wp_kses( implode( '<br/>', is_array( $app->get_redirect_uris() ) ? $app->get_redirect_uris() : explode( ',', $app->get_redirect_uris() ) ), array( 'br' => array() ) ); ?></td>
+						<td><?php echo esc_html( $app->get_scopes() ); ?></td>
+						<td class="debug-hide">
+							<details>
+								<summary><?php echo esc_html( implode( ', ', $app->get_post_formats() ) ); ?></summary>
+								<?php post_format_select( 'app_post_formats[' . $app->get_client_id() . ']', $app->get_post_formats() ); ?>
+							</details>
+						</td>
+							<?php td_timestamp( $app->get_last_used() ); ?>
+							<?php td_timestamp( $app->get_creation_date() ); ?>
+						<td>
+							<button name="save-app" value="<?php echo esc_attr( $app->get_client_id() ); ?>" class="button save-app button-secondary"><?php esc_html_e( 'Save' ); /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ ?></button>
+							<button name="delete-app" data-confirm="<?php echo esc_attr( $confirm ); ?>" value="<?php echo esc_attr( $app->get_client_id() ); ?>" class="button button-destructive"><?php esc_html_e( 'Delete' ); /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ ?></button>
+						</td>
+					</tr>
+					<?php
+					if ( $args['enable_debug'] ) {
+						$last_requests = $app->get_last_requests();
+						if ( $last_requests ) {
+							$confirm = esc_html(
+								sprintf(
+								// translators: %s is the app name.
+									__( 'Are you sure you want to delete all logs for %s?', 'enable-mastodon-apps' ),
+									$app->get_client_name()
+								)
+							);
+							?>
+							<tr id='applog-<?php echo esc_attr( $app->get_client_id() ); ?>' class="<?php echo $alternate ? 'alternate' : ''; ?>">
+								<td colspan="6">
+									<details class="tt"><summary>
 									<?php
-									if ( $app->get_website() ) {
-										?>
-										<a href="<?php echo esc_url( $app->get_website() ); ?>"><?php echo esc_html( $app->get_client_name() ); ?></a>
-										<?php
-									} else {
-										echo esc_html( $app->get_client_name() );
-									}
+									echo esc_html(
+										sprintf(
+											// translators: %ds is the number of requests.
+											_n( '%d logged request', '%d logged requests', count( $last_requests ), 'enable-mastodon-apps' ),
+											count( $last_requests )
+										)
+									);
 									?>
-								</td>
-								<td><?php echo wp_kses( implode( '<br/>', is_array( $app->get_redirect_uris() ) ? $app->get_redirect_uris() : explode( ',', $app->get_redirect_uris() ) ), array( 'br' => array() ) ); ?></td>
-								<td><?php echo esc_html( $app->get_scopes() ); ?></td>
-								<td>
-									<details>
-										<summary><?php echo esc_html( implode( ', ', $app->get_post_formats() ) ); ?></summary>
-										<?php post_format_select( 'app_post_formats[' . $app->get_client_id() . ']', $app->get_post_formats() ); ?>
+									</summary>
+											<?php
+											foreach ( $last_requests as $request ) {
+												output_request_log( $request, $rest_nonce );
+											}
+											?>
 									</details>
 								</td>
-								<?php td_timestamp( $app->get_last_used() ); ?>
-								<?php td_timestamp( $app->get_creation_date() ); ?>
 								<td>
-									<button name="save-app" value="<?php echo esc_attr( $app->get_client_id() ); ?>" class="button button-secondary"><?php esc_html_e( 'Save' ); /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ ?></button>
-									<button name="delete-app" value="<?php echo esc_attr( $app->get_client_id() ); ?>" class="button button-link-delete"><?php esc_html_e( 'Delete' ); /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ ?></button>
+									<button name="clear-app-logs" data-confirm="<?php echo esc_attr( $confirm ); ?>" value="<?php echo esc_attr( $app->get_client_id() ); ?>" class="button button-destructive"><?php esc_html_e( 'Clear logs', 'enable-mastodon-apps' ); ?></button>
 								</td>
 							</tr>
 							<?php
-
-							$last_requests = $app->get_last_requests();
-							if ( $last_requests ) {
-								?>
-								<tr id='applog-<?php echo esc_attr( $app->get_client_id() ); ?>' class="<?php echo $alternate ? 'alternate' : ''; ?>">
-									<td colspan="6">
-										<details class="tt"><summary>
-										<?php
-										echo esc_html(
-											sprintf(
-												// translators: %ds is the number of requests.
-												_n( '%d logged request', '%d logged requests', count( $last_requests ), 'enable-mastodon-apps' ),
-												count( $last_requests )
-											)
-										);
-										?>
-										</summary>
-										<?php
-										foreach ( $last_requests as $request ) {
-											output_request_log( $request, $rest_nonce );
-										}
-										?>
-										</details>
-									</td>
-									<td>
-										<button name="clear-app-logs" value="<?php echo esc_attr( $app->get_client_id() ); ?>" class="button button-link-delete"><?php esc_html_e( 'Clear logs', 'enable-mastodon-apps' ); ?></button>
-									</td>
-								</tr>
-								<?php
-							}
 						}
-						?>
-					</tbody>
-				</table>
-		<h2><?php esc_html_e( 'Authorization Codes', 'enable-mastodon-apps' ); ?></h2>
+					}
+				}
+				?>
+			</tbody>
+		</table>
+
+		<?php if ( $args['enable_debug'] ) : ?>
+			<h2><?php esc_html_e( 'Authorization Codes', 'enable-mastodon-apps' ); ?></h2>
 
 			<span class="count">
-			<?php
+				<?php
 				echo esc_html(
 					sprintf(
 						// translators: %d is the number of authorization codes.
@@ -149,13 +175,16 @@ function post_format_select( $name, $selected = array() ) {
 									echo esc_html( $args['apps'][ $data['client_id'] ]->get_client_name() );
 								} else {
 									echo esc_html( 'Unknown: ' . $data['client_id'] );
+									echo ' <span class="pill pill-unknown" title="' . esc_html__( 'Associated with an app that no longer exists.', 'enable-mastodon-apps' ) . '">' . esc_html__( 'Outdated', 'enable-mastodon-apps' ) . '</span>';
+
 								}
+
 								?>
 							</td>
 							<td><?php echo esc_html( $data['redirect_uri'] ); ?></td>
 							<?php td_timestamp( $data['expires'] ); ?>
 							<td><?php echo esc_html( $data['scope'] ); ?></td>
-							<td><button name="delete-code" value="<?php echo esc_attr( $code ); ?>" class="button"><?php esc_html_e( 'Delete' ); /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ ?></button></td>
+							<td><button name="delete-code" value="<?php echo esc_attr( $code ); ?>" class="button button-destructive"><?php esc_html_e( 'Delete' ); /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ ?></button></td>
 						</tr>
 						<?php
 					}
@@ -163,7 +192,7 @@ function post_format_select( $name, $selected = array() ) {
 				</tbody>
 			</table>
 
-		<h2><?php esc_html_e( 'Access Tokens', 'enable-mastodon-apps' ); ?></h2>
+			<h2><?php esc_html_e( 'Access Tokens', 'enable-mastodon-apps' ); ?></h2>
 			<span class="count">
 				<?php
 				echo esc_html(
@@ -223,7 +252,7 @@ function post_format_select( $name, $selected = array() ) {
 							<?php td_timestamp( $data['last_used'] ); ?>
 							<?php td_timestamp( $data['expires'], true ); ?>
 							<td><?php echo esc_html( $data['scope'] ); ?></td>
-							<td><button name="delete-token" value="<?php echo esc_attr( $token ); ?>" class="button"><?php esc_html_e( 'Delete' ); /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ ?></button></td>
+							<td><button name="delete-token" value="<?php echo esc_attr( $token ); ?>" class="button button-destructive"><?php esc_html_e( 'Delete' ); /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ ?></button></td>
 						</tr>
 						<?php
 					}
@@ -231,13 +260,13 @@ function post_format_select( $name, $selected = array() ) {
 				</tbody>
 			</table>
 
-	<?php if ( ! empty( $args['codes'] ) || ! empty( $args['tokens'] ) || ! empty( $args['apps'] ) ) : ?>
-		<h2><?php esc_html_e( 'Cleanup', 'enable-mastodon-apps' ); ?></h2>
-			<button name="delete-outdated" class="button"><?php esc_html_e( 'Delete outdated apps and tokens', 'enable-mastodon-apps' ); ?></button>
-			<button name="delete-never-used" class="button"><?php esc_html_e( 'Delete never used apps and tokens', 'enable-mastodon-apps' ); ?></button>
-			<button name="delete-apps-without-tokens" class="button"><?php esc_html_e( 'Delete apps without tokens', 'enable-mastodon-apps' ); ?></button>
-			<button name="clear-all-app-logs" class="button button-link-delete"><?php esc_html_e( 'Clear all logs', 'enable-mastodon-apps' ); ?></button>
-
+			<?php if ( ! empty( $args['codes'] ) || ! empty( $args['tokens'] ) || ! empty( $args['apps'] ) ) : ?>
+				<h2><?php esc_html_e( 'Cleanup', 'enable-mastodon-apps' ); ?></h2>
+				<button name="delete-outdated" class="button"><?php esc_html_e( 'Delete outdated apps and tokens', 'enable-mastodon-apps' ); ?></button>
+				<button name="delete-never-used" class="button"><?php esc_html_e( 'Delete never used apps and tokens', 'enable-mastodon-apps' ); ?></button>
+				<button name="delete-apps-without-tokens" class="button"><?php esc_html_e( 'Delete apps without tokens', 'enable-mastodon-apps' ); ?></button>
+				<button name="clear-all-app-logs" class="button button-destructive"><?php esc_html_e( 'Clear all logs', 'enable-mastodon-apps' ); ?></button>
+		<?php endif; ?>
 	<?php endif; ?>
 </form>
 </div>

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -3,7 +3,8 @@
 	__DIR__ . '/admin-header.php',
 	true,
 	array(
-		'active' => 'settings',
+		'active'       => 'settings',
+		'enable_debug' => $args['enable_debug'],
 	)
 );
 ?>
@@ -19,10 +20,22 @@
 						<fieldset>
 							<label for="mastodon_api_enable_logins">
 								<input name="mastodon_api_enable_logins" type="checkbox" id="mastodon_api_enable_logins" value="1" <?php checked( '1', ! get_option( 'mastodon_api_disable_logins' ) ); ?> />
-								<span><?php esc_html_e( 'Allow new and existing apps to sign in.', 'enable-mastodon-apps' ); ?></span>
+								<span><?php esc_html_e( 'Allow new and existing apps to sign in', 'enable-mastodon-apps' ); ?></span>
 							</label>
 						</fieldset>
 						<p class="description"><?php esc_html_e( 'New apps can register on their own, so the list might grow if you keep this enabled.', 'enable-mastodon-apps' ); ?></p>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row"><?php esc_html_e( 'Debugging', 'enable-mastodon-apps' ); ?></th>
+					<td>
+						<fieldset>
+							<label for="mastodon_api_enable_debug">
+								<input name="mastodon_api_enable_debug" type="checkbox" id="mastodon_api_enable_debug" value="1" <?php checked( '1', get_option( 'mastodon_api_enable_debug' ) ); ?> />
+								<span><?php esc_html_e( 'Enable debugging settings', 'enable-mastodon-apps' ); ?></span>
+							</label>
+						</fieldset>
+						<p class="description"><?php esc_html_e( 'This will enable the Tester and Debug tab, and add more information about registered apps.', 'enable-mastodon-apps' ); ?></p>
 					</td>
 				</tr>
 			</tbody>

--- a/templates/tester.php
+++ b/templates/tester.php
@@ -3,7 +3,8 @@
 	__DIR__ . '/admin-header.php',
 	true,
 	array(
-		'active' => 'tester',
+		'active'       => 'tester',
+		'enable_debug' => true,
 	)
 );
 

--- a/templates/welcome.php
+++ b/templates/welcome.php
@@ -3,7 +3,8 @@
 	__DIR__ . '/admin-header.php',
 	true,
 	array(
-		'active' => 'welcome',
+		'active'       => 'welcome',
+		'enable_debug' => $args['enable_debug'],
 	)
 );
 ?>


### PR DESCRIPTION
Now the Settings screen only has 3 tabs:
![Screenshot 2024-06-04 at 17 18 56](https://github.com/akirk/enable-mastodon-apps/assets/203408/8ddee34f-79e9-4555-b642-93010c628a4f)
Unless you turn on the debug setting:
![Screenshot 2024-06-04 at 17 19 00](https://github.com/akirk/enable-mastodon-apps/assets/203408/26ff6692-965e-4e5a-b076-52efa8e3bf3e)

The Registered Apps are also lighter:
![Screenshot 2024-06-04 at 17 19 21](https://github.com/akirk/enable-mastodon-apps/assets/203408/82f50a17-1c5e-41c0-b6c3-7ba7fba62a98)
Unless you activate the debug setting:
![Screenshot 2024-06-04 at 17 19 05](https://github.com/akirk/enable-mastodon-apps/assets/203408/985a7e1f-3d60-4dc6-a23f-9934831f6c9e)

Also shows which entries are considered outdated:
![Screenshot 2024-06-04 at 17 33 32](https://github.com/akirk/enable-mastodon-apps/assets/203408/538f9e36-f677-4897-a832-f9c91e209bf8)
![Screenshot 2024-06-04 at 17 33 26](https://github.com/akirk/enable-mastodon-apps/assets/203408/4dc72aad-bfdb-48bd-8cbd-41f6dc1d26fc)
