### PR TITLE
Don't convert spam comments to posts

### DIFF
--- a/enable-mastodon-apps.php
+++ b/enable-mastodon-apps.php
@@ -64,3 +64,7 @@ add_action(
 		new Enable_Mastodon_Apps\Comment_CPT();
 	}
 );
+
+if ( is_admin() && version_compare( ENABLE_MASTODON_APPS_VERSION, get_option( 'ema_plugin_version', '>' ) ) {
+	add_action( 'admin_init', array( __NAMESPACE__ . '\Mastodon_Admin', 'upgrade_plugin' ) );
+}

--- a/enable-mastodon-apps.php
+++ b/enable-mastodon-apps.php
@@ -65,6 +65,6 @@ add_action(
 	}
 );
 
-if ( is_admin() && version_compare( get_option( 'ema_plugin_version', ENABLE_MASTODON_APPS_VERSION, '<' ) ) ) {
+if ( is_admin() && version_compare( get_option( 'ema_plugin_version', ENABLE_MASTODON_APPS_VERSION ), '<' ) ) {
 	add_action( 'admin_init', array( __NAMESPACE__ . '\Mastodon_Admin', 'upgrade_plugin' ) );
 }

--- a/enable-mastodon-apps.php
+++ b/enable-mastodon-apps.php
@@ -65,6 +65,6 @@ add_action(
 	}
 );
 
