### PR TITLE
Linted for wpcom

### DIFF
--- a/bin/extract-hooks.php
+++ b/bin/extract-hooks.php
@@ -421,7 +421,7 @@ foreach ( $filters as $hook => $data ) {
 			}
 
 
-			$count += 1;
+			++$count;
 			$p = preg_split( '/ +/', $param, 3 );
 			if ( '\\' === substr( $p[0], 0, 1 ) ) {
 				$p[0] = substr( $p[0], 1 );

--- a/bin/extract-hooks.php
+++ b/bin/extract-hooks.php
@@ -102,7 +102,7 @@ foreach ( $files as $file ) {
 		$comment = '';
 		$hook = false;
 
-		for ( $j = $i; $j > max( 0, $i - 10 ); $j-- ) {
+		for ( $j = $i, $l = max( 0, $i - 10 ); $j > $l; $j-- ) {
 			if ( ! is_array( $tokens[ $j ] ) ) {
 				continue;
 			}

--- a/enable-mastodon-apps.php
+++ b/enable-mastodon-apps.php
@@ -34,7 +34,7 @@ OAuth2\Autoloader::register();
 
 		if ( strncmp( $full_class, $base, strlen( $base ) ) === 0 ) {
 			$maybe_uppercase = str_replace( $base, '', $full_class );
-			$class = strtolower( $maybe_uppercase );
+			$class           = strtolower( $maybe_uppercase );
 			// All classes should be capitalized. If this is instead looking for a lowercase method, we ignore that.
 			if ( $maybe_uppercase === $class ) {
 				return;

--- a/includes/class-comment-cpt.php
+++ b/includes/class-comment-cpt.php
@@ -23,7 +23,7 @@ namespace Enable_Mastodon_Apps;
  * This class maps comments to a custom post type.
  */
 class Comment_CPT {
-	const CPT = 'comment';
+	const CPT      = 'comment';
 	const META_KEY = 'comment_id';
 
 	/**
@@ -90,7 +90,7 @@ class Comment_CPT {
 			return;
 		}
 		$parent_post_id = $comment->comment_post_ID;
-		$post    = get_post( $parent_post_id );
+		$post           = get_post( $parent_post_id );
 		if ( ! $post ) {
 			return;
 		}

--- a/includes/class-mastodon-admin.php
+++ b/includes/class-mastodon-admin.php
@@ -78,7 +78,8 @@ class Mastodon_Admin {
 
 	public function admin_page() {
 		$this->enable_debug = get_option( 'mastodon_api_enable_debug' );
-		$tab                = isset( $_GET['tab'] ) ? sanitize_text_field( wp_unslash( $_GET['tab'] ) ) : 'welcome';
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		$tab = isset( $_GET['tab'] ) ? sanitize_text_field( wp_unslash( $_GET['tab'] ) ) : 'welcome';
 		if ( isset( $_GET['app'] ) ) {
 			$app = Mastodon_App::get_by_client_id( sanitize_text_field( wp_unslash( $_GET['app'] ) ) );
 			if ( $app ) {
@@ -86,6 +87,7 @@ class Mastodon_Admin {
 			}
 			$tab = 'registered-apps';
 		}
+		// phpcs:enable
 		switch ( $tab ) {
 			case 'welcome':
 				$this->admin_welcome_page();

--- a/includes/class-mastodon-admin.php
+++ b/includes/class-mastodon-admin.php
@@ -51,13 +51,13 @@ class Mastodon_Admin {
 			return;
 		}
 
-		if ( ! wp_verify_nonce( $_POST['_wpnonce'], 'enable-mastodon-apps' ) ) {
+		if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_key( $_POST['_wpnonce'] ), 'enable-mastodon-apps' ) ) {
 			return;
 		}
 
-		$tab = $_GET['tab'] ?? 'welcome';
+		$tab = isset( $_GET['tab'] ) ? sanitize_key( $_GET['tab'] ) : 'welcome';
 		if ( isset( $_POST['app'] ) ) {
-			$app = Mastodon_App::get_by_client_id( $_POST['app'] );
+			$app = Mastodon_App::get_by_client_id( sanitize_text_field( wp_unslash( $_POST['app'] ) ) );
 			if ( $app ) {
 				return $this->process_admin_app_page( $app );
 			}
@@ -78,9 +78,9 @@ class Mastodon_Admin {
 
 	public function admin_page() {
 		$this->enable_debug = get_option( 'mastodon_api_enable_debug' );
-		$tab                = $_GET['tab'] ?? 'welcome';
+		$tab                = isset( $_GET['tab'] ) ? sanitize_text_field( wp_unslash( $_GET['tab'] ) ) : 'welcome';
 		if ( isset( $_GET['app'] ) ) {
-			$app = Mastodon_App::get_by_client_id( $_GET['app'] );
+			$app = Mastodon_App::get_by_client_id( sanitize_text_field( wp_unslash( $_GET['app'] ) ) );
 			if ( $app ) {
 				return $this->admin_app_page( $app );
 			}
@@ -117,13 +117,13 @@ class Mastodon_Admin {
 	}
 
 	public function process_admin_settings_page() {
-		if ( isset( $_POST['mastodon_api_enable_logins'] ) ) {
+		if ( isset( $_POST['mastodon_api_enable_logins'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
 			delete_option( 'mastodon_api_disable_logins' );
 		} else {
 			update_option( 'mastodon_api_disable_logins', true );
 		}
 
-		if ( isset( $_POST['mastodon_api_enable_debug'] ) ) {
+		if ( isset( $_POST['mastodon_api_enable_debug'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
 			update_option( 'mastodon_api_enable_debug', true );
 		} else {
 			delete_option( 'mastodon_api_enable_debug' );
@@ -141,12 +141,12 @@ class Mastodon_Admin {
 	}
 
 	public function process_admin_debug_page() {
-		if ( isset( $_POST['mastodon_api_debug_mode'] ) ) {
+		if ( isset( $_POST['mastodon_api_debug_mode'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
 			update_option( 'mastodon_api_debug_mode', time() + 5 * MINUTE_IN_SECONDS );
 		} else {
 			delete_option( 'mastodon_api_debug_mode' );
 		}
-		if ( isset( $_POST['mastodon_api_auto_app_reregister'] ) ) {
+		if ( isset( $_POST['mastodon_api_auto_app_reregister'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
 			update_option( 'mastodon_api_auto_app_reregister', true );
 		} else {
 			delete_option( 'mastodon_api_auto_app_reregister' );
@@ -162,8 +162,10 @@ class Mastodon_Admin {
 	}
 
 	public function process_admin_registered_apps_page() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing
 		if ( isset( $_POST['delete-code'] ) ) {
-			$deleted = $this->oauth->get_code_storage()->expireAuthorizationCode( $_POST['delete-code'] );
+			 // phpcs:ignore WordPress.Security.NonceVerification.Missing
+			$deleted = $this->oauth->get_code_storage()->expireAuthorizationCode( sanitize_text_field( wp_unslash( $_POST['delete-code'] ) ) );
 			add_settings_error(
 				'enable-mastodon-apps',
 				'deleted-codes',
@@ -177,8 +179,10 @@ class Mastodon_Admin {
 			return;
 		}
 
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing
 		if ( isset( $_POST['delete-token'] ) ) {
-			$deleted = $this->oauth->get_token_storage()->unsetAccessToken( $_POST['delete-token'] );
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing
+			$deleted = $this->oauth->get_token_storage()->unsetAccessToken( sanitize_text_field( wp_unslash( $_POST['delete-token'] ) ) );
 			add_settings_error(
 				'enable-mastodon-apps',
 				'deleted-tokens',
@@ -192,8 +196,10 @@ class Mastodon_Admin {
 			return;
 		}
 
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing
 		if ( isset( $_POST['delete-app'] ) ) {
-			$deleted = Mastodon_App::get_by_client_id( $_POST['delete-app'] )->delete();
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing
+			$deleted = Mastodon_App::get_by_client_id( sanitize_text_field( wp_unslash( $_POST['delete-app'] ) ) )->delete();
 			add_settings_error(
 				'enable-mastodon-apps',
 				'deleted-apps',
@@ -207,8 +213,10 @@ class Mastodon_Admin {
 			return;
 		}
 
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing
 		if ( isset( $_POST['clear-app-logs'] ) ) {
-			$deleted = Mastodon_App::get_by_client_id( $_POST['clear-app-logs'] )->delete_last_requests();
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing
+			$deleted = Mastodon_App::get_by_client_id( sanitize_text_field( wp_unslash( $_POST['clear-app-logs'] ) ) )->delete_last_requests();
 			if ( $deleted ) {
 				add_settings_error(
 					'enable-mastodon-apps',
@@ -226,12 +234,13 @@ class Mastodon_Admin {
 			}
 			return;
 		}
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing
 		if ( isset( $_POST['clear-all-app-logs'] ) ) {
 			$total_deleted = 0;
 			foreach ( Mastodon_App::get_all() as $app ) {
 				$deleted = $app->delete_last_requests();
 				if ( $deleted ) {
-					$total_deleted += 1;
+					++$total_deleted;
 				}
 			}
 			if ( $total_deleted ) {
@@ -256,6 +265,7 @@ class Mastodon_Admin {
 			return;
 		}
 
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing
 		if ( isset( $_POST['delete-outdated'] ) ) {
 			$apps    = Mastodon_App::get_all();
 			$deleted = OAuth2\Access_Token_Storage::cleanupOldTokens();
@@ -264,7 +274,7 @@ class Mastodon_Admin {
 			}
 			foreach ( OAuth2\Access_Token_Storage::getAll() as $token => $data ) {
 				if ( ! isset( $apps[ $data['client_id'] ] ) ) {
-					$deleted += 1;
+					++$deleted;
 					$this->oauth->get_token_storage()->unsetAccessToken( $token );
 				}
 			}
@@ -287,7 +297,7 @@ class Mastodon_Admin {
 			}
 			foreach ( OAuth2\Authorization_Code_Storage::getAll() as $code => $data ) {
 				if ( ! isset( $apps[ $data['client_id'] ] ) ) {
-					$deleted += 1;
+					++$deleted;
 					$this->oauth->get_code_storage()->expireAuthorizationCode( $code );
 				}
 			}
@@ -321,11 +331,12 @@ class Mastodon_Admin {
 			return;
 		}
 
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing
 		if ( isset( $_POST['delete-never-used'] ) ) {
 			$deleted = 0;
 			foreach ( Mastodon_App::get_all() as $app ) {
 				if ( ! $app->get_last_used() ) {
-					$deleted += 1;
+					++$deleted;
 					$app->delete();
 				}
 			}
@@ -345,7 +356,7 @@ class Mastodon_Admin {
 			foreach ( OAuth2\Access_Token_Storage::getAll() as $token => $data ) {
 				if ( empty( $data['last_used'] ) ) {
 					if ( $this->oauth->get_token_storage()->unsetAccessToken( $token ) ) {
-						$deleted += 1;
+						++$deleted;
 					}
 				}
 			}
@@ -363,6 +374,7 @@ class Mastodon_Admin {
 			return;
 		}
 
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing
 		if ( isset( $_POST['delete-apps-without-tokens'] ) ) {
 			$app_tokens = array();
 			foreach ( OAuth2\Access_Token_Storage::getAll() as $token => $data ) {
@@ -374,7 +386,7 @@ class Mastodon_Admin {
 			$deleted = 0;
 			foreach ( Mastodon_App::get_all() as $app ) {
 				if ( empty( $app_tokens[ $app->get_client_id() ] ) ) {
-					$deleted += 1;
+					++$deleted;
 					$app->delete();
 				}
 			}
@@ -391,8 +403,10 @@ class Mastodon_Admin {
 			);
 			return;
 		}
+		// phpcs:disable WordPress.Security.NonceVerification.Missing
 		if ( isset( $_POST['app_post_formats'] ) && is_array( $_POST['app_post_formats'] ) ) {
-			foreach ( $_POST['app_post_formats'] as $client_id => $post_formats ) {
+			// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			foreach ( wp_unslash( $_POST['app_post_formats'] ) as $client_id => $post_formats ) {
 				$post_formats = array_filter(
 					$post_formats,
 					function ( $post_format ) {
@@ -487,7 +501,7 @@ class Mastodon_Admin {
 		}
 
 		if ( isset( $_POST['delete-token'] ) ) {
-			$deleted = $this->oauth->get_token_storage()->unsetAccessToken( $_POST['delete-token'] );
+			$deleted = $this->oauth->get_token_storage()->unsetAccessToken( sanitize_text_field( wp_unslash( $_POST['delete-token'] ) ) );
 			add_settings_error(
 				'enable-mastodon-apps',
 				'deleted-tokens',
@@ -524,7 +538,7 @@ class Mastodon_Admin {
 		$post_formats = array();
 		if ( isset( $_POST['post_formats'] ) && is_array( $_POST['post_formats'] ) ) {
 			$post_formats = array_filter(
-				$_POST['post_formats'],
+				wp_unslash( $_POST['post_formats'] ),
 				function ( $post_format ) {
 					if ( ! in_array( $post_format, get_post_format_slugs(), true ) ) {
 						return false;
@@ -545,15 +559,16 @@ class Mastodon_Admin {
 			)
 		);
 
-		if ( isset( $_POST['create_post_type'] ) && $_POST['create_post_type'] ) {
-			if ( isset( $post_types[ $_POST['create_post_type'] ] ) ) {
-				$app->set_create_post_type( $_POST['create_post_type'] );
+		if ( isset( $_POST['create_post_type'] ) ) {
+			$create_post_type = sanitize_text_field( wp_unslash( $_POST['create_post_type'] ) );
+			if ( isset( $post_types[ $create_post_type ] ) ) {
+				$app->set_create_post_type( $create_post_type );
 			}
 		}
 
 		if ( isset( $_POST['view_post_types'] ) && is_array( $_POST['view_post_types'] ) ) {
 			$view_post_types = array();
-			foreach ( $_POST['view_post_types'] as $post_type ) {
+			foreach ( wp_unslash( $_POST['view_post_types'] ) as $post_type ) {
 				if ( isset( $post_types[ $post_type ] ) ) {
 					$view_post_types[ $post_type ] = true;
 				}

--- a/includes/class-mastodon-admin.php
+++ b/includes/class-mastodon-admin.php
@@ -78,7 +78,7 @@ class Mastodon_Admin {
 
 	public function admin_page() {
 		$this->enable_debug = get_option( 'mastodon_api_enable_debug' );
-		$tab = $_GET['tab'] ?? 'welcome';
+		$tab                = $_GET['tab'] ?? 'welcome';
 		if ( isset( $_GET['app'] ) ) {
 			$app = Mastodon_App::get_by_client_id( $_GET['app'] );
 			if ( $app ) {
@@ -257,7 +257,7 @@ class Mastodon_Admin {
 		}
 
 		if ( isset( $_POST['delete-outdated'] ) ) {
-			$apps = Mastodon_App::get_all();
+			$apps    = Mastodon_App::get_all();
 			$deleted = OAuth2\Access_Token_Storage::cleanupOldTokens();
 			if ( ! $deleted ) {
 				$deleted = 0;
@@ -464,7 +464,7 @@ class Mastodon_Admin {
 	public function process_admin_app_page( Mastodon_App $app ) {
 
 		if ( isset( $_POST['delete-app'] ) && $_POST['delete-app'] === $app->get_client_id() ) {
-			$name = $app->get_client_name();
+			$name    = $app->get_client_name();
 			$deleted = $app->delete();
 			if ( $deleted ) {
 				$message = sprintf(

--- a/includes/class-mastodon-api.php
+++ b/includes/class-mastodon-api.php
@@ -24,7 +24,7 @@ use function PHPUnit\Framework\returnCallback;
  */
 class Mastodon_API {
 	const ACTIVITYPUB_USERNAME_REGEXP = '(?:([A-Za-z0-9_-]+)@((?:[A-Za-z0-9_-]+\.)+[A-Za-z]+))';
-	const VERSION = ENABLE_MASTODON_APPS_VERSION;
+	const VERSION                     = ENABLE_MASTODON_APPS_VERSION;
 	/**
 	 * The OAuth handler.
 	 *
@@ -41,10 +41,10 @@ class Mastodon_API {
 
 	private static $last_error = false;
 
-	const PREFIX = 'enable-mastodon-apps';
-	const APP_TAXONOMY = 'mastodon-app';
+	const PREFIX         = 'enable-mastodon-apps';
+	const APP_TAXONOMY   = 'mastodon-app';
 	const REMAP_TAXONOMY = 'mastodon-api-remap';
-	const CPT = 'enable-mastodon-apps';
+	const CPT            = 'enable-mastodon-apps';
 
 	/**
 	 * Constructor
@@ -132,7 +132,7 @@ class Mastodon_API {
 		}
 
 		if ( ! isset( $result['code'] ) && isset( $result['error'] ) && is_string( $result['error'] ) ) {
-			$result['code'] = sanitize_title_with_dashes( $result['error'] );
+			$result['code']    = sanitize_title_with_dashes( $result['error'] );
 			$result['message'] = $result['error'];
 		}
 
@@ -189,9 +189,9 @@ class Mastodon_API {
 
 	public function rewrite_rules() {
 		$existing_rules = get_option( 'rewrite_rules' );
-		$needs_flush = false;
+		$needs_flush    = false;
 
-		$generic = apply_filters(
+		$generic      = apply_filters(
 			'mastodon_api_generic_routes',
 			array(
 				'api/v1/accounts/relationships',
@@ -1391,7 +1391,7 @@ class Mastodon_API {
 		}
 
 		$has_scope = false;
-		$token = $this->oauth->get_token();
+		$token     = $this->oauth->get_token();
 		if ( $token && isset( $token['scope'] ) ) {
 			foreach ( explode( ',', $scopes ) as $scope ) {
 				if ( OAuth2\Scope_Util::checkSingleScope( $scope, $token['scope'] ) ) {
@@ -1487,7 +1487,7 @@ class Mastodon_API {
 			);
 		} catch ( \Exception $e ) {
 			list( $code, $message ) = explode( ',', $e->getMessage(), 2 );
-			$app = new \WP_Error( $code, $message, array( 'status' => 422 ) );
+			$app                    = new \WP_Error( $code, $message, array( 'status' => 422 ) );
 		}
 
 		if ( is_wp_error( $app ) ) {
@@ -1631,7 +1631,7 @@ class Mastodon_API {
 		$wp_rest_response = false;
 		if ( $entities instanceof \WP_REST_Response ) {
 			$wp_rest_response = $entities;
-			$entities = $entities->data;
+			$entities         = $entities->data;
 		}
 		if ( ! is_array( $entities ) ) {
 			return array();
@@ -1693,10 +1693,10 @@ class Mastodon_API {
 		 */
 		$in_reply_to_id = apply_filters( 'mastodon_api_in_reply_to_id', $request->get_param( 'in_reply_to_id' ), $request );
 
-		$media_ids = $request->get_param( 'media_ids' );
+		$media_ids    = $request->get_param( 'media_ids' );
 		$scheduled_at = $request->get_param( 'scheduled_at' );
 
-		$app = Mastodon_App::get_current_app();
+		$app              = Mastodon_App::get_current_app();
 		$app_post_formats = array();
 		if ( $app ) {
 			$app_post_formats = $app->get_post_formats();
@@ -1919,7 +1919,7 @@ class Mastodon_API {
 		}
 
 		$context_post_id = self::maybe_get_remapped_reblog_id( $context_post_id );
-		$url = get_permalink( $context_post_id );
+		$url             = get_permalink( $context_post_id );
 
 		$context = array(
 			'ancestors'   => array(),
@@ -2068,10 +2068,10 @@ class Mastodon_API {
 		 */
 		$in_reply_to_id = apply_filters( 'mastodon_api_in_reply_to_id', $request->get_param( 'in_reply_to_id' ), $request );
 
-		$media_ids = $request->get_param( 'media_ids' );
+		$media_ids    = $request->get_param( 'media_ids' );
 		$scheduled_at = $request->get_param( 'scheduled_at' );
 
-		$app = Mastodon_App::get_current_app();
+		$app              = Mastodon_App::get_current_app();
 		$app_post_formats = array();
 		if ( $app ) {
 			$app_post_formats = $app->get_post_formats();
@@ -2523,8 +2523,8 @@ class Mastodon_API {
 
 
 	public static function remap_user_id( $user_id ) {
-		$user_id = apply_filters( 'mastodon_api_canonical_user_id', $user_id );
-		$term = get_term_by( 'name', $user_id, self::REMAP_TAXONOMY );
+		$user_id        = apply_filters( 'mastodon_api_canonical_user_id', $user_id );
+		$term           = get_term_by( 'name', $user_id, self::REMAP_TAXONOMY );
 		$remote_user_id = 0;
 		if ( $term ) {
 			$remote_user_id = $term->term_id;
@@ -2540,7 +2540,7 @@ class Mastodon_API {
 	}
 
 	public static function remap_url( $url ) {
-		$term = get_term_by( 'name', $url, self::REMAP_TAXONOMY );
+		$term        = get_term_by( 'name', $url, self::REMAP_TAXONOMY );
 		$remapped_id = 0;
 		if ( $term ) {
 			$remapped_id = $term->term_id;
@@ -2581,7 +2581,7 @@ class Mastodon_API {
 			'version' => self::VERSION,
 		);
 		$software = apply_filters( 'mastodon_api_nodeinfo_software', $software );
-		$ret = array(
+		$ret      = array(
 			'metadata'          => array(
 				'nodeName'        => html_entity_decode( get_bloginfo( 'name' ), ENT_QUOTES ),
 				'nodeDescription' => html_entity_decode( get_bloginfo( 'description' ), ENT_QUOTES ),
@@ -2636,7 +2636,7 @@ class Mastodon_API {
 		);
 
 		$post_formats = $app->get_post_formats();
-		$content[] = sprintf(
+		$content[]    = sprintf(
 			// Translators: %s is the post formats.
 			_n( 'Posts with the post format <strong>%s</strong> will appear in this app.', 'Posts with the post formats <strong>%s</strong> will appear in this app.', count( $app->get_post_formats() ), 'enable-mastodon-apps' ),
 			implode( ', ', $post_formats )

--- a/includes/class-mastodon-api.php
+++ b/includes/class-mastodon-api.php
@@ -89,7 +89,7 @@ class Mastodon_API {
 		header( 'Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS' );
 		header( 'Access-Control-Allow-Headers: content-type, authorization' );
 		header( 'Access-Control-Allow-Credentials: true' );
-		if ( 'OPTIONS' === $_SERVER['REQUEST_METHOD'] ) {
+		if ( 'OPTIONS' === $_SERVER['REQUEST_METHOD'] ) { // phpcs:ignore
 			header( 'Access-Control-Allow-Origin: *', true, 204 );
 			exit;
 		}
@@ -1423,7 +1423,7 @@ class Mastodon_API {
 				$app->was_used(
 					$request,
 					array(
-						'user_agent' => $_SERVER['HTTP_USER_AGENT'],
+						'user_agent' => $_SERVER['HTTP_USER_AGENT'], // phpcs:ignore
 					)
 				);
 			}
@@ -1441,12 +1441,14 @@ class Mastodon_API {
 		if ( get_option( 'mastodon_api_debug_mode' ) <= time() ) {
 			return $template;
 		}
+		// phpcs:disable
 		if ( 0 !== strpos( $_SERVER['REQUEST_URI'], '/api/v' ) ) {
 			return $template;
 		}
 		$request = new WP_REST_Request( $_SERVER['REQUEST_METHOD'], $_SERVER['REQUEST_URI'] );
 		$request->set_query_params( $_GET );
 		$request->set_body_params( $_POST );
+		// phpcs:enable
 		$request->set_headers( getallheaders() );
 		if ( ! empty( $_SERVER['HTTP_AUTHORIZATION'] ) ) {
 			$this->oauth->get_token();
@@ -1458,7 +1460,7 @@ class Mastodon_API {
 		$app->was_used(
 			$request,
 			array(
-				'user_agent' => $_SERVER['HTTP_USER_AGENT'],
+				'user_agent' => $_SERVER['HTTP_USER_AGENT'], // phpcs:ignore
 				'status'     => 404,
 			)
 		);

--- a/includes/class-mastodon-api.php
+++ b/includes/class-mastodon-api.php
@@ -1552,7 +1552,7 @@ class Mastodon_API {
 	 *
 	 * @return     array   The potentially modified default value.
 	 */
-	public function default_option_mastodon_api_default_post_formats( $post_formats ) {
+	public function default_option_mastodon_api_default_post_formats( $post_formats ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 		return array(
 			'standard',
 		);
@@ -1898,7 +1898,7 @@ class Mastodon_API {
 		return $this->validate_entity( $account, Entity\Account::class );
 	}
 
-	public function api_push_subscription( $request ) {
+	public function api_push_subscription( $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 		return array();
 	}
 
@@ -2369,7 +2369,7 @@ class Mastodon_API {
 		return apply_filters( 'mastodon_api_notifications_get', array(), $request );
 	}
 
-	public function api_preferences( $request ) {
+	public function api_preferences( $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 		$preferences = array(
 			'posting:default:language'   => self::get_mastodon_language( get_user_locale() ),
 			'posting:default:visibility' => apply_filters( 'mastodon_api_account_visibility', 'public', wp_get_current_user() ),
@@ -2731,7 +2731,7 @@ class Mastodon_API {
 	 * @param WP_REST_Request $request The full request object.
 	 * @return WP_REST_Response
 	 */
-	public function api_instance_peers( WP_REST_Request $request ): WP_REST_Response {
+	public function api_instance_peers( WP_REST_Request $request ): WP_REST_Response { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 		$peers = get_bookmarks();
 		$peers = wp_list_pluck( $peers, 'link_url' );
 
@@ -2761,7 +2761,7 @@ class Mastodon_API {
 	 * @param WP_REST_Request $request The full request object.
 	 * @return WP_REST_Response
 	 */
-	public function api_instance_rules( WP_REST_Request $request ): WP_REST_Response {
+	public function api_instance_rules( WP_REST_Request $request ): WP_REST_Response { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 		/**
 		 * Modify the instance rules returned for `/api/instance/rules` requests.
 		 *
@@ -2788,7 +2788,7 @@ class Mastodon_API {
 	 * @param WP_REST_Request $request The full request object.
 	 * @return WP_REST_Response
 	 */
-	public function api_instance_domain_blocks( WP_REST_Request $request ): WP_REST_Response {
+	public function api_instance_domain_blocks( WP_REST_Request $request ): WP_REST_Response { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 		/**
 		 * Modify the instance domain_blocks returned for `/api/instance/domain_blocks` requests.
 		 *
@@ -2815,7 +2815,7 @@ class Mastodon_API {
 	 * @param WP_REST_Request $request The full request object.
 	 * @return WP_REST_Response
 	 */
-	public function api_instance_extended_description( WP_REST_Request $request ): WP_REST_Response {
+	public function api_instance_extended_description( WP_REST_Request $request ): WP_REST_Response { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 		/**
 		 * Modify the instance extended_description returned for `/api/instance/extended_description` requests.
 		 *
@@ -2840,7 +2840,7 @@ class Mastodon_API {
 	 * @param WP_REST_Request $request The full request object.
 	 * @return WP_REST_Response
 	 */
-	public function api_instance_translation_languages( WP_REST_Request $request ): WP_REST_Response {
+	public function api_instance_translation_languages( WP_REST_Request $request ): WP_REST_Response { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 		/**
 		 * Modify the translation languages returned for `/api/instance/translation_languages` requests.
 		 *

--- a/includes/class-mastodon-api.php
+++ b/includes/class-mastodon-api.php
@@ -2581,45 +2581,47 @@ class Mastodon_API {
 		return $software;
 	}
 
-	public function api_nodeinfo() {
-		global $wp_version;
-		$software = array(
-			'name'    => $this->software_string(),
-			'version' => self::VERSION,
-		);
-		$software = apply_filters( 'mastodon_api_nodeinfo_software', $software );
-		$ret      = array(
-			'metadata'          => array(
-				'nodeName'        => html_entity_decode( get_bloginfo( 'name' ), ENT_QUOTES ),
-				'nodeDescription' => html_entity_decode( get_bloginfo( 'description' ), ENT_QUOTES ),
-				'software'        => $software,
-				'config'          => array(
-					'features' => array(
-						'timelines'   => array(
-							'local'   => true,
-							'network' => true,
-						),
-						'mobile_apis' => true,
-						'stories'     => false,
-						'video'       => false,
-						'import'      => array(
-							'instagram' => false,
-							'mastodon'  => false,
-							'pixelfed'  => false,
+	public function api_nodeinfo( $request ) {
+		$nodeinfo_version = $request->get_param( 'version' );
+
+		if ( '2.0' === $nodeinfo_version ) {
+			global $wp_version;
+			$software = array(
+				'name'    => $this->software_string(),
+				'version' => self::VERSION,
+			);
+			$software = apply_filters( 'mastodon_api_nodeinfo_software', $software );
+			$ret      = array(
+				'metadata' => array(
+					'nodeName'          => html_entity_decode( get_bloginfo( 'name' ), ENT_QUOTES ),
+					'nodeDescription'   => html_entity_decode( get_bloginfo( 'description' ), ENT_QUOTES ),
+					'config'            => array(
+						'features' => array(
+							'timelines'   => array(
+								'local'   => true,
+								'network' => true,
+							),
+							'mobile_apis' => true,
+							'stories'     => false,
+							'video'       => false,
+							'import'      => array(
+								'instagram' => false,
+								'mastodon'  => false,
+								'pixelfed'  => false,
+							),
 						),
 					),
-				),
-				'version'           => '2.0',
-				'protocols'         => array(
-					'activitpypub',
-				),
-				'services'          => array(
-					'inbound'  => array(),
-					'outbound' => array(),
-				),
+					'version'           => '2.0',
+					'protocols'         => array(
+						'activitpypub',
+					),
+					'services'          => array(
+						'outbound' => array(),
+					),
 
-				'software'          => $software,
-				'openRegistrations' => false,
+					'software'          => $software,
+					'openRegistrations' => false,
+				),
 			);
 		} else {
 			$ret = new WP_Error(

--- a/includes/class-mastodon-app.php
+++ b/includes/class-mastodon-app.php
@@ -92,7 +92,7 @@ class Mastodon_App {
 	}
 
 	public function get_admin_page() {
-		return admin_url( 'admin.php?page=enable-mastodon-apps&app=' . urlencode( $this->term->slug ) );
+		return add_query_arg( 'app', $this->term->slug, admin_url( 'admin.php?page=enable-mastodon-apps' ) );
 	}
 
 	public function get_create_post_type() {
@@ -371,8 +371,8 @@ class Mastodon_App {
 					if ( ! $url ) {
 						return '';
 					}
-					$host = parse_url( $url, PHP_URL_HOST );
-					$protocol = parse_url( $url, PHP_URL_SCHEME );
+					$host = wp_parse_url( $url, PHP_URL_HOST );
+					$protocol = wp_parse_url( $url, PHP_URL_SCHEME );
 
 					if ( ! $host || 0 !== strpos( 'https', $protocol ) ) {
 						$url = '';
@@ -535,7 +535,7 @@ class Mastodon_App {
 			}
 			$tax_query[] = $post_format_query;
 		}
-		$args['tax_query'] = $tax_query;
+		$args['tax_query'] = $tax_query; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 
 		return $args;
 	}
@@ -592,7 +592,7 @@ class Mastodon_App {
 		return new self( $term );
 	}
 
-	public static function save( $client_name, array $redirect_uris, $scopes, $website ) {
+	public static function save( $client_name, array $redirect_uris, $scopes, $website ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		$client_id     = strtolower( wp_generate_password( 32, false ) );
 		$client_secret = wp_generate_password( 128, false );
 

--- a/includes/class-mastodon-app.php
+++ b/includes/class-mastodon-app.php
@@ -28,8 +28,8 @@ class Mastodon_App {
 	private static $current_app = null;
 
 	const DEBUG_CLIENT_ID = 'enable-mastodon-apps';
-	const TAXONOMY = 'mastodon-app';
-	const VALID_SCOPES = array(
+	const TAXONOMY        = 'mastodon-app';
+	const VALID_SCOPES    = array(
 		'read',
 		'write',
 		'follow',
@@ -242,7 +242,7 @@ class Mastodon_App {
 			)
 		) as $term ) {
 			if ( $term instanceof \WP_Term ) {
-				$app = new Mastodon_App( $term );
+				$app                           = new Mastodon_App( $term );
 				$apps[ $app->get_client_id() ] = $app;
 			}
 		}
@@ -498,7 +498,7 @@ class Mastodon_App {
 		}
 
 		$filter_by_post_format = $this->get_post_formats();
-		$post_formats = get_post_format_slugs();
+		$post_formats          = get_post_format_slugs();
 		$filter_by_post_format = array_filter(
 			$filter_by_post_format,
 			function ( $post_format ) use ( $post_formats ) {
@@ -593,7 +593,7 @@ class Mastodon_App {
 	}
 
 	public static function save( $client_name, array $redirect_uris, $scopes, $website ) {
-		$client_id = strtolower( wp_generate_password( 32, false ) );
+		$client_id     = strtolower( wp_generate_password( 32, false ) );
 		$client_secret = wp_generate_password( 128, false );
 
 		$term = wp_insert_term( $client_id, self::TAXONOMY );

--- a/includes/class-mastodon-app.php
+++ b/includes/class-mastodon-app.php
@@ -185,8 +185,8 @@ class Mastodon_App {
 				array_merge(
 					array(
 						'timestamp'    => microtime( true ),
-						'path'         => $_SERVER['REQUEST_URI'],
-						'method'       => $_SERVER['REQUEST_METHOD'],
+						'path'         => $_SERVER['REQUEST_URI'], // phpcs:ignore
+						'method'       => $_SERVER['REQUEST_METHOD'], // phpcs:ignore
 						'params'       => $request->get_params(),
 						'json'         => $request->get_json_params(),
 						'files'        => $request->get_file_params(),
@@ -571,7 +571,7 @@ class Mastodon_App {
 		foreach ( self::get_all() as $app ) {
 			if ( $app->is_outdated() ) {
 				if ( $app->delete() ) {
-					$count += 1;
+					++$count;
 				}
 			}
 		}

--- a/includes/class-mastodon-oauth.php
+++ b/includes/class-mastodon-oauth.php
@@ -98,7 +98,7 @@ class Mastodon_OAuth {
 	public function handle_oauth( $return_value = false ) {
 		global $wp_query;
 		if ( 'POST' === $_SERVER['REQUEST_METHOD'] && empty( $_POST ) && ! empty( $_REQUEST ) ) { // phpcs:ignore
-			$_POST = $_REQUEST;
+			$_POST = $_REQUEST; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		}
 		$endpoint = null;
 
@@ -145,8 +145,8 @@ class Mastodon_OAuth {
 		}
 
 		if ( get_option( 'mastodon_api_debug_mode' ) > time() ) {
-			$app     = Mastodon_App::get_debug_app();
 			// phpcs:disable
+			$app     = Mastodon_App::get_debug_app();
 			$request = new \WP_REST_Request( $_SERVER['REQUEST_METHOD'], $_SERVER['REQUEST_URI'] );
 			$request->set_query_params( $_GET );
 			$request->set_body_params( $_POST );

--- a/includes/class-mastodon-oauth.php
+++ b/includes/class-mastodon-oauth.php
@@ -67,7 +67,7 @@ class Mastodon_OAuth {
 
 	public function rewrite_rules() {
 		$existing_rules = get_option( 'rewrite_rules' );
-		$needs_flush = false;
+		$needs_flush    = false;
 
 		$generic =
 			array(
@@ -118,7 +118,7 @@ class Mastodon_OAuth {
 					return null;
 				}
 				$wp_query->is_404 = false;
-				$handler = new OAuth2\Authorize_Handler( $this->server );
+				$handler          = new OAuth2\Authorize_Handler( $this->server );
 				break;
 
 			case 'token':
@@ -131,12 +131,12 @@ class Mastodon_OAuth {
 				}
 				header( 'Access-Control-Allow-Origin: *' );
 				$wp_query->is_404 = false;
-				$handler = new OAuth2\Token_Handler( $this->server );
+				$handler          = new OAuth2\Token_Handler( $this->server );
 				break;
 
 			case 'revoke':
 				$wp_query->is_404 = false;
-				$handler = new OAuth2\Revokation_Handler( $this->server );
+				$handler          = new OAuth2\Revokation_Handler( $this->server );
 				break;
 		}
 
@@ -145,7 +145,7 @@ class Mastodon_OAuth {
 		}
 
 		if ( get_option( 'mastodon_api_debug_mode' ) > time() ) {
-			$app = Mastodon_App::get_debug_app();
+			$app     = Mastodon_App::get_debug_app();
 			$request = new \WP_REST_Request( $_SERVER['REQUEST_METHOD'], $_SERVER['REQUEST_URI'] );
 			$request->set_query_params( $_GET );
 			$request->set_body_params( $_POST );
@@ -169,7 +169,7 @@ class Mastodon_OAuth {
 	}
 
 	public function get_token() {
-		$request = Request::createFromGlobals();
+		$request  = Request::createFromGlobals();
 		$response = new Response();
 		if ( ! $this->server->verifyResourceRequest( $request, $response ) ) {
 			return null;

--- a/includes/class-mastodon-oauth.php
+++ b/includes/class-mastodon-oauth.php
@@ -47,7 +47,7 @@ class Mastodon_OAuth {
 		$this->server->addStorage( new Oauth2\Access_Token_Storage(), 'access_token' );
 		$this->server->setScopeUtil( new Oauth2\Scope_Util() );
 
-		if ( '/oauth/token' === strtok( $_SERVER['REQUEST_URI'], '?' ) ) {
+		if ( '/oauth/token' === strtok( $_SERVER['REQUEST_URI'], '?' ) ) { // phpcs:ignore
 			// Avoid interference with private site plugins.
 			add_filter(
 				'pre_option_blog_public',
@@ -97,7 +97,7 @@ class Mastodon_OAuth {
 
 	public function handle_oauth( $return_value = false ) {
 		global $wp_query;
-		if ( 'POST' === $_SERVER['REQUEST_METHOD'] && empty( $_POST ) && ! empty( $_REQUEST ) ) {
+		if ( 'POST' === $_SERVER['REQUEST_METHOD'] && empty( $_POST ) && ! empty( $_REQUEST ) ) { // phpcs:ignore
 			$_POST = $_REQUEST;
 		}
 		$endpoint = null;
@@ -105,7 +105,7 @@ class Mastodon_OAuth {
 		if ( isset( $wp_query->query['mastodon-oauth'] ) ) {
 			$endpoint = $wp_query->query['mastodon-oauth'];
 		} else {
-			$request_uri = trim( strtok( $_SERVER['REQUEST_URI'], '?' ), '/' );
+			$request_uri = trim( strtok( $_SERVER['REQUEST_URI'], '?' ), '/' ); // phpcs:ignore
 
 			if ( in_array( $request_uri, array( 'oauth/authorize', 'oauth/token', 'oauth/revoke' ) ) ) {
 				$endpoint = explode( '/', $request_uri )[1];
@@ -125,7 +125,7 @@ class Mastodon_OAuth {
 				header( 'Access-Control-Allow-Methods: POST' );
 				header( 'Access-Control-Allow-Headers: content-type' );
 				header( 'Access-Control-Allow-Credentials: true' );
-				if ( 'OPTIONS' === $_SERVER['REQUEST_METHOD'] ) {
+				if ( 'OPTIONS' === $_SERVER['REQUEST_METHOD'] ) { // phpcs:ignore
 					header( 'Access-Control-Allow-Origin: *', true, 204 );
 					exit;
 				}
@@ -146,9 +146,11 @@ class Mastodon_OAuth {
 
 		if ( get_option( 'mastodon_api_debug_mode' ) > time() ) {
 			$app     = Mastodon_App::get_debug_app();
+			// phpcs:disable
 			$request = new \WP_REST_Request( $_SERVER['REQUEST_METHOD'], $_SERVER['REQUEST_URI'] );
 			$request->set_query_params( $_GET );
 			$request->set_body_params( $_POST );
+			// phpcs:enable
 			$request->set_headers( getallheaders() );
 			$app->was_used( $request );
 		}

--- a/includes/entity/class-account.php
+++ b/includes/entity/class-account.php
@@ -17,7 +17,7 @@ namespace Enable_Mastodon_Apps\Entity;
  * @package Enable_Mastodon_Apps
  */
 class Account extends Entity {
-	protected $_types = array(
+	protected $types = array(
 		'id'              => 'string',
 		'username'        => 'string',
 		'acct'            => 'string',

--- a/includes/entity/class-application.php
+++ b/includes/entity/class-application.php
@@ -17,7 +17,7 @@ namespace Enable_Mastodon_Apps\Entity;
  * @package Enable_Mastodon_Apps
  */
 class Application extends Entity {
-	protected $_types = array(
+	protected $types = array(
 		'name'          => 'string',
 		'client_id'     => 'string',
 		'client_secret' => 'string',

--- a/includes/entity/class-domain-block.php
+++ b/includes/entity/class-domain-block.php
@@ -22,7 +22,7 @@ class Domain_Block extends Entity {
 	 *
 	 * @var array
 	 */
-	protected $_types = array(
+	protected $types = array(
 		'domain'   => 'string',
 		'digest'   => 'string',
 		'severity' => 'string',

--- a/includes/entity/class-entity.php
+++ b/includes/entity/class-entity.php
@@ -45,7 +45,7 @@ abstract class Entity implements \JsonSerializable {
 				continue;
 			}
 
-			$object = rtrim( $type, '?' );
+			$object   = rtrim( $type, '?' );
 			$nullable = preg_match( '/\?\?$/', $type );
 			$optional = preg_match( '/\?$/', $type );
 
@@ -123,7 +123,7 @@ abstract class Entity implements \JsonSerializable {
 			if ( preg_match( '/array\[([^\]]+)\]/', $object, $matches ) ) {
 				$object = $matches[1];
 				if ( substr( $object, -1 ) === '?' ) {
-					$object = rtrim( $object, '?' );
+					$object    = rtrim( $object, '?' );
 					$skippable = true;
 				}
 				if ( ! class_exists( '\\Enable_Mastodon_Apps\\Entity\\' . $object ) ) {

--- a/includes/entity/class-entity.php
+++ b/includes/entity/class-entity.php
@@ -18,7 +18,7 @@ abstract class Entity implements \JsonSerializable {
 	 *
 	 * Example:
 	 * ```
-	 * protected $_types = array(
+	 * protected $types = array(
 	 *     'id'             => 'string',
 	 *     'created_at'     => 'DateTime', // DateTime is the PHP class.
 	 *     'text'           => 'string',
@@ -28,7 +28,7 @@ abstract class Entity implements \JsonSerializable {
 	 *
 	 * @var array
 	 */
-	protected $_types;
+	protected $types;
 
 	/**
 	 * Provide the data that should be serialized as JSON.
@@ -40,7 +40,7 @@ abstract class Entity implements \JsonSerializable {
 	#[\ReturnTypeWillChange]
 	public function jsonSerialize() {
 		$array = array();
-		foreach ( $this->_types as $var => $type ) {
+		foreach ( $this->types as $var => $type ) {
 			if ( is_wp_error( $this->$var ) ) {
 				continue;
 			}
@@ -63,14 +63,12 @@ abstract class Entity implements \JsonSerializable {
 					return array(
 						'error' => 'Required variable is missing: ' . $var,
 					);
-					continue;
 				}
 				$valid = $this->validate( $var );
 				if ( is_wp_error( $valid ) ) {
 					return array(
 						'error' => $var . ': ' . $valid->get_error_message(),
 					);
-					continue;
 				}
 
 				settype( $this->$var, $object );

--- a/includes/entity/class-extended-description.php
+++ b/includes/entity/class-extended-description.php
@@ -22,7 +22,7 @@ class Extended_Description extends Entity {
 	 *
 	 * @var array
 	 */
-	protected $_types = array(
+	protected $types = array(
 		'updated_at' => 'string',
 		'content'    => 'string',
 	);

--- a/includes/entity/class-instance-v1.php
+++ b/includes/entity/class-instance-v1.php
@@ -22,7 +22,7 @@ class Instance_V1 extends Entity {
 	 *
 	 * @var array
 	 */
-	protected $_types = array(
+	protected $types = array(
 		'uri'               => 'string',
 		'title'             => 'string',
 		'short_description' => 'string',

--- a/includes/entity/class-instance.php
+++ b/includes/entity/class-instance.php
@@ -22,7 +22,7 @@ class Instance extends Entity {
 	 *
 	 * @var array
 	 */
-	protected $_types = array(
+	protected $types = array(
 		'domain'        => 'string',
 		'title'         => 'string',
 		'version'       => 'string',

--- a/includes/entity/class-media-attachment.php
+++ b/includes/entity/class-media-attachment.php
@@ -13,7 +13,7 @@ namespace Enable_Mastodon_Apps\Entity;
  * This is the class that implements the Media_Attachment entity.
  */
 class Media_Attachment extends Entity {
-	protected $_types = array(
+	protected $types = array(
 		'id'          => 'string',
 		'type'        => 'string',
 		'url'         => 'string',

--- a/includes/entity/class-notification.php
+++ b/includes/entity/class-notification.php
@@ -17,7 +17,7 @@ namespace Enable_Mastodon_Apps\Entity;
  * @package Enable_Mastodon_Apps
  */
 class Notification extends Entity {
-	protected $_types = array(
+	protected $types = array(
 		'id'         => 'string',
 		'type'       => 'string',
 		'created_at' => 'string',

--- a/includes/entity/class-poll.php
+++ b/includes/entity/class-poll.php
@@ -17,7 +17,7 @@ namespace Enable_Mastodon_Apps\Entity;
  * @package Enable_Mastodon_Apps
  */
 class Poll extends Entity {
-	protected $_types = array(
+	protected $types = array(
 		'id'           => 'string',
 
 		'expires_at'   => 'string?',

--- a/includes/entity/class-preview-card.php
+++ b/includes/entity/class-preview-card.php
@@ -17,7 +17,7 @@ namespace Enable_Mastodon_Apps\Entity;
  * @package Enable_Mastodon_Apps
  */
 class Preview_Card extends Entity {
-	protected $_types = array(
+	protected $types = array(
 		'url'           => 'string',
 		'title'         => 'string',
 		'description'   => 'string',

--- a/includes/entity/class-relationship.php
+++ b/includes/entity/class-relationship.php
@@ -21,7 +21,7 @@ class Relationship extends Entity {
 	 *
 	 * @var array
 	 */
-	protected $_types = array(
+	protected $types = array(
 		'id'                   => 'string',
 		'following'            => 'bool',
 		'showing_reblogs'      => 'bool',

--- a/includes/entity/class-rule.php
+++ b/includes/entity/class-rule.php
@@ -22,7 +22,7 @@ class Rule extends Entity {
 	 *
 	 * @var array
 	 */
-	protected $_types = array(
+	protected $types = array(
 		'id'   => 'string',
 		'text' => 'string',
 	);

--- a/includes/entity/class-search.php
+++ b/includes/entity/class-search.php
@@ -17,7 +17,7 @@ namespace Enable_Mastodon_Apps\Entity;
  * @package Enable_Mastodon_Apps
  */
 class Search extends Entity {
-	protected $_types = array(
+	protected $types = array(
 		'accounts' => 'array',
 		'statuses' => 'array',
 		'hashtags' => 'array',

--- a/includes/entity/class-status-source.php
+++ b/includes/entity/class-status-source.php
@@ -17,7 +17,7 @@ namespace Enable_Mastodon_Apps\Entity;
  * @package Enable_Mastodon_Apps
  */
 class Status_Source extends Entity {
-	protected $_types = array(
+	protected $types = array(
 		'id'           => 'string',
 		'spoiler_text' => 'string',
 		'text'         => 'string',

--- a/includes/entity/class-status.php
+++ b/includes/entity/class-status.php
@@ -17,7 +17,7 @@ namespace Enable_Mastodon_Apps\Entity;
  * @package Enable_Mastodon_Apps
  */
 class Status extends Entity {
-	protected $_types = array(
+	protected $types = array(
 		'id'                     => 'string',
 		'created_at'             => 'DateTime',
 		'spoiler_text'           => 'string',

--- a/includes/entity/class-tag.php
+++ b/includes/entity/class-tag.php
@@ -17,7 +17,7 @@ namespace Enable_Mastodon_Apps\Entity;
  * @package Enable_Mastodon_Apps
  */
 class Tag extends Entity {
-	protected $_types = array(
+	protected $types = array(
 		'name'      => 'string',
 		'url'       => 'string',
 		'history'   => 'array',

--- a/includes/handler/class-account.php
+++ b/includes/handler/class-account.php
@@ -39,8 +39,8 @@ class Account extends Handler {
 			return $user_data;
 		}
 
-		$note    = get_user_meta( $user->ID, 'description', true );
-		$account = new Account_Entity();
+		$note                    = get_user_meta( $user->ID, 'description', true );
+		$account                 = new Account_Entity();
 		$account->id             = strval( $user->ID );
 		$account->username       = $user->user_login;
 		$account->display_name   = $user->display_name;

--- a/includes/handler/class-handler.php
+++ b/includes/handler/class-handler.php
@@ -107,7 +107,7 @@ class Handler {
 			}
 
 			if ( is_wp_error( $status ) ) {
-				error_log( print_r( $status, true ) );
+				error_log( print_r( $status, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log,WordPress.PHP.DevelopmentFunctions.error_log_print_r
 				continue;
 			}
 
@@ -118,7 +118,7 @@ class Handler {
 			}
 
 			if ( ! $status->is_valid() ) {
-				error_log( wp_json_encode( compact( 'status', 'post' ) ) );
+				error_log( wp_json_encode( compact( 'status', 'post' ) ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 				continue;
 			}
 

--- a/includes/handler/class-handler.php
+++ b/includes/handler/class-handler.php
@@ -21,7 +21,7 @@ class Handler {
 		if ( $limit < 1 ) {
 			$limit = 20;
 		}
-		$app = Mastodon_App::get_current_app();
+		$app        = Mastodon_App::get_current_app();
 		$post_types = array( 'post' );
 		if ( $app ) {
 			$post_types = $app->get_view_post_types();
@@ -33,7 +33,7 @@ class Handler {
 
 		$pinned = $request->get_param( 'pinned' );
 		if ( $pinned || 'true' === $pinned ) {
-			$args['pinned'] = true;
+			$args['pinned']   = true;
 			$args['post__in'] = get_option( 'sticky_posts' );
 			if ( empty( $args['post__in'] ) ) {
 				// No pinned posts, we need to find nothing.
@@ -69,7 +69,7 @@ class Handler {
 					global $wpdb;
 					return $where . $wpdb->prepare( " AND {$wpdb->posts}.ID > %d", $min_id );
 				};
-				$args['order'] = 'ASC';
+				$args['order']      = 'ASC';
 				add_filter( 'posts_where', $min_filter_handler );
 			}
 

--- a/includes/handler/class-handler.php
+++ b/includes/handler/class-handler.php
@@ -129,8 +129,9 @@ class Handler {
 
 		$response = new \WP_REST_Response( array_values( $statuses ) );
 		if ( ! empty( $statuses ) ) {
-			$response->add_link( 'next', remove_query_arg( 'min_id', add_query_arg( 'max_id', end( $statuses )->id, home_url( $_SERVER['REQUEST_URI'] ) ) ) );
-			$response->add_link( 'prev', remove_query_arg( 'max_id', add_query_arg( 'min_id', reset( $statuses )->id, home_url( $_SERVER['REQUEST_URI'] ) ) ) );
+			$req_uri = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
+			$response->add_link( 'next', remove_query_arg( 'min_id', add_query_arg( 'max_id', end( $statuses )->id, home_url( $req_uri ) ) ) );
+			$response->add_link( 'prev', remove_query_arg( 'max_id', add_query_arg( 'min_id', reset( $statuses )->id, home_url( $req_uri ) ) ) );
 		}
 		return $response;
 	}

--- a/includes/handler/class-instance.php
+++ b/includes/handler/class-instance.php
@@ -63,8 +63,8 @@ class Instance extends Handler {
 		$instance->registrations     = (bool) get_option( 'users_can_register' );
 		$instance->approval_required = false;
 		$instance->invites_enabled   = false;
-		$instance->languages     = empty( get_available_languages() ) ? array( 'en' ) : get_available_languages();
-		$instance->configuration = array(
+		$instance->languages         = empty( get_available_languages() ) ? array( 'en' ) : get_available_languages();
+		$instance->configuration     = array(
 			'media_attachment' => array(
 				'supported_mime_types' => array_values( get_allowed_mime_types() ),
 				'image_size_limit'     => \wp_max_upload_size(),

--- a/includes/handler/class-media-attachment.php
+++ b/includes/handler/class-media-attachment.php
@@ -99,7 +99,7 @@ class Media_Attachment extends Handler {
 			$thumb_meta   = \wp_get_attachment_metadata( $thumbnail_id );
 			if ( isset( $thumb_meta['sizes']['medium-large'] ) ) {
 				$thumb = \wp_get_attachment_image_src( $thumbnail_id, 'medium-large' );
-			} elseif ( isset( $meta['sizes']['medium'] ) ) {
+			} elseif ( isset( $thumb_meta['sizes']['medium'] ) ) {
 				$thumb = \wp_get_attachment_image_src( $thumbnail_id, 'medium' );
 			}
 		}

--- a/includes/handler/class-media-attachment.php
+++ b/includes/handler/class-media-attachment.php
@@ -95,8 +95,8 @@ class Media_Attachment extends Handler {
 		);
 		if ( \has_post_thumbnail( $attachment_id ) ) {
 			$thumbnail_id = get_post_thumbnail_id( $attachment_id );
-			$thumb = \wp_get_attachment_image_src( $thumbnail_id );
-			$thumb_meta = \wp_get_attachment_metadata( $thumbnail_id );
+			$thumb        = \wp_get_attachment_image_src( $thumbnail_id );
+			$thumb_meta   = \wp_get_attachment_metadata( $thumbnail_id );
 			if ( isset( $thumb_meta['sizes']['medium-large'] ) ) {
 				$thumb = \wp_get_attachment_image_src( $thumbnail_id, 'medium-large' );
 			} elseif ( isset( $meta['sizes']['medium'] ) ) {
@@ -169,12 +169,12 @@ class Media_Attachment extends Handler {
 				continue;
 			}
 
-			$attachment = new \Enable_Mastodon_Apps\Entity\Media_Attachment();
-			$attachment->id = strval( 2e10 + crc32( $block['src'] ) );
-			$attachment->type = 'image';
-			$attachment->url = $block['src'];
+			$attachment              = new \Enable_Mastodon_Apps\Entity\Media_Attachment();
+			$attachment->id          = strval( 2e10 + crc32( $block['src'] ) );
+			$attachment->type        = 'image';
+			$attachment->url         = $block['src'];
 			$attachment->preview_url = $block['src'];
-			$attachment->remote_url = $block['src'];
+			$attachment->remote_url  = $block['src'];
 			if ( isset( $block['width'] ) && $block['width'] > 0 && isset( $block['height'] ) && $block['height'] > 0 ) {
 				$attachment->meta = array(
 					'width'  => intval( $block['width'] ),
@@ -190,10 +190,10 @@ class Media_Attachment extends Handler {
 					'aspect' => 1,
 				);
 			}
-			$original = $attachment->meta;
+			$original                     = $attachment->meta;
 			$attachment->meta['original'] = $original;
-			$attachment->description = '';
-			$status->media_attachments[] = $attachment;
+			$attachment->description      = '';
+			$status->media_attachments[]  = $attachment;
 		}
 		return $status;
 	}
@@ -218,7 +218,7 @@ class Media_Attachment extends Handler {
 
 		foreach ( $matches as $match ) {
 			$status->content = str_replace( $match[0], '', $status->content );
-			$block = array();
+			$block           = array();
 			foreach ( array( 'src', 'width', 'height', 'poster' ) as $attr ) {
 				if ( preg_match( '/\s' . $attr . '="(?P<' . $attr . '>[^"]+)"/', $match[1], $m ) ) {
 					$block[ $attr ] = $m[ $attr ];
@@ -229,10 +229,10 @@ class Media_Attachment extends Handler {
 				continue;
 			}
 
-			$attachment = new \Enable_Mastodon_Apps\Entity\Media_Attachment();
-			$attachment->id = strval( 2e10 + crc32( $block['src'] ) );
+			$attachment       = new \Enable_Mastodon_Apps\Entity\Media_Attachment();
+			$attachment->id   = strval( 2e10 + crc32( $block['src'] ) );
 			$attachment->type = 'video';
-			$attachment->url = $block['src'];
+			$attachment->url  = $block['src'];
 			if ( isset( $block['poster'] ) ) {
 				$attachment->preview_url = $block['poster'];
 			} else {
@@ -255,7 +255,7 @@ class Media_Attachment extends Handler {
 					'aspect' => 1,
 				);
 			}
-			$attachment->description = '';
+			$attachment->description     = '';
 			$status->media_attachments[] = $attachment;
 		}
 		return $status;

--- a/includes/handler/class-notification.php
+++ b/includes/handler/class-notification.php
@@ -230,7 +230,7 @@ class Notification extends Handler {
 
 		if ( $status ) {
 			$notification['status'] = $status;
-			$notification['id'] .= $status->id;
+			$notification['id']    .= $status->id;
 		}
 
 		return $notification;

--- a/includes/handler/class-search.php
+++ b/includes/handler/class-search.php
@@ -39,7 +39,7 @@ class Search extends Handler {
 	 */
 	public function search( $search, object $request ) {
 		$type = $request->get_param( 'type' );
-		$ret = array(
+		$ret  = array(
 			'accounts' => array(),
 			'statuses' => array(),
 			'hashtags' => array(),
@@ -80,7 +80,7 @@ class Search extends Handler {
 			if ( empty( $args ) ) {
 				return array();
 			}
-			$args = apply_filters( 'mastodon_api_timelines_args', $args, $request );
+			$args      = apply_filters( 'mastodon_api_timelines_args', $args, $request );
 			$valid_url = wp_parse_url( $q );
 			if ( $valid_url && isset( $valid_url['host'] ) ) {
 				if ( ! $request->get_param( 'offset' ) ) {
@@ -88,14 +88,14 @@ class Search extends Handler {
 					// TODO allow lookup by URL.
 				}
 			} elseif ( is_user_logged_in() ) {
-				$args['s'] = $q;
-				$args['offset'] = $request->get_param( 'offset' );
+				$args['s']              = $q;
+				$args['offset']         = $request->get_param( 'offset' );
 				$args['posts_per_page'] = $request->get_param( 'limit' );
-				$ret['statuses'] = array_merge( $ret['statuses'], $this->get_posts( $args )->get_data() );
+				$ret['statuses']        = array_merge( $ret['statuses'], $this->get_posts( $args )->get_data() );
 			}
 		}
 		if ( ! $type || 'hashtags' === $type ) {
-			$q_param = $request->get_param( 'q' );
+			$q_param    = $request->get_param( 'q' );
 			$categories = get_categories(
 				array(
 					'orderby'    => 'name',

--- a/includes/handler/class-status-source.php
+++ b/includes/handler/class-status-source.php
@@ -43,8 +43,8 @@ class Status_Source extends Status {
 		if ( ! $post ) {
 			$comment = get_comment( $object_id );
 			if ( isset( $comment ) && $comment instanceof \WP_Comment ) {
-				$status_source = new Status_Source_Entity();
-				$status_source->id = strval( Mastodon_API::remap_comment_id( $comment->comment_ID ) );
+				$status_source       = new Status_Source_Entity();
+				$status_source->id   = strval( Mastodon_API::remap_comment_id( $comment->comment_ID ) );
 				$status_source->text = trim( wp_strip_all_tags( $comment->comment_content ) );
 			}
 
@@ -52,8 +52,8 @@ class Status_Source extends Status {
 		}
 
 		if ( $post instanceof \WP_Post ) {
-			$status_source = new Status_Source_Entity();
-			$status_source->id = strval( $post->ID );
+			$status_source       = new Status_Source_Entity();
+			$status_source->id   = strval( $post->ID );
 			$status_source->text = trim( wp_strip_all_tags( $post->post_title . PHP_EOL . $post->post_content ) );
 		}
 

--- a/includes/handler/class-status.php
+++ b/includes/handler/class-status.php
@@ -292,12 +292,12 @@ class Status extends Handler {
 						'id'       => $media_id,
 						'sizeSlug' => 'large',
 					);
-					$post_data['post_content'] .= '<!-- wp:image ' . json_encode( $meta_json ) . ' -->' . PHP_EOL;
+					$post_data['post_content'] .= '<!-- wp:image ' . wp_json_encode( $meta_json ) . ' -->' . PHP_EOL;
 					$post_data['post_content'] .= '<figure class="wp-block-image"><img src="' . esc_url( wp_get_attachment_url( $media_id ) ) . '" width="' . esc_attr( $attachment['width'] ) . '" height="' . esc_attr( $attachment['height'] ) . '" alt="" class="wp-image-' . esc_attr( $media_id ) . '"/></figure>' . PHP_EOL;
 					$post_data['post_content'] .= '<!-- /wp:image -->' . PHP_EOL;
 				} elseif ( \wp_attachment_is( 'video', $media_id ) ) {
 					$post_data['post_content'] .= PHP_EOL;
-					$post_data['post_content'] .= '<!-- wp:video ' . json_encode( array( 'id' => $media_id ) ) . '  -->' . PHP_EOL;
+					$post_data['post_content'] .= '<!-- wp:video ' . wp_json_encode( array( 'id' => $media_id ) ) . '  -->' . PHP_EOL;
 					$post_data['post_content'] .= '<figure class="wp-block-video"><video controls src="' . esc_url( wp_get_attachment_url( $media_id ) ) . '" width="' . esc_attr( $attachment['width'] ) . '" height="' . esc_attr( $attachment['height'] ) . '" /></figure>' . PHP_EOL;
 					$post_data['post_content'] .= '<!-- /wp:video -->' . PHP_EOL;
 				}

--- a/includes/handler/class-status.php
+++ b/includes/handler/class-status.php
@@ -135,13 +135,13 @@ class Status extends Handler {
 			if ( ! ( $account instanceof \Enable_Mastodon_Apps\Entity\Account ) ) {
 				return $status;
 			}
-			$status = new Status_Entity();
-			$status->id = strval( Mastodon_API::remap_comment_id( $comment->comment_ID ) );
+			$status             = new Status_Entity();
+			$status->id         = strval( Mastodon_API::remap_comment_id( $comment->comment_ID ) );
 			$status->created_at = new \DateTime( $comment->comment_date_gmt, new \DateTimeZone( 'UTC' ) );
 			$status->visibility = 'public';
-			$status->uri = get_comment_link( $comment );
-			$status->content = $comment->comment_content;
-			$status->account = $account;
+			$status->uri        = get_comment_link( $comment );
+			$status->content    = $comment->comment_content;
+			$status->account    = $account;
 			if ( $comment->comment_parent ) {
 				$status->in_reply_to_id = strval( Mastodon_API::remap_comment_id( $comment->comment_parent ) );
 			} else {
@@ -154,19 +154,19 @@ class Status extends Handler {
 			if ( ! ( $account instanceof \Enable_Mastodon_Apps\Entity\Account ) ) {
 				return $status;
 			}
-			$status = new Status_Entity();
-			$status->id = strval( $post->ID );
+			$status             = new Status_Entity();
+			$status->id         = strval( $post->ID );
 			$status->created_at = new \DateTime( $post->post_date_gmt, new \DateTimeZone( 'UTC' ) );
 			$status->visibility = 'public';
-			$status->uri = get_permalink( $post->ID );
-			$status->content = $post->post_title . PHP_EOL . $post->post_content;
-			$status->account = $account;
-			$media_attachments = $this->get_block_attachments( $post );
+			$status->uri        = get_permalink( $post->ID );
+			$status->content    = $post->post_title . PHP_EOL . $post->post_content;
+			$status->account    = $account;
+			$media_attachments  = $this->get_block_attachments( $post );
 			foreach ( $media_attachments as $media_id => $html ) {
 				$media_attachment = apply_filters( 'mastodon_api_media_attachment', null, $media_id );
 				if ( $media_attachment ) {
 					// We don't want to show the media in the content as they are attachments.
-					$status->content = str_replace( $html, '', $status->content );
+					$status->content             = str_replace( $html, '', $status->content );
 					$status->media_attachments[] = $media_attachment;
 				}
 			}
@@ -263,8 +263,8 @@ class Status extends Handler {
 		if ( 'standard' === $post_format ) {
 			// Use the first line of a post as the post title if we're using a standard post format.
 			list( $post_title, $post_content ) = explode( PHP_EOL, $post_data['post_content'], 2 );
-			$post_data['post_title']   = $post_title;
-			$post_data['post_content'] = trim( $post_content );
+			$post_data['post_title']           = $post_title;
+			$post_data['post_content']         = trim( $post_content );
 		}
 
 		if ( $in_reply_to_id ) {
@@ -273,7 +273,7 @@ class Status extends Handler {
 
 		if ( $scheduled_at ) {
 			$post_data['post_status'] = 'future';
-			$post_data['post_date'] = $scheduled_at;
+			$post_data['post_date']   = $scheduled_at;
 		}
 
 		if ( ! empty( $media_ids ) ) {
@@ -288,7 +288,7 @@ class Status extends Handler {
 				$attachment = \wp_get_attachment_metadata( $media_id );
 				if ( \wp_attachment_is( 'image', $media_id ) ) {
 					$post_data['post_content'] .= PHP_EOL;
-					$meta_json = array(
+					$meta_json                  = array(
 						'id'       => $media_id,
 						'sizeSlug' => 'large',
 					);
@@ -431,11 +431,11 @@ class Status extends Handler {
 		 */
 		$parent_post_id = apply_filters( 'mastodon_api_comment_parent_post_id', $in_reply_to_id, $status_text );
 
-		$comment_data['comment_content'] = $status_text;
-		$comment_data['comment_post_ID'] = $parent_post_id;
-		$comment_data['comment_parent']  = 0;
-		$comment_data['comment_author'] = get_current_user_id();
-		$comment_data['user_id'] = get_current_user_id();
+		$comment_data['comment_content']  = $status_text;
+		$comment_data['comment_post_ID']  = $parent_post_id;
+		$comment_data['comment_parent']   = 0;
+		$comment_data['comment_author']   = get_current_user_id();
+		$comment_data['user_id']          = get_current_user_id();
 		$comment_data['comment_approved'] = 1;
 
 		$parent_comment_id = Mastodon_API::maybe_get_remapped_comment_id( $in_reply_to_id );
@@ -455,7 +455,7 @@ class Status extends Handler {
 				if ( 'attachment' !== $media->post_type ) {
 					return new \WP_Error( 'mastodon_' . __FUNCTION__, 'Media not found', array( 'status' => 400 ) );
 				}
-				$attachment = \wp_get_attachment_metadata( $media_id );
+				$attachment                       = \wp_get_attachment_metadata( $media_id );
 				$comment_data['comment_content'] .= PHP_EOL;
 				$comment_data['comment_content'] .= '<!-- wp:image -->';
 				$comment_data['comment_content'] .= '<p><img src="' . esc_url( wp_get_attachment_url( $media_id ) ) . '" width="' . esc_attr( $attachment['width'] ) . '"  height="' . esc_attr( $attachment['height'] ) . '" class="size-full" /></p>';
@@ -505,12 +505,12 @@ class Status extends Handler {
 		 */
 		$parent_post_id = apply_filters( 'mastodon_api_comment_parent_post_id', $in_reply_to_id, $status_text );
 
-		$comment_data['comment_ID'] = $comment_id;
-		$comment_data['comment_content'] = $status_text;
-		$comment_data['comment_post_ID'] = $parent_post_id;
-		$comment_data['comment_parent']  = 0;
-		$comment_data['comment_author'] = get_current_user_id();
-		$comment_data['user_id'] = get_current_user_id();
+		$comment_data['comment_ID']       = $comment_id;
+		$comment_data['comment_content']  = $status_text;
+		$comment_data['comment_post_ID']  = $parent_post_id;
+		$comment_data['comment_parent']   = 0;
+		$comment_data['comment_author']   = get_current_user_id();
+		$comment_data['user_id']          = get_current_user_id();
 		$comment_data['comment_approved'] = 1;
 
 		$parent_comment_id = Mastodon_API::maybe_get_remapped_comment_id( $in_reply_to_id );
@@ -530,7 +530,7 @@ class Status extends Handler {
 				if ( 'attachment' !== $media->post_type ) {
 					return new \WP_Error( 'mastodon_' . __FUNCTION__, 'Media not found', array( 'status' => 400 ) );
 				}
-				$attachment = \wp_get_attachment_metadata( $media_id );
+				$attachment                       = \wp_get_attachment_metadata( $media_id );
 				$comment_data['comment_content'] .= PHP_EOL;
 				$comment_data['comment_content'] .= '<!-- wp:image -->';
 				$comment_data['comment_content'] .= '<p><img src="' . esc_url( wp_get_attachment_url( $media_id ) ) . '" width="' . esc_attr( $attachment['width'] ) . '"  height="' . esc_attr( $attachment['height'] ) . '" class="size-full" /></p>';
@@ -595,7 +595,7 @@ class Status extends Handler {
 				continue;
 			}
 			$post_id = $post->ID;
-			$args = array();
+			$args    = array();
 			/**
 			 * Modify the status data.
 			 *
@@ -619,7 +619,7 @@ class Status extends Handler {
 
 		ksort( $context['descendants'] );
 
-		$context['ancestors'] = array_values( $context['ancestors'] );
+		$context['ancestors']   = array_values( $context['ancestors'] );
 		$context['descendants'] = array_values( $context['descendants'] );
 		return $context;
 	}

--- a/includes/handler/class-status.php
+++ b/includes/handler/class-status.php
@@ -293,7 +293,7 @@ class Status extends Handler {
 						'sizeSlug' => 'large',
 					);
 					$post_data['post_content'] .= '<!-- wp:image ' . json_encode( $meta_json ) . ' -->' . PHP_EOL;
-					$post_data['post_content'] .= '<figure class="wp-block-image"><img src="' . esc_url( wp_get_attachment_url( $media_id ) ) . '" width="' . esc_attr( $attachment['width'] ) . '" height="' . esc_attr( $attachment['height'] ) . '" alt="' . esc_attr( $meta[''] ) . '" class="wp-image-' . esc_attr( $media_id ) . '"/></figure>' . PHP_EOL;
+					$post_data['post_content'] .= '<figure class="wp-block-image"><img src="' . esc_url( wp_get_attachment_url( $media_id ) ) . '" width="' . esc_attr( $attachment['width'] ) . '" height="' . esc_attr( $attachment['height'] ) . '" alt="" class="wp-image-' . esc_attr( $media_id ) . '"/></figure>' . PHP_EOL;
 					$post_data['post_content'] .= '<!-- /wp:image -->' . PHP_EOL;
 				} elseif ( \wp_attachment_is( 'video', $media_id ) ) {
 					$post_data['post_content'] .= PHP_EOL;

--- a/includes/handler/class-timeline.php
+++ b/includes/handler/class-timeline.php
@@ -67,7 +67,7 @@ class Timeline extends Handler {
 	 * @return Entity\Status[]|array An array of Status objects.
 	 */
 	public function api_tag_timeline( $statuses, $request ) {
-		$args = $this->get_posts_query_args( array(), $request );
+		$args        = $this->get_posts_query_args( array(), $request );
 		$args['tag'] = $request->get_param( 'hashtag' );
 
 		$ppp_param = $request->get_param( 'limit' );

--- a/includes/integration/class-pixelfed.php
+++ b/includes/integration/class-pixelfed.php
@@ -24,7 +24,7 @@ class Pixelfed {
 	}
 
 	public function mastodon_api_pixelfed_nodeinfo_software( $software ) {
-		if ( false !== strpos( $_SERVER['HTTP_USER_AGENT'], 'Pixelfed' ) ) {
+		if ( false !== strpos( $_SERVER['HTTP_USER_AGENT'], 'Pixelfed' ) ) { // phpcs:ignore
 			return array(
 				'name'    => 'pixelfed',
 				'version' => '0.11.5',

--- a/includes/oauth2/class-access-token-storage.php
+++ b/includes/oauth2/class-access-token-storage.php
@@ -260,7 +260,7 @@ class Access_Token_Storage implements AccessTokenInterface {
 				'taxonomy'   => self::TAXONOMY,
 				'hide_empty' => false,
 				'fields'     => 'ids',
-				'meta_query' => array(
+				'meta_query' => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 					array(
 						'key'     => 'expires',
 						'value'   => time(),

--- a/includes/oauth2/class-authenticate-handler.php
+++ b/includes/oauth2/class-authenticate-handler.php
@@ -21,7 +21,7 @@ class Authenticate_Handler {
 		if ( ! is_user_logged_in() ) {
 			auth_redirect();
 		}
-		$client_id = isset( $_GET['client_id'] ) ? sanitize_text_field( wp_unslash( $_GET['client_id'] ) ) : '';
+		$client_id = isset( $_GET['client_id'] ) ? sanitize_text_field( wp_unslash( $_GET['client_id'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$app = Mastodon_App::get_by_client_id( $client_id );
 		if ( is_wp_error( $app ) ) {
 			$response->setStatusCode( 404 );
@@ -31,7 +31,7 @@ class Authenticate_Handler {
 
 		$client_name = $app->get_client_name();
 
-		$redirect_uri = isset( $_GET['redirect_uri'] ) ? sanitize_text_field( wp_unslash( $_GET['redirect_uri'] ) ) : '';
+		$redirect_uri = isset( $_GET['redirect_uri'] ) ? sanitize_text_field( wp_unslash( $_GET['redirect_uri'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$redirect_uri = $app->check_redirect_uri( $redirect_uri );
 		if ( is_wp_error( $redirect_uri ) ) {
 			return $redirect_uri;
@@ -56,7 +56,7 @@ class Authenticate_Handler {
 			'body_class_attr' => implode( ' ', array_diff( get_body_class(), array( 'error404' ) ) ),
 			'cancel_url'      => $this->get_cancel_url( $request ),
 			'form_url'        => home_url( '/oauth/authorize' ),
-			'form_fields'     => $_GET,
+			'form_fields'     => $_GET, // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		);
 
 		$has_permission = current_user_can( 'edit_private_posts' );

--- a/includes/oauth2/class-authenticate-handler.php
+++ b/includes/oauth2/class-authenticate-handler.php
@@ -175,7 +175,7 @@ class Authenticate_Handler {
 							$all = isset( $subscopes['all'] ) && $subscopes['all'];
 							unset( $subscopes['all'] );
 							if ( ! empty( $subscopes ) && ! $all ) {
-								echo ' ', __( 'Only the following sub-permissions:', 'enable-mastodon-apps' );
+								echo ' ', esc_html__( 'Only the following sub-permissions:', 'enable-mastodon-apps' );
 								echo '<ul style="margin-left: 1em">';
 								foreach ( $subscopes as $subscope => $true ) {
 									if ( ! isset( $scope_explanations[ $main_scope . ':' . $subscope ] ) ) {

--- a/includes/oauth2/class-authenticate-handler.php
+++ b/includes/oauth2/class-authenticate-handler.php
@@ -21,7 +21,8 @@ class Authenticate_Handler {
 		if ( ! is_user_logged_in() ) {
 			auth_redirect();
 		}
-		$app = Mastodon_App::get_by_client_id( $_GET['client_id'] );
+		$client_id = isset( $_GET['client_id'] ) ? sanitize_text_field( wp_unslash( $_GET['client_id'] ) ) : '';
+		$app = Mastodon_App::get_by_client_id( $client_id );
 		if ( is_wp_error( $app ) ) {
 			$response->setStatusCode( 404 );
 
@@ -30,13 +31,15 @@ class Authenticate_Handler {
 
 		$client_name = $app->get_client_name();
 
-		$redirect_uri = $app->check_redirect_uri( $_GET['redirect_uri'] );
+		$redirect_uri = isset( $_GET['redirect_uri'] ) ? sanitize_text_field( wp_unslash( $_GET['redirect_uri'] ) ) : '';
+		$redirect_uri = $app->check_redirect_uri( $redirect_uri );
 		if ( is_wp_error( $redirect_uri ) ) {
 			return $redirect_uri;
 		}
 
 		$scopes = array();
-		foreach ( explode( ' ', $_GET['scope'] ) as $scope ) {
+
+		foreach ( explode( ' ', $_GET['scope'] ) as $scope ) { // phpcs:ignore
 			if ( $app->has_scope( $scope ) ) {
 				$scopes[] = $scope;
 			}

--- a/includes/oauth2/class-authorization-code-storage.php
+++ b/includes/oauth2/class-authorization-code-storage.php
@@ -243,7 +243,7 @@ class Authorization_Code_Storage implements AuthorizationCodeInterface {
 				'taxonomy'   => self::TAXONOMY,
 				'hide_empty' => false,
 				'fields'     => 'ids',
-				'meta_query' => array(
+				'meta_query' => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 					array(
 						'key'     => 'expires',
 						'value'   => time(),

--- a/includes/oauth2/class-mastodon-app-storage.php
+++ b/includes/oauth2/class-mastodon-app-storage.php
@@ -94,11 +94,13 @@ class Mastodon_App_Storage implements ClientCredentialsInterface {
 		$client = $this->get( $client_id );
 		if ( is_wp_error( $client ) && get_option( 'mastodon_api_auto_app_reregister' ) ) {
 			$term = wp_insert_term( $client_id, Mastodon_App::TAXONOMY );
+			$redirect_uri = isset( $_REQUEST['redirect_uri'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['redirect_uri'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
+			$scope = isset( $_REQUEST['scope'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['scope'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
 
 			$app_metadata = array(
-				'client_name'   => preg_replace( '/[^a-z0-9-]/', ' ', wp_parse_url( $_REQUEST['redirect_uri'], PHP_URL_HOST ) ) . ' (auto-generated)',
-				'redirect_uris' => array( $_REQUEST['redirect_uri'] ),
-				'scopes'        => $_REQUEST['scope'],
+				'client_name'   => preg_replace( '/[^a-z0-9-]/', ' ', wp_parse_url( $redirect_uri, PHP_URL_HOST ) ) . ' (auto-generated)',
+				'redirect_uris' => array( $redirect_uri ),
+				'scopes'        => $scope,
 			);
 
 			$post_formats = get_option( 'mastodon_api_default_post_formats', array() );

--- a/includes/oauth2/class-token-handler.php
+++ b/includes/oauth2/class-token-handler.php
@@ -25,7 +25,7 @@ class Token_Handler {
 		$this->server = $server;
 	}
 
-	public function handle( Request $request, Response $response ) {
+	public function handle( Request $request, Response $response ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		return $this->server->handleTokenRequest( $request );
 	}
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -4,6 +4,8 @@
 
 	<config name="text_domain" value="enable-mastodon-apps" />
 
+	<rule ref="WordPress" />
+
 	<rule ref="WordPress-Core">
 		<exclude name="Generic.Formatting.MultipleStatementAlignment.NotSameWarning" />
 		<exclude name="WordPress.PHP.StrictInArray.MissingTrueStrict" />
@@ -16,6 +18,14 @@
 
 	<rule ref="WordPress.Files.FileName.InvalidClassFileName">
 		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
+
+	<rule ref="WordPress.Security">
+		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
+
+	<rule ref="WordPress">
+		<exclude-pattern>bin/extract-hooks.php</exclude-pattern>
 	</rule>
 
 	<rule ref="WordPress.Security.EscapeOutput">

--- a/templates/admin-header.php
+++ b/templates/admin-header.php
@@ -111,7 +111,9 @@ function td_timestamp( $timestamp, $strikethrough_past = false ) {
 <hr class="wp-header-end">
 <?php
 if ( isset( $_GET['success'] ) ) {
+	// phpcs:ignore
+	$success = santize_text_field( wp_unslash( $_GET['success'] ) );
 	?>
-	<div class="notice notice-success is-dismissible"><p><?php echo esc_html( wp_unslash( $_GET['success'] ) ); ?></p></div>
+	<div class="notice notice-success is-dismissible"><p><?php echo esc_html( $success ); ?></p></div>
 	<?php
 }

--- a/templates/admin-header.php
+++ b/templates/admin-header.php
@@ -29,7 +29,7 @@ function output_request_log( $request, $rest_nonce ) {
 		echo '</summary>';
 		echo '<pre style="padding-left: 1em; border-left: 3px solid #999; margin: 0">';
 		foreach ( $meta as $key => $value ) {
-			echo esc_html( $key ), ' ', esc_html( var_export( $value, true ) ), '<br/>';
+			echo esc_html( $key ), ' ', esc_html( var_export( $value, true ) ), '<br/>'; // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
 		}
 		echo '</pre>';
 		echo '</details>';
@@ -110,9 +110,8 @@ function td_timestamp( $timestamp, $strikethrough_past = false ) {
 </div>
 <hr class="wp-header-end">
 <?php
-if ( isset( $_GET['success'] ) ) {
-	// phpcs:ignore
-	$success = santize_text_field( wp_unslash( $_GET['success'] ) );
+if ( isset( $_GET['success'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	$success = santize_text_field( wp_unslash( $_GET['success'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 	?>
 	<div class="notice notice-success is-dismissible"><p><?php echo esc_html( $success ); ?></p></div>
 	<?php

--- a/templates/admin-header.php
+++ b/templates/admin-header.php
@@ -3,7 +3,7 @@
 
 function output_request_log( $request, $rest_nonce ) {
 	$date = \DateTimeImmutable::createFromFormat( 'U.u', $request['timestamp'] );
-	$url = add_query_arg(
+	$url  = add_query_arg(
 		array(
 			'_wpnonce' => $rest_nonce,
 			'_pretty'  => 1,

--- a/templates/app.php
+++ b/templates/app.php
@@ -11,10 +11,10 @@ use Enable_Mastodon_Apps\Mastodon_App;
 	)
 );
 
-$rest_nonce = wp_create_nonce( 'wp_rest' );
+$rest_nonce  = wp_create_nonce( 'wp_rest' );
 $_post_types = \get_post_types( array( 'show_ui' => true ), 'objects' );
-$app = $args['app'];
-$confirm = esc_html(
+$app         = $args['app'];
+$confirm     = esc_html(
 	sprintf(
 	// translators: %s is the app name.
 		__( 'Are you sure you want to delete %s?', 'enable-mastodon-apps' ),

--- a/templates/app.php
+++ b/templates/app.php
@@ -121,7 +121,7 @@ $confirm     = esc_html(
 					<td>
 						<select name="create_post_type">
 						<?php
-						foreach ( $_post_types as $post_type ) :
+						foreach ( $_post_types as $post_type ) : // phpcs:ignore
 							?>
 								<option value="<?php echo esc_attr( $post_type->name ); ?>" <?php selected( $post_type->name, $app->get_create_post_type() ); ?>><?php echo esc_html( $post_type->labels->singular_name ); ?></option>
 							<?php endforeach; ?>
@@ -135,7 +135,7 @@ $confirm     = esc_html(
 					<th scope="row" class="view-post-type"><?php esc_html_e( 'Show these post types', 'enable-mastodon-apps' ); ?></th>
 					<td>
 						<fieldset>
-						<?php foreach ( $_post_types as $post_type ) : ?>
+						<?php foreach ( $_post_types as $post_type ) : /* phpcs:ignore */ ?>
 							<label><input type="checkbox" name="view_post_types[]" value="<?php echo esc_attr( $post_type->name ); ?>"<?php checked( in_array( $post_type->name, $app->get_view_post_types(), true ) ); ?> /> <?php echo esc_html( $post_type->label ); ?></label>
 						<?php endforeach; ?>
 						</fieldset>
@@ -196,7 +196,7 @@ $confirm     = esc_html(
 				foreach ( $args['tokens'] as $token => $data ) {
 					$user = 'app-level';
 					if ( $data['user_id'] ) {
-						$userdata = get_user_by( 'ID', $data['user_id'] );
+						$userdata = get_user_by( 'ID', $data['user_id'] ); // phpcs:ignore
 						if ( $userdata ) {
 							if ( is_wp_error( $userdata ) ) {
 								$user = $userdata->get_error_message();

--- a/templates/debug.php
+++ b/templates/debug.php
@@ -173,7 +173,7 @@ $rest_nonce = wp_create_nonce( 'wp_rest' );
 					foreach ( $tokens as $token => $data ) {
 						$user = 'app-level';
 						if ( $data['user_id'] ) {
-							$userdata = get_user_by( 'ID', $data['user_id'] );
+							$userdata = get_user_by( 'ID', $data['user_id'] ); // phpcs:ignore
 							if ( $userdata ) {
 								if ( is_wp_error( $userdata ) ) {
 									$user = $userdata->get_error_message();

--- a/templates/debug.php
+++ b/templates/debug.php
@@ -64,7 +64,7 @@ $rest_nonce = wp_create_nonce( 'wp_rest' );
 		?>
 		<h2><?php esc_html_e( 'Recently Logged Requests', 'enable-mastodon-apps' ); ?></h2>
 		<?php
-		$debug_start_time = \DateTimeImmutable::createFromFormat( 'U', time() - HOUR_IN_SECONDS );
+		$debug_start_time  = \DateTimeImmutable::createFromFormat( 'U', time() - HOUR_IN_SECONDS );
 		$all_last_requests = array();
 		foreach ( \Enable_Mastodon_Apps\Mastodon_App::get_all() as $app ) {
 			$last_requests = $app->get_last_requests();

--- a/templates/debug.php
+++ b/templates/debug.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 \load_template(
 	__DIR__ . '/admin-header.php',
 	true,

--- a/templates/registered-apps.php
+++ b/templates/registered-apps.php
@@ -1,6 +1,7 @@
 <?php
 
 use Enable_Mastodon_Apps\Mastodon_App;
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 
 \load_template(
 	__DIR__ . '/admin-header.php',

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 \load_template(
 	__DIR__ . '/admin-header.php',
 	true,

--- a/templates/welcome.php
+++ b/templates/welcome.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 \load_template(
 	__DIR__ . '/admin-header.php',
 	true,

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -62,7 +62,7 @@ add_filter(
 add_filter(
 	'http_request_args',
 	function ( $args, $url ) {
-		if ( in_array( parse_url( $url, PHP_URL_HOST ), array( 'me.local', 'friend.local', 'mastodon.local' ) ) ) {
+		if ( in_array( wp_parse_url( $url, PHP_URL_HOST ), array( 'me.local', 'friend.local', 'mastodon.local' ) ) ) {
 			$args['reject_unsafe_urls'] = false;
 		}
 		return $args;
@@ -93,7 +93,7 @@ if ( defined( 'TESTS_VERBOSE' ) && TESTS_VERBOSE ) {
 			if ( is_numeric( $meta_value ) || is_string( $meta_value ) ) {
 				echo $meta_value, PHP_EOL;
 			} else {
-				var_dump( $meta_value );
+				var_dump( $meta_value ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_dump
 			}
 		},
 		10,

--- a/tests/class-mastodon-api-testcase.php
+++ b/tests/class-mastodon-api-testcase.php
@@ -128,7 +128,7 @@ class Mastodon_API_TestCase extends \WP_UnitTestCase {
 
 		add_filter(
 			'default_option_mastodon_api_default_post_formats',
-			function ( $post_formats ) {
+			function ( $post_formats ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 				return array( 'status' );
 			},
 			20

--- a/tests/test-accounts-endpoint.php
+++ b/tests/test-accounts-endpoint.php
@@ -15,10 +15,6 @@ namespace Enable_Mastodon_Apps;
 class AccountsEndpoint_Test extends Mastodon_API_TestCase {
 	private $external_account = 'alex@kirk.at';
 
-	public function set_up() {
-		parent::set_up();
-	}
-
 	public function mastodon_api_webfinger( $body, $url ) {
 		if ( $url !== $this->external_account ) {
 			return $body;
@@ -55,7 +51,7 @@ class AccountsEndpoint_Test extends Mastodon_API_TestCase {
 
 		$this->assertEquals( 200, $response->get_status() );
 
-		$data = json_decode( json_encode( $response->get_data() ), true );
+		$data = json_decode( wp_json_encode( $response->get_data() ), true );
 		$userdata = get_userdata( $this->administrator );
 
 		$this->assertIsString( $data['id'] );

--- a/tests/test-ids.php
+++ b/tests/test-ids.php
@@ -34,14 +34,14 @@ class Ids_Test extends Mastodon_API_TestCase {
 		$response = $this->dispatch( $request );
 
 		$this->assertEquals( 200, $response->get_status() );
-		$data = json_decode( json_encode( $response->get_data() ), true );
+		$data = json_decode( wp_json_encode( $response->get_data() ), true );
 		$this->assertEquals( $this->administrator, $data['id'] );
 
 		add_filter( 'mastodon_api_account', array( $this, 'account_id_mapper' ), 20, 2 );
 		$response = $this->dispatch( $request );
 
 		$this->assertEquals( 200, $response->get_status() );
-		$data = json_decode( json_encode( $response->get_data() ), true );
+		$data = json_decode( wp_json_encode( $response->get_data() ), true );
 		$this->assertTrue( $data['id'] > 1e10 );
 		$this->mapped_id = $data['id'];
 
@@ -50,7 +50,7 @@ class Ids_Test extends Mastodon_API_TestCase {
 		$response = $this->dispatch( $request );
 
 		$this->assertEquals( 200, $response->get_status() );
-		$data = json_decode( json_encode( $response->get_data() ), true );
+		$data = json_decode( wp_json_encode( $response->get_data() ), true );
 		$this->assertEquals( $this->mapped_id, $data['id'] );
 	}
 }

--- a/tests/test-media-endpoint.php
+++ b/tests/test-media-endpoint.php
@@ -23,7 +23,7 @@ class MediaEndpoint_Test extends Mastodon_API_TestCase {
 
 	public function tearDown(): void {
 		if ( file_exists( $this->test_file ) ) {
-			unlink( $this->test_file );
+			wp_delete_file( $this->test_file );
 		}
 
 		$uploads  = wp_upload_dir();
@@ -31,7 +31,7 @@ class MediaEndpoint_Test extends Mastodon_API_TestCase {
 		$objects  = new \RecursiveIteratorIterator( $iterator );
 		foreach ( $objects as $name => $object ) {
 			if ( is_file( $name ) ) {
-				unlink( $name );
+				wp_delete_file( $name );
 			}
 		}
 
@@ -55,7 +55,7 @@ class MediaEndpoint_Test extends Mastodon_API_TestCase {
 		$request->set_file_params(
 			array(
 				'file' => array(
-					'file'     => file_get_contents( $this->test_file ),
+					'file'     => file_get_contents( $this->test_file ), // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 					'name'     => 'fox.jpg',
 					'size'     => filesize( $this->test_file ),
 					'tmp_name' => $this->test_file,
@@ -74,7 +74,7 @@ class MediaEndpoint_Test extends Mastodon_API_TestCase {
 		$request->set_file_params(
 			array(
 				'file' => array(
-					'file'     => file_get_contents( $this->test_file ),
+					'file'     => file_get_contents( $this->test_file ), // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 					'name'     => 'fox.jpg',
 					'size'     => filesize( $this->test_file ),
 					'tmp_name' => $this->test_file,

--- a/tests/test-statuses-endpoint.php
+++ b/tests/test-statuses-endpoint.php
@@ -77,7 +77,7 @@ class StatusesEndpoint_Test extends Mastodon_API_TestCase {
 	public function test_submit_status_basic_status() {
 		add_filter(
 			'mastodon_api_new_post_format',
-			function ( $format ) {
+			function ( $format ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 				return 'status';
 			}
 		);
@@ -97,7 +97,7 @@ class StatusesEndpoint_Test extends Mastodon_API_TestCase {
 	public function test_submit_status_multiline_status() {
 		add_filter(
 			'mastodon_api_new_post_format',
-			function ( $format ) {
+			function ( $format ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 				return 'status';
 			}
 		);

--- a/tests/test-third-party-interactions.php
+++ b/tests/test-third-party-interactions.php
@@ -40,7 +40,7 @@ class ThirdPartyInteraction_Test extends Mastodon_API_TestCase {
 	 */
 	public function test_fluentcrm() {
 		global $current_user;
-		$current_user = null;
+		$current_user = null; // phpcs:ignore
 		$request = new \WP_REST_Request( 'GET', '/fluentcrm/v2/tags' );
 		$_SERVER['HTTP_AUTHORIZATION'] = 'Basic ' . base64_encode( 'a:b' );
 		global $wp_rest_server;

--- a/tests/test-third-party-interactions.php
+++ b/tests/test-third-party-interactions.php
@@ -42,7 +42,7 @@ class ThirdPartyInteraction_Test extends Mastodon_API_TestCase {
 		global $current_user;
 		$current_user = null; // phpcs:ignore
 		$request = new \WP_REST_Request( 'GET', '/fluentcrm/v2/tags' );
-		$_SERVER['HTTP_AUTHORIZATION'] = 'Basic ' . base64_encode( 'a:b' );
+		$_SERVER['HTTP_AUTHORIZATION'] = 'Basic ' . base64_encode( 'a:b' ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 		global $wp_rest_server;
 		ob_start();
 		$response = $wp_rest_server->dispatch( $request );

--- a/tests/test-timeline-endpoint.php
+++ b/tests/test-timeline-endpoint.php
@@ -22,7 +22,7 @@ class TimelineEndpoint_Test extends Mastodon_API_TestCase {
 	public function test_timelines_home() {
 		$request = $this->api_request( 'GET', '/api/v1/timelines/home' );
 		$response = $this->dispatch_authenticated( $request );
-		$data = json_decode( json_encode( $response->get_data() ), true );
+		$data = json_decode( wp_json_encode( $response->get_data() ), true );
 
 		$this->assertArrayHasKey( 0, $data );
 		$this->assertArrayHasKey( 'id', $data[0] );
@@ -64,7 +64,7 @@ class TimelineEndpoint_Test extends Mastodon_API_TestCase {
 
 		$request = $this->api_request( 'GET', '/api/v1/timelines/home' );
 		$response = $this->dispatch_authenticated( $request );
-		$data = json_decode( json_encode( $response->get_data() ), true );
+		$data = json_decode( wp_json_encode( $response->get_data() ), true );
 
 		$this->assertArrayHasKey( 'prev', $response->get_links() );
 		$this->assertStringContainsString( 'min_id=' . $third_post->ID, $response->get_links()['prev'][0]['href'] );
@@ -81,7 +81,7 @@ class TimelineEndpoint_Test extends Mastodon_API_TestCase {
 		$request = $this->api_request( 'GET', '/api/v1/timelines/home' );
 		$request->set_param( 'min_id', $first_post->ID );
 		$response = $this->dispatch_authenticated( $request );
-		$data = json_decode( json_encode( $response->get_data() ), true );
+		$data = json_decode( wp_json_encode( $response->get_data() ), true );
 
 		$this->assertArrayHasKey( 'next', $response->get_links() );
 		$this->assertStringContainsString( 'max_id=' . $second_post->ID, $response->get_links()['next'][0]['href'] );
@@ -97,7 +97,7 @@ class TimelineEndpoint_Test extends Mastodon_API_TestCase {
 		$request = $this->api_request( 'GET', '/api/v1/timelines/home' );
 		$request->set_param( 'max_id', $second_post->ID );
 		$response = $this->dispatch_authenticated( $request );
-		$data = json_decode( json_encode( $response->get_data() ), true );
+		$data = json_decode( wp_json_encode( $response->get_data() ), true );
 
 		$this->assertArrayHasKey( 'next', $response->get_links() );
 		$this->assertStringContainsString( 'max_id=' . $first_post->ID, $response->get_links()['next'][0]['href'] );
@@ -112,7 +112,7 @@ class TimelineEndpoint_Test extends Mastodon_API_TestCase {
 		$request->set_param( 'min_id', $first_post->ID );
 		$request->set_param( 'max_id', $third_post->ID );
 		$response = $this->dispatch_authenticated( $request );
-		$data = json_decode( json_encode( $response->get_data() ), true );
+		$data = json_decode( wp_json_encode( $response->get_data() ), true );
 
 		$this->assertArrayHasKey( 'next', $response->get_links() );
 		$this->assertStringContainsString( 'max_id=' . $second_post->ID, $response->get_links()['next'][0]['href'] );
@@ -127,7 +127,7 @@ class TimelineEndpoint_Test extends Mastodon_API_TestCase {
 		$request = $this->api_request( 'GET', '/api/v1/timelines/home' );
 		$request->set_param( 'limit', 1 );
 		$response = $this->dispatch_authenticated( $request );
-		$data = json_decode( json_encode( $response->get_data() ), true );
+		$data = json_decode( wp_json_encode( $response->get_data() ), true );
 
 		$this->assertArrayHasKey( 'next', $response->get_links() );
 		$this->assertStringContainsString( 'max_id=' . $third_post->ID, $response->get_links()['next'][0]['href'] );
@@ -142,7 +142,7 @@ class TimelineEndpoint_Test extends Mastodon_API_TestCase {
 		$request = $this->api_request( 'GET', '/api/v1/timelines/home' );
 		$request->set_param( 'limit', 2 );
 		$response = $this->dispatch_authenticated( $request );
-		$data = json_decode( json_encode( $response->get_data() ), true );
+		$data = json_decode( wp_json_encode( $response->get_data() ), true );
 
 		$this->assertCount( 2, $data );
 		$this->assertArrayHasKey( 0, $data );
@@ -154,7 +154,7 @@ class TimelineEndpoint_Test extends Mastodon_API_TestCase {
 		$request = $this->api_request( 'GET', '/api/v1/timelines/home' );
 		$request->set_param( 'limit', 3 );
 		$response = $this->dispatch_authenticated( $request );
-		$data = json_decode( json_encode( $response->get_data() ), true );
+		$data = json_decode( wp_json_encode( $response->get_data() ), true );
 
 		$this->assertArrayHasKey( 'next', $response->get_links() );
 		$this->assertStringContainsString( 'max_id=' . $first_post->ID, $response->get_links()['next'][0]['href'] );
@@ -172,7 +172,7 @@ class TimelineEndpoint_Test extends Mastodon_API_TestCase {
 		$request = $this->api_request( 'GET', '/api/v1/timelines/home' );
 		$request->set_param( 'limit', 5 );
 		$response = $this->dispatch_authenticated( $request );
-		$data = json_decode( json_encode( $response->get_data() ), true );
+		$data = json_decode( wp_json_encode( $response->get_data() ), true );
 
 		$this->assertArrayHasKey( 'next', $response->get_links() );
 		$this->assertStringContainsString( 'max_id=' . $first_post->ID, $response->get_links()['next'][0]['href'] );
@@ -193,13 +193,13 @@ class TimelineEndpoint_Test extends Mastodon_API_TestCase {
 			$request = $this->api_request( 'GET', '/api/v1/timelines/home' );
 			$request->set_param( 'limit', 1 );
 			if ( $response && isset( $response->get_links()['next'] ) ) {
-				parse_str( parse_url( $response->get_links()['next'][0]['href'], PHP_URL_QUERY ), $query );
+				parse_str( wp_parse_url( $response->get_links()['next'][0]['href'], PHP_URL_QUERY ), $query );
 				foreach ( $query as $key => $value ) {
 					$request->set_param( $key, $value );
 				}
 			}
 			$response = $this->dispatch_authenticated( $request );
-			$data = json_decode( json_encode( $response->get_data() ), true );
+			$data = json_decode( wp_json_encode( $response->get_data() ), true );
 
 			if ( empty( $pages ) ) {
 				$this->assertCount( 0, $data );
@@ -220,7 +220,7 @@ class TimelineEndpoint_Test extends Mastodon_API_TestCase {
 			$request = $this->api_request( 'GET', '/api/v1/timelines/home' );
 			$request->set_param( 'limit', 1 );
 			if ( $response && isset( $response->get_links()['prev'] ) ) {
-				parse_str( parse_url( $response->get_links()['prev'][0]['href'], PHP_URL_QUERY ), $query );
+				parse_str( wp_parse_url( $response->get_links()['prev'][0]['href'], PHP_URL_QUERY ), $query );
 				foreach ( $query as $key => $value ) {
 					$request->set_param( $key, $value );
 				}
@@ -228,7 +228,7 @@ class TimelineEndpoint_Test extends Mastodon_API_TestCase {
 				$request->set_param( 'max_id', $second_post->ID );
 			}
 			$response = $this->dispatch_authenticated( $request );
-			$data = json_decode( json_encode( $response->get_data() ), true );
+			$data = json_decode( wp_json_encode( $response->get_data() ), true );
 
 			if ( empty( $pages ) ) {
 				$this->assertCount( 0, $data );


### PR DESCRIPTION
I used `phpcs:ignore` perhaps a little too liberally, and phpcs may be annoying now with the full WP ruleset, but we can't ship to dotcom without some lint fixes.

I'm going to try to find a way to bypass lint for `vendor/bshaffer/oauth2-server-php` on wpcom though, because its code style is so radically different, although I did see indication that it's not receiving updates anyway?