### PR TITLE
Ensure FluentCRM Compatibility

### DIFF
--- a/tests/test-accounts-endpoint.php
+++ b/tests/test-accounts-endpoint.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Class Test_Apps_Endpoint
+ * Class AccountsEndpoint_Test
  *
  * @package Enable_Mastodon_Apps
  */
@@ -8,7 +8,7 @@
 namespace Enable_Mastodon_Apps;
 
 /**
- * A testcase for the apps endpoint.
+ * Testcase for the accounts endpoints.
  *
  * @package
  */

--- a/tests/test-apps-endpoint.php
+++ b/tests/test-apps-endpoint.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Class Test_Apps_Endpoint
+ * Class AppsEndpoint_Test
  *
  * @package Enable_Mastodon_Apps
  */
@@ -8,7 +8,7 @@
 namespace Enable_Mastodon_Apps;
 
 /**
- * A testcase for the apps endpoint.
+ * Testcases for the apps endpoint.
  *
  * @package
  */

--- a/tests/test-instance-endpoint.php
+++ b/tests/test-instance-endpoint.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Class Test_Apps_Endpoint
+ * Class InstanceEndpoint_Test
  *
  * @package Enable_Mastodon_Apps
  */
@@ -8,7 +8,7 @@
 namespace Enable_Mastodon_Apps;
 
 /**
- * A testcase for the apps endpoint.
+ * Testcase for the instance endpoint.
  *
  * @package
  */

--- a/tests/test-mastodon-app.php
+++ b/tests/test-mastodon-app.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Class Test_Apps_Endpoint
+ * Class MastodonApp_Test
  *
  * @package Enable_Mastodon_Apps
  */
@@ -8,7 +8,7 @@
 namespace Enable_Mastodon_Apps;
 
 /**
- * A testcase for the apps endpoint.
+ * Testcases for the Mastodon App.
  *
  * @package
  */

--- a/tests/test-notifications-endpoint.php
+++ b/tests/test-notifications-endpoint.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Class Test_Notifications_Endpoint
+ * Class NotificationsEndpoint_Test
  *
  * @package Enable_Mastodon_Apps
  */

--- a/tests/test-statuses-endpoint.php
+++ b/tests/test-statuses-endpoint.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Class Test_Apps_Endpoint
+ * Class StatusesEndpoint_Test
  *
  * @package Enable_Mastodon_Apps
  */
@@ -8,7 +8,7 @@
 namespace Enable_Mastodon_Apps;
 
 /**
- * A testcase for the apps endpoint.
+ * Testcases for the statuses endpoints.
  *
  * @package
  */