-if ( is_admin() && version_compare( ENABLE_MASTODON_APPS_VERSION, get_option( 'ema_plugin_version', '>' ) ) {
+if ( is_admin() && version_compare( get_option( 'ema_plugin_version', ENABLE_MASTODON_APPS_VERSION, '<' ) ) ) {
 	add_action( 'admin_init', array( __NAMESPACE__ . '\Mastodon_Admin', 'upgrade_plugin' ) );
 }

--- a/includes/class-comment-cpt.php
+++ b/includes/class-comment-cpt.php
@@ -172,7 +172,7 @@ class Comment_CPT {
 			'trash' === $new_status ||
 			'spam' === $new_status
 		) {
-			delete_comment_post( $comment->comment_ID );
+			$this->delete_comment_post( $comment->comment_ID );
 			return;
 		}
 	}

--- a/includes/class-comment-cpt.php
+++ b/includes/class-comment-cpt.php
@@ -78,7 +78,7 @@ class Comment_CPT {
 		if ( ! $comment && $comment_id ) {
 			$comment = get_comment( $comment_id );
 		}
-		if ( ! $comment || ! isset( $comment->comment_approved ) || '0' === strval( $comment->comment_approved ) ) {
+		if ( ! $comment || ! isset( $comment->comment_approved ) || '1' !== strval( $comment->comment_approved ) ) {
 			return;
 		}
 		$parent_post_id = $comment->comment_post_ID;
@@ -177,17 +177,17 @@ class Comment_CPT {
 		}
 	}
 
-	public function update_comment_post( $comment_id, $comment ) {
+	public function update_comment_post( $comment_id, $data ) {
 		$post_id = self::comment_id_to_post_id( $comment_id );
 		if ( ! $post_id ) {
 			return;
 		}
-
 		$post_data = array(
 			'ID'            => $post_id,
-			'post_content'  => $comment->comment_content,
-			'post_date'     => $comment->comment_date,
-			'post_date_gmt' => $comment->comment_date_gmt,
+			'post_content'  => $data['comment_content'],
+			'post_date'     => $data['comment_date'],
+			'post_date_gmt' => $data['comment_date_gmt'],
+			'post_status'   => $data['comment_approved'] ? 'publish' : 'trash',
 		);
 
 		wp_update_post( $post_data );

--- a/includes/class-comment-cpt.php
+++ b/includes/class-comment-cpt.php
@@ -4,6 +4,14 @@
  *
  * This contains the automatic mapping of comments to a custom post type.
  *
+ * The reason this exists in this plugin is that the ActivityPub plugin (rightfully) stores
+ * incoming replies to posts as WordPress comments. Also the Friends plugin follows suite, so
+ * a reply to a post is stored as a comment on the post, and then the ActivityPub plugin will
+ * send it out via ActivityPub. In Mastodon, there is no distinction between a post and a
+ * comment, so they all live in the same "id pool". Thus, clients expect them to appear in the
+ * same stream and interspersed with each other. This plugin syncs comments to a custom post
+ * type so that they can be queried and displayed in the same way as posts.
+ *
  * @package Enable_Mastodon_Apps
  */
 

--- a/includes/class-mastodon-admin.php
+++ b/includes/class-mastodon-admin.php
@@ -447,9 +447,14 @@ class Mastodon_Admin {
 		);
 	}
 
-	public function upgrade_plugin() {
+	public static function upgrade_plugin( $override_old_version = false ) {
 		$old_version = get_option( 'ema_plugin_version' );
-		update_option( 'ema_plugin_version', ENABLE_MASTODON_APPS_VERSION );
+		if ( preg_match( '/^(\d+\.\d+\.\d+)$/', $override_old_version ) ) {
+			// Used in tests.
+			$old_version = $override_old_version;
+		} else {
+			update_option( 'ema_plugin_version', ENABLE_MASTODON_APPS_VERSION );
+		}
 
 		if ( version_compare( $old_version, '0.9.1', '<' ) ) {
 			$comment_posts = get_posts(

--- a/includes/class-mastodon-admin.php
+++ b/includes/class-mastodon-admin.php
@@ -465,7 +465,7 @@ class Mastodon_Admin {
 					continue;
 				}
 				$comment = get_comment( $comment_id );
-				if ( ! $comment || 'approved' !== $comment->comment_approved ) {
+				if ( ! $comment || 1 !== intval( $comment->comment_approved ) ) {
 					wp_delete_post( $comment_post->ID, true );
 				}
 			}

--- a/includes/class-mastodon-admin.php
+++ b/includes/class-mastodon-admin.php
@@ -446,4 +446,29 @@ class Mastodon_Admin {
 			)
 		);
 	}
+
+	public function upgrade_plugin() {
+		$old_version = get_option( 'ema_plugin_version' );
+		update_option( 'ema_plugin_version', ENABLE_MASTODON_APPS_VERSION );
+
+		if ( version_compare( $old_version, '0.9.1', '<' ) ) {
+			$comment_posts = get_posts(
+				array(
+					'post_type'      => Comment_CPT::CPT,
+					'posts_per_page' => -1,
+					'post_status'    => 'any',
+				)
+			);
+			foreach ( $comment_posts as $comment_post ) {
+				$comment_id = get_post_meta( $comment_post->ID, Comment_CPT::META_KEY, true );
+				if ( ! $comment_id ) {
+					continue;
+				}
+				$comment = get_comment( $comment_id );
+				if ( ! $comment || 'approved' !== $comment->comment_approved ) {
+					wp_delete_post( $comment_post->ID, true );
+				}
+			}
+		}
+	}
 }

--- a/tests/test-comments-cpt.php
+++ b/tests/test-comments-cpt.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Class Test_Apps_Endpoint
+ *
+ * @package Enable_Mastodon_Apps
+ */
+
+namespace Enable_Mastodon_Apps;
+
+/**
+ * A testcase for the comments CPT.
+ *
+ * @package
+ */
+class CommentsCPT_Tests extends \WP_UnitTestCase {
+	public function test_new_comment() {
+		$posts_count = wp_count_posts( Comment_CPT::CPT );
+		$post = $this->factory->post->create_and_get();
+		$comment = $this->factory->comment->create_and_get(
+			array(
+				'comment_post_ID' => $post->ID,
+			)
+		);
+		$this->assertNotNull( $comment );
+
+		$new_count = wp_count_posts( Comment_CPT::CPT );
+		$this->assertEquals( 1 + $posts_count->publish, $new_count->publish );
+
+		$comment = $this->factory->comment->create_and_get(
+			array(
+				'comment_post_ID'  => $post->ID,
+				'comment_approved' => '0',
+			)
+		);
+		$this->assertNotNull( $comment );
+
+		$third_count = wp_count_posts( Comment_CPT::CPT );
+		$this->assertEquals( 1 + $posts_count->publish, $third_count->publish );
+	}
+
+	public function test_approving_comment() {
+		$posts_count = wp_count_posts( Comment_CPT::CPT );
+		$post = $this->factory->post->create_and_get();
+		$comment = $this->factory->comment->create_and_get(
+			array(
+				'comment_post_ID'  => $post->ID,
+				'comment_approved' => '0',
+			)
+		);
+		$this->assertNotNull( $comment );
+
+		$new_count = wp_count_posts( Comment_CPT::CPT );
+		$this->assertEquals( $posts_count->publish, $new_count->publish );
+
+		wp_update_comment(
+			array(
+				'comment_ID'       => $comment->comment_ID,
+				'comment_approved' => '1',
+			)
+		);
+
+		$new_count = wp_count_posts( Comment_CPT::CPT );
+		$this->assertEquals( 1 + $posts_count->publish, $new_count->publish );
+
+		wp_update_comment(
+			array(
+				'comment_ID'       => $comment->comment_ID,
+				'comment_approved' => '0',
+			)
+		);
+
+		$new_count = wp_count_posts( Comment_CPT::CPT );
+		$this->assertEquals( $posts_count->publish, $new_count->publish );
+
+		wp_update_comment(
+			array(
+				'comment_ID'       => $comment->comment_ID,
+				'comment_approved' => '1',
+			)
+		);
+
+		$new_count = wp_count_posts( Comment_CPT::CPT );
+		$this->assertEquals( 1 + $posts_count->publish, $new_count->publish );
+
+		wp_trash_comment( $comment->comment_ID );
+
+		wp_cache_delete( _count_posts_cache_key( Comment_CPT::CPT ), 'counts' );
+		$new_count = wp_count_posts( Comment_CPT::CPT );
+		$this->assertEquals( $posts_count->publish, $new_count->publish );
+	}
+
+	public function test_deleting() {
+		$posts_count = wp_count_posts( Comment_CPT::CPT );
+		$post = $this->factory->post->create_and_get();
+		$comment = $this->factory->comment->create_and_get(
+			array(
+				'comment_post_ID'  => $post->ID,
+				'comment_approved' => '1',
+			)
+		);
+		$this->assertNotNull( $comment );
+
+		$new_count = wp_count_posts( Comment_CPT::CPT );
+		$this->assertEquals( 1 + $posts_count->publish, $new_count->publish );
+
+		wp_delete_post( $post->ID, true );
+
+		wp_cache_delete( _count_posts_cache_key( Comment_CPT::CPT ), 'counts' );
+		$new_count = wp_count_posts( Comment_CPT::CPT );
+		$this->assertEquals( $posts_count->publish, $new_count->publish );
+	}
+}

--- a/tests/test-comments-cpt.php
+++ b/tests/test-comments-cpt.php
@@ -109,4 +109,50 @@ class CommentsCPT_Tests extends \WP_UnitTestCase {
 		$new_count = wp_count_posts( Comment_CPT::CPT );
 		$this->assertEquals( $posts_count->publish, $new_count->publish );
 	}
+
+	public function test_upgrade() {
+		remove_all_actions( 'wp_insert_comment' );
+		$original_post = $this->factory->post->create_and_get();
+		$approved_comment = $this->factory->comment->create_and_get(
+			array(
+				'comment_post_ID'  => $original_post->ID,
+				'comment_approved' => '1',
+			)
+		);
+		$synced_approved_post = $this->factory->post->create_and_get(
+			array(
+				'post_type'  => Comment_CPT::CPT,
+				'meta_input' => array(
+					Comment_CPT::META_KEY => $approved_comment->comment_ID,
+				),
+			)
+		);
+
+		$spam_comment = $this->factory->comment->create_and_get(
+			array(
+				'comment_post_ID'  => $original_post->ID,
+				'comment_approved' => '0',
+			)
+		);
+		$synced_spam_post = $this->factory->post->create_and_get(
+			array(
+				'post_type'  => Comment_CPT::CPT,
+				'meta_input' => array(
+					Comment_CPT::META_KEY => $spam_comment->comment_ID,
+				),
+			)
+		);
+
+		$old_count = wp_count_posts( Comment_CPT::CPT );
+		$this->assertEquals( 2, $old_count->publish );
+
+		Mastodon_Admin::upgrade_plugin( '0.9.0' );
+
+		wp_cache_delete( _count_posts_cache_key( Comment_CPT::CPT ), 'counts' );
+		$new_count = wp_count_posts( Comment_CPT::CPT );
+		$this->assertEquals( 1, $new_count->publish );
+
+		$this->assertNotNull( get_post( $synced_approved_post->ID ) );
+		$this->assertNull( get_post( $synced_spam_post->ID ) );
+	}
 }


### PR DESCRIPTION
The Comments Custom Post Type syncs comments to posts but didn't take enough care about approved comments. This could cause slowdowns. 

In this PR we take more care to only sync approved comments.