### PR TITLE
Avoid errors when dividing strings

### DIFF
--- a/includes/handler/class-media-attachment.php
+++ b/includes/handler/class-media-attachment.php
@@ -180,7 +180,7 @@ class Media_Attachment extends Handler {
 					'width'  => intval( $block['width'] ),
 					'height' => intval( $block['height'] ),
 					'size'   => $block['width'] . 'x' . $block['height'],
-					'aspect' => $block['width'] / $block['height'],
+					'aspect' => (int) $block['width'] / (int) $block['height'],
 				);
 			} else {
 				$attachment->meta = array(
@@ -245,7 +245,7 @@ class Media_Attachment extends Handler {
 					'width'  => intval( $block['width'] ),
 					'height' => intval( $block['height'] ),
 					'size'   => $block['width'] . 'x' . $block['height'],
-					'aspect' => $block['width'] / $block['height'],
+					'aspect' => (int) $block['width'] / (int) $block['height'],
 				);
 			} else {
 				$attachment->meta = array(


### PR DESCRIPTION
I was getting this error

```
Fatal error: Uncaught TypeError: Unsupported operand types: string / string in wp-content/plugins/enable-mastodon-apps/includes/handler/class-media-attachment.php:183
```

on my home stream. Looks like we're running PHP 8.1.29, maybe it's something to do with that.