### PR TITLE
Add an option to convert post content to blocks

### DIFF
--- a/templates/app.php
+++ b/templates/app.php
@@ -146,6 +146,15 @@ $confirm     = esc_html(
 						</p>
 					</td>
 				</tr>
+				<tr>
+					<th scope="row"><?php esc_html_e( 'Options', 'enable-mastodon-apps' ); ?></th>
+					<td>
+						<label><input type="checkbox" name="disable_blocks" value="1" <?php checked( $app->get_disable_blocks() ); ?> /> <?php esc_html_e( 'Disable automatic conversion to blocks', 'enable-mastodon-apps' ); ?></label>
+						<p class="description">
+							<span><?php esc_html_e( 'If checked, post content will not be converted to blocks.', 'enable-mastodon-apps' ); ?></span>
+						</p>
+					</td>
+				</tr>
 			</tbody>
 		</table>
 


### PR DESCRIPTION
Fixes #172.

By default now post content will be converted to blocks. It can be disabled on an app by app basis:


![Screenshot 2024-09-26 at 16 39 04](https://github.com/user-attachments/assets/e0254898-1891-4b33-ab94-d5f4898e7ea0)

