### PR TITLE
Fix wp:image block created for attachments

### DIFF
--- a/includes/handler/class-status.php
+++ b/includes/handler/class-status.php
@@ -308,7 +308,7 @@ class Status extends Handler {
 						'sizeSlug' => 'large',
 					);
 					$post_data['post_content'] .= '<!-- wp:image ' . wp_json_encode( $meta_json ) . ' -->' . PHP_EOL;
-					$post_data['post_content'] .= '<figure class="wp-block-image"><img src="' . esc_url( wp_get_attachment_url( $media_id ) ) . '" width="' . esc_attr( $attachment['width'] ) . '" height="' . esc_attr( $attachment['height'] ) . '" alt="" class="wp-image-' . esc_attr( $media_id ) . '"/></figure>' . PHP_EOL;
+					$post_data['post_content'] .= '<figure class="wp-block-image"><img src="' . esc_url( wp_get_attachment_url( $media_id ) ) . '" alt="" class="wp-image-' . esc_attr( $media_id ) . '"/></figure>' . PHP_EOL;
 					$post_data['post_content'] .= '<!-- /wp:image -->' . PHP_EOL;
 				} elseif ( \wp_attachment_is( 'video', $media_id ) ) {
 					$post_data['post_content'] .= PHP_EOL;

--- a/includes/handler/class-status.php
+++ b/includes/handler/class-status.php
@@ -304,7 +304,7 @@ class Status extends Handler {
 				if ( \wp_attachment_is( 'image', $media_id ) ) {
 					$post_data['post_content'] .= PHP_EOL;
 					$meta_json                  = array(
-						'id'       => $media_id,
+						'id'       => intval( $media_id ),
 						'sizeSlug' => 'large',
 					);
 					$post_data['post_content'] .= '<!-- wp:image ' . wp_json_encode( $meta_json ) . ' -->' . PHP_EOL;


### PR DESCRIPTION
The code currently produced creates an invalid block:
```
<!-- wp:image {"id":"10040","sizeSlug":"large"} -->
<figure class="wp-block-image"><img src="https://example.com/wp-content/uploads/sites/4/2024/11/Tusky-Test_1731495973955_M8D7KUL8U8-scaled.jpg" width="2560" height="1920" alt="" class="wp-image-10040"/></figure>
<!-- /wp:image -->
```

![Screenshot 2024-11-13 at 12 14 30](https://github.com/user-attachments/assets/beaea95d-1847-43a3-9b2c-96b7b11f68df)

We need to make the id an integer and remove width and height.

```
<!-- wp:image {"id":10040,"sizeSlug":"large"} -->
<figure class="wp-block-image"><img src="https://example.com/wp-content/uploads/sites/4/2024/11/Tusky-Test_1731495973955_M8D7KUL8U8-scaled.jpg" alt="" class="wp-image-10040"/></figure>
<!-- /wp:image -->
```