### PR TITLE
Make token storage taxonomies private

### DIFF
--- a/includes/class-mastodon-api.php
+++ b/includes/class-mastodon-api.php
@@ -1412,7 +1412,7 @@ class Mastodon_API {
 		// A helpful shim in case this is PHP <=5.6 when php://input could only be accessed once.
 		static $input;
 		if ( ! isset( $input ) ) {
-			$input = file_get_contents( 'php://input' ); // phcs:ignore .
+			$input = file_get_contents( 'php://input' ); // phpcs:ignore
 		}
 
 		return $input;

--- a/includes/oauth2/class-access-token-storage.php
+++ b/includes/oauth2/class-access-token-storage.php
@@ -28,7 +28,7 @@ class Access_Token_Storage implements AccessTokenInterface {
 		add_action( 'mastodon_api_cron_hook', array( $this, 'cleanupOldCodes' ) );
 
 		// Store the access tokens in a taxonomy.
-		register_taxonomy( self::TAXONOMY, null, [ 'public' => false ] );
+		register_taxonomy( self::TAXONOMY, null, array( 'public' => false ) );
 		foreach ( self::$access_token_data as $key => $type ) {
 			register_term_meta(
 				self::TAXONOMY,

--- a/includes/oauth2/class-access-token-storage.php
+++ b/includes/oauth2/class-access-token-storage.php
@@ -28,7 +28,7 @@ class Access_Token_Storage implements AccessTokenInterface {
 		add_action( 'mastodon_api_cron_hook', array( $this, 'cleanupOldCodes' ) );
 
 		// Store the access tokens in a taxonomy.
-		register_taxonomy( self::TAXONOMY, null );
+		register_taxonomy( self::TAXONOMY, null, [ 'public' => false ] );
 		foreach ( self::$access_token_data as $key => $type ) {
 			register_term_meta(
 				self::TAXONOMY,

--- a/includes/oauth2/class-authorization-code-storage.php
+++ b/includes/oauth2/class-authorization-code-storage.php
@@ -29,7 +29,7 @@ class Authorization_Code_Storage implements AuthorizationCodeInterface {
 		add_action( 'mastodon_api_cron_hook', array( $this, 'cleanupOldCodes' ) );
 
 		// Store the authorization codes in a taxonomy.
-		register_taxonomy( self::TAXONOMY, null, [ 'public' => false ] );
+		register_taxonomy( self::TAXONOMY, null, array( 'public' => false ) );
 		foreach ( self::$authorization_code_data as $key => $type ) {
 			register_term_meta(
 				self::TAXONOMY,

--- a/includes/oauth2/class-authorization-code-storage.php
+++ b/includes/oauth2/class-authorization-code-storage.php
@@ -29,7 +29,7 @@ class Authorization_Code_Storage implements AuthorizationCodeInterface {
 		add_action( 'mastodon_api_cron_hook', array( $this, 'cleanupOldCodes' ) );
 
 		// Store the authorization codes in a taxonomy.
-		register_taxonomy( self::TAXONOMY, null );
+		register_taxonomy( self::TAXONOMY, null, [ 'public' => false ] );
 		foreach ( self::$authorization_code_data as $key => $type ) {
 			register_term_meta(
 				self::TAXONOMY,

--- a/vendor/bshaffer/oauth2-server-php/src/OAuth2/Request.php
+++ b/vendor/bshaffer/oauth2-server-php/src/OAuth2/Request.php
@@ -144,7 +144,7 @@ class Request implements RequestInterface
         }
 
         if (null === $this->content) {
-            $this->content = file_get_contents('php://input');
+            $this->content = file_get_contents('php://input'); // phpcs:ignore
         }
 
         return $this->content;


### PR DESCRIPTION
We can only store `termmeta` on private taxonomies on wpcom. 

Also a couple of `phpcs` loose ends while I'm here!