### PR TITLE
Adds urls[steaming_api] to instance_v1

### DIFF
--- a/includes/entity/class-instance-v1.php
+++ b/includes/entity/class-instance-v1.php
@@ -38,6 +38,7 @@ class Instance_V1 extends Entity {
 		'configuration'     => 'array',
 		'contact_account'   => 'Account?',
 		'rules'             => 'array',
+		'urls'              => 'array',
 	);
 
 	/**

--- a/includes/handler/class-instance.php
+++ b/includes/handler/class-instance.php
@@ -74,6 +74,9 @@ class Instance extends Handler {
 				'enabled' => false,
 			),
 		);
+		$instance->urls       = array(
+			'streaming_api' => null,
+		);
 
 		return $instance;
 	}


### PR DESCRIPTION
This adds a `urls[steaming_api] = null` to the instance_v1 endpoint  

Re: #169 

Tested, I was able to login to a tunneled local instance and login with Feditext