### PR TITLE
Show all comments by others as notifications

### DIFF
--- a/includes/class-comment-cpt.php
+++ b/includes/class-comment-cpt.php
@@ -105,7 +105,7 @@ class Comment_CPT {
 		}
 
 		$post_data = array(
-			'post_title'    => 'Comment',
+			'post_title'    => '',
 			'post_content'  => $comment->comment_content,
 			'post_author'   => $comment->user_id,
 			'post_status'   => 'publish',

--- a/includes/handler/class-handler.php
+++ b/includes/handler/class-handler.php
@@ -21,13 +21,17 @@ class Handler {
 		if ( $limit < 1 ) {
 			$limit = 20;
 		}
+
 		$app = Mastodon_App::get_current_app();
-		$post_types = array( 'post' );
-		if ( $app ) {
-			$post_types = $app->get_view_post_types();
+
+		if ( ! isset( $args['post_type'] ) ) {
+			$post_types = array( 'post' );
+			if ( $app ) {
+				$post_types = $app->get_view_post_types();
+			}
+			$args['post_type'] = array_merge( $post_types, array( Mastodon_API::CPT ) );
 		}
 		$args['posts_per_page']   = $limit;
-		$args['post_type']        = array_merge( $post_types, array( Mastodon_API::CPT ) );
 		$args['suppress_filters'] = false;
 		$args['post_status']      = array( 'publish', 'private' );
 
@@ -41,7 +45,6 @@ class Handler {
 			}
 		}
 
-		$app = Mastodon_App::get_current_app();
 		if ( $app ) {
 			$args = $app->modify_wp_query_args( $args );
 		}

--- a/includes/handler/class-notification.php
+++ b/includes/handler/class-notification.php
@@ -9,6 +9,7 @@
 
 namespace Enable_Mastodon_Apps\Handler;
 
+use Enable_Mastodon_Apps\Comment_CPT;
 use Enable_Mastodon_Apps\Handler\Handler;
 use Enable_Mastodon_Apps\Entity\Notification as Notification_Entity;
 
@@ -120,13 +121,37 @@ class Notification extends Handler {
 		);
 		$exclude_types = $request->get_param( 'exclude_types' );
 		if ( ( ! is_array( $types ) || in_array( 'mention', $types, true ) ) && ( ! is_array( $exclude_types ) || ! in_array( 'mention', $exclude_types, true ) ) ) {
-			$external_user = apply_filters( 'mastodon_api_external_mentions_user', null );
-			if ( ! $external_user || ! ( $external_user instanceof \WP_User ) ) {
+			/**
+			 * Get the WP_Query arguments for fetching notifications.
+			 *
+			 * @param array $args WP_Query arguments.
+			 * @param string $type Type of notifications.
+			 * @param object $request Request object from WP.
+			 * @return array The modified WP_Query arguments.
+			 *
+			* Example:
+			* ```php
+			* add_filter( 'mastodon_api_get_notifications_query_args', function( $args, $type ) {
+			*     if ( $type === 'notification' ) {
+			*         $args['post_type'] = 'notification';
+			*     }
+			*     return $args;
+			* } );
+			* ```
+			 */
+			$args = apply_filters(
+				'mastodon_api_get_notifications_query_args',
+				array(
+					'post_type'      => Comment_CPT::CPT,
+					'author__not_in' => array( get_current_user_id() ),
+				),
+				'mention',
+				$request
+			);
+			if ( empty( $args ) ) {
 				return array();
 			}
-			$args                   = $this->get_posts_query_args( array(), $request );
 			$args['posts_per_page'] = $limit + 2;
-			$args['author']         = $external_user->ID;
 
 			$notification_dismissed_tag = get_term_by( 'slug', apply_filters( 'mastodon_api_notification_dismissed_tag', 'notification-dismissed' ), 'post_tag' );
 			if ( $notification_dismissed_tag ) {


### PR DESCRIPTION
This should also make the notifications useful for someone who doesn't use the Friends plugin, before this it revolved around the external mentions user but this should be really the business of the Friends plugin to modify that query if necessary.