### PR TITLE
Multisite: ensure that user_ids only work for users of this site

### DIFF
--- a/includes/class-mastodon-api.php
+++ b/includes/class-mastodon-api.php
@@ -2415,6 +2415,10 @@ class Mastodon_API {
 	public function api_account( $request ) {
 		$user_id = $this->get_user_id_from_request( $request );
 
+		if ( is_multisite() && ! is_user_member_of_blog( $user_id ) ) {
+			return new \WP_Error( 'mastodon_api_account', 'Record not found', array( 'status' => 404 ) );
+		}
+
 		/**
 		 * Modify the account data returned for `/api/account/{user_id}` requests.
 		 *


### PR DESCRIPTION
When browsing Followers, they can have a `user_id` on their own instance that Mastodon clients then try to retrieve from their own instance. Eg say that a user is followed by my `mattwiebe@mastodon.onlinne` account. When the client queries the `mastodon.online` instance, it gets this: 

```
{
  "id": "110770996307846062",
  "username": "mattwiebe",
  "acct": "mattwiebe",
  "display_name": "mw.social"
  // snip
}
```

But when browsing profiles, some clients (Ivory in my case) tries to query that ID against the current instance, doing `api/v1/accounts/110770996307846062` against EMA. For wpcom, that particular ID is above our highest user_id, but many will produce a false positive for a user in the network who isn't even a member of the blog.

This doesn't fix for user ID collisions where the user ID from a remote user is the same as one that is also a member of the blog, but it's a good start. 