### PR TITLE
Improve REST Authentication Error Debugging

### DIFF
--- a/includes/class-mastodon-app.php
+++ b/includes/class-mastodon-app.php
@@ -518,7 +518,15 @@ class Mastodon_App {
 							if ( 'method' === $key && preg_match( '/^[A-Z]{3,15}$/', $value[ $key ] ) ) {
 								continue;
 							}
-							if ( ( 'files' === $key || 'params' === $key || 'json' === $key ) && ! empty( $value[ $key ] ) ) {
+							if (
+								(
+									'files' === $key ||
+									'params' === $key ||
+									'json' === $key ||
+									'errors' === $key
+								) &&
+								! empty( $value[ $key ] )
+							) {
 								continue;
 							}
 							unset( $value[ $key ] );


### PR DESCRIPTION
Before this, API requests that got caught in `rest_authentication_errors` were not logged because they didn't reach the permission_callback.

This adds some extra logging for this.