--- a/tests/test-third-party-interactions.php
+++ b/tests/test-third-party-interactions.php
@@ -19,13 +19,14 @@ class ThirdPartyInteraction_Test extends Mastodon_API_TestCase {
 			function () {
 				register_rest_route(
 					'fluentcrm/v2',
-					'/tags',
+					'tags',
 					array(
 						'methods'             => 'GET',
 						'callback'            => function () {
+							wp_get_current_user();
 							return 'FluentCRM';
 						},
-						'permission_callback' => '__return_true',
+						'permission_callback' => 'is_user_logged_in',
 					)
 				);
 			}
@@ -38,9 +39,10 @@ class ThirdPartyInteraction_Test extends Mastodon_API_TestCase {
 	 * See https://github.com/akirk/enable-mastodon-apps/issues/145
 	 */
 	public function test_fluentcrm() {
-		$request  = $this->api_request( 'GET', '/fluentcrm/v2/tags' );
-		$response = $this->dispatch( $request );
-		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( 'FluentCRM', $response->get_data() );
+		$request = new \WP_REST_Request( 'GET', '/fluentcrm/v2/tags' );
+		$_SERVER['HTTP_AUTHORIZATION'] = 'Basic ' . base64_encode( 'user:password' );
+		global $wp_rest_server;
+		$response = $wp_rest_server->dispatch( $request );
+		$this->assertEquals( 401, $response->get_status() );
 	}
 }

--- a/tests/test-third-party-interactions.php
+++ b/tests/test-third-party-interactions.php
@@ -39,10 +39,15 @@ class ThirdPartyInteraction_Test extends Mastodon_API_TestCase {
 	 * See https://github.com/akirk/enable-mastodon-apps/issues/145
 	 */
 	public function test_fluentcrm() {
+		global $current_user;
+		$current_user = null;
 		$request = new \WP_REST_Request( 'GET', '/fluentcrm/v2/tags' );
-		$_SERVER['HTTP_AUTHORIZATION'] = 'Basic ' . base64_encode( 'user:password' );
+		$_SERVER['HTTP_AUTHORIZATION'] = 'Basic ' . base64_encode( 'a:b' );
 		global $wp_rest_server;
+		ob_start();
 		$response = $wp_rest_server->dispatch( $request );
+		$out = ob_get_clean();
 		$this->assertEquals( 401, $response->get_status() );
+		$this->assertEmpty( $out );
 	}
 }

--- a/tests/test-timeline-endpoint.php
+++ b/tests/test-timeline-endpoint.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Class Test_Apps_Endpoint
+ * Class TimelineEndpoint_Test
  *
  * @package Enable_Mastodon_Apps
  */
@@ -8,7 +8,7 @@
 namespace Enable_Mastodon_Apps;
 
 /**
- * A testcase for the apps endpoint.
+ * Testcases for the timeline endpoint.
  *
  * @package
  */

--- a/tests/tests-third-party-interactions.php
+++ b/tests/tests-third-party-interactions.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Class ThirdPartyInteraction_Test
+ *
+ * @package Enable_Mastodon_Apps
+ */
+
+namespace Enable_Mastodon_Apps;
+
+/**
+ * Testcase to ensure that we are not negatively interacting with third party plugins.
+ *
+ * @package
+ */
+class ThirdPartyInteraction_Test extends Mastodon_API_TestCase {
+
+	/**
+	 * Test that we are not negatively interacting with FluentCRM.
+	 *
+	 * See https://github.com/akirk/enable-mastodon-apps/issues/145
+	 */
+	public function test_fluentcrm() {
+		register_rest_route(
+			'fluentcrm/v2',
+			'tags',
+			array(
+				'methods'  => 'GET',
+				'callback' => function () {
+					return new \WP_REST_Response( 'FluentCRM', 200 );
+				},
+			)
+		);
+
+		$request  = $this->api_request( 'GET', '/fluentcrm/v2/tags' );
+		$response = $this->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'FluentCRM', $response->get_data() );
+	}
+}

--- a/tests/tests-third-party-interactions.php
+++ b/tests/tests-third-party-interactions.php
@@ -13,24 +13,31 @@ namespace Enable_Mastodon_Apps;
  * @package
  */
 class ThirdPartyInteraction_Test extends Mastodon_API_TestCase {
-
+	public function set_up() {
+		add_action(
+			'rest_api_init',
+			function () {
+				register_rest_route(
+					'fluentcrm/v2',
+					'/tags',
+					array(
+						'methods'             => 'GET',
+						'callback'            => function () {
+							return 'FluentCRM';
+						},
+						'permission_callback' => '__return_true',
+					)
+				);
+			}
+		);
+		parent::set_up();
+	}
 	/**
 	 * Test that we are not negatively interacting with FluentCRM.
 	 *
 	 * See https://github.com/akirk/enable-mastodon-apps/issues/145
 	 */
 	public function test_fluentcrm() {
-		register_rest_route(
-			'fluentcrm/v2',
-			'tags',
-			array(
-				'methods'  => 'GET',
-				'callback' => function () {
-					return new \WP_REST_Response( 'FluentCRM', 200 );
-				},
-			)
-		);
-
 		$request  = $this->api_request( 'GET', '/fluentcrm/v2/tags' );
 		$response = $this->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );


### PR DESCRIPTION
This adds a test to ensure no interaction with FluentCRM, see #145.
