### PR TITLE
Fix the missing namespace in the main plugin file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 0.9.3
+- Bring back the upgrade code.
+
 ### 0.9.2
 - Quick fix to disable the upgrade script to avoid errors.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 - Tested up to: 6.5
 - Requires PHP: 7.4
 - License: [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
-- Stable tag: 0.9.2
+- Stable tag: 0.9.3
 
 Allow accessing your WordPress with Mastodon clients. Just enter your own blog URL as your instance.
 
@@ -96,6 +96,9 @@ Endpoints around interacting with non-local users require the [ActivityPub plugi
 2. The Mastodon Apps settings page.
 
 ## Changelog
+
+### 0.9.3
+- Bring back the upgrade code.
 
 ### 0.9.2
 - Quick fix to disable the upgrade script to avoid errors.

--- a/enable-mastodon-apps.php
+++ b/enable-mastodon-apps.php
@@ -13,6 +13,9 @@
  * @package Enable_Mastodon_Apps
  */
 
+namespace Enable_Mastodon_Apps;
+use OAuth2;
+
 defined( 'ABSPATH' ) || exit;
 define( 'ENABLE_MASTODON_APPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'ENABLE_MASTODON_APPS_VERSION', '0.9.2' );
@@ -59,8 +62,11 @@ OAuth2\Autoloader::register();
 add_action(
 	'init',
 	function () {
-		new Enable_Mastodon_Apps\Mastodon_API();
-		new Enable_Mastodon_Apps\Integration\Pixelfed();
-		new Enable_Mastodon_Apps\Comment_CPT();
+		new Mastodon_API();
+		new Integration\Pixelfed();
+		new Comment_CPT();
 	}
 );
+if ( is_admin() && version_compare( get_option( 'ema_plugin_version', ENABLE_MASTODON_APPS_VERSION ), '<' ) ) {
+	add_action( 'admin_init', array( __NAMESPACE__ . '\Mastodon_Admin', 'upgrade_plugin' ) );
+}

--- a/enable-mastodon-apps.php
+++ b/enable-mastodon-apps.php
@@ -3,7 +3,7 @@
  * Plugin name: Enable Mastodon Apps
  * Plugin author: Alex Kirk
  * Plugin URI: https://github.com/akirk/enable-mastodon-apps
- * Version: 0.9.2
+ * Version: 0.9.3
  *
  * Description: Allow accessing your WordPress with Mastodon clients. Just enter your own blog URL as your instance.
  *
@@ -18,7 +18,7 @@ use OAuth2;
 
 defined( 'ABSPATH' ) || exit;
 define( 'ENABLE_MASTODON_APPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
-define( 'ENABLE_MASTODON_APPS_VERSION', '0.9.2' );
+define( 'ENABLE_MASTODON_APPS_VERSION', '0.9.3' );
 
 require __DIR__ . '/vendor/bshaffer/oauth2-server-php/src/OAuth2/Autoloader.php';
 OAuth2\Autoloader::register();
@@ -67,6 +67,7 @@ add_action(
 		new Comment_CPT();
 	}
 );
+
 if ( is_admin() && version_compare( get_option( 'ema_plugin_version', ENABLE_MASTODON_APPS_VERSION ), '<' ) ) {
 	add_action( 'admin_init', array( __NAMESPACE__ . '\Mastodon_Admin', 'upgrade_plugin' ) );
 }

--- a/includes/class-mastodon-admin.php
+++ b/includes/class-mastodon-admin.php
@@ -471,7 +471,9 @@ class Mastodon_Admin {
 				}
 				$comment = get_comment( $comment_id );
 				if ( ! $comment || 1 !== intval( $comment->comment_approved ) ) {
-					wp_delete_post( $comment_post->ID, true );
+					if ( Comment_CPT::CPT === get_post_type( $comment_post->ID ) ) {
+						wp_delete_post( $comment_post->ID, true );
+					}
 				}
 			}
 		}

--- a/tests/test-comments-cpt.php
+++ b/tests/test-comments-cpt.php
@@ -143,10 +143,16 @@ class CommentsCPT_Tests extends \WP_UnitTestCase {
 			)
 		);
 
+		$post_count = wp_count_posts();
+		$this->assertEquals( 1, $post_count->publish );
 		$old_count = wp_count_posts( Comment_CPT::CPT );
 		$this->assertEquals( 2, $old_count->publish );
 
 		Mastodon_Admin::upgrade_plugin( '0.9.0' );
+
+		wp_cache_delete( _count_posts_cache_key(), 'counts' );
+		$post_count = wp_count_posts();
+		$this->assertEquals( 1, $post_count->publish );
 
 		wp_cache_delete( _count_posts_cache_key( Comment_CPT::CPT ), 'counts' );
 		$new_count = wp_count_posts( Comment_CPT::CPT );


### PR DESCRIPTION
This caused a fatal (only for an admin) because `__NAMESPACE__` was not defined.