### PR TITLE
Post through Mastodon Apps to a new post type by default

### DIFF
--- a/.extract-wp-hooks.json
+++ b/.extract-wp-hooks.json
@@ -3,6 +3,7 @@
   "wiki_directory": "../enable-mastodon-apps.wiki",
   "github_blob_url": "https://github.com/akirk/enable-mastodon-apps/blob/main/",
   "ignore_filter": [
-    "rest_api_init"
+    "rest_api_init",
+    "activitypub_process_outbox"
   ]
 }

--- a/enable-mastodon-apps.php
+++ b/enable-mastodon-apps.php
@@ -19,7 +19,7 @@ use OAuth2;
 
 defined( 'ABSPATH' ) || exit;
 define( 'ENABLE_MASTODON_APPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
-define( 'ENABLE_MASTODON_APPS_VERSION', '0.9.9' );
+define( 'ENABLE_MASTODON_APPS_VERSION', '1.0.0' );
 
 require __DIR__ . '/vendor/bshaffer/oauth2-server-php/src/OAuth2/Autoloader.php';
 OAuth2\Autoloader::register();

--- a/includes/class-mastodon-admin.php
+++ b/includes/class-mastodon-admin.php
@@ -132,7 +132,7 @@ class Mastodon_Admin {
 		 *
 		 * This only applies if the user unchekcks: Make posts through Mastodon apps appear on this WordPress
 		 *
-		 * @var string $post_type The default post type.
+		 * @param string $post_type The default post type.
 		 *
 		 * Example:
 		 * ```php

--- a/includes/class-mastodon-admin.php
+++ b/includes/class-mastodon-admin.php
@@ -127,19 +127,35 @@ class Mastodon_Admin {
 			update_option( 'mastodon_api_disable_logins', true );
 		}
 
+		/**
+		 * The default post type for posting from Mastodon apps when the configured to do so.
+		 *
+		 * This only applies if the user unchekcks: Make posts through Mastodon apps appear on this WordPress
+		 *
+		 * @var string $post_type The default post type.
+		 *
+		 * Example:
+		 * ```php
+		 * add_filter( 'mastodon_api_default_post_type', function( $post_type ) {
+		 *    return 'my-own-custom-post-type';
+		 * } );
+		 * ```
+		 */
+		$default_ema_post_type = apply_filters( 'mastodon_api_default_post_type', \Enable_Mastodon_Apps\Mastodon_API::POST_CPT );
+
 		if ( isset( $_POST['mastodon_api_posting_cpt'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
 			update_option( 'mastodon_api_posting_cpt', 'post' );
 
 			$supported_post_types = (array) \get_option( 'activitypub_support_post_types', array( 'post' ) );
-			if ( in_array( \Enable_Mastodon_Apps\Mastodon_API::POST_CPT, $supported_post_types, true ) ) {
-				$supported_post_types = array_diff( $supported_post_types, array( \Enable_Mastodon_Apps\Mastodon_API::POST_CPT ) );
+			if ( in_array( $default_ema_post_type, $supported_post_types, true ) ) {
+				$supported_post_types = array_diff( $supported_post_types, array( $default_ema_post_type ) );
 				\update_option( 'activitypub_support_post_types', $supported_post_types );
 			}
 		} else {
 			delete_option( 'mastodon_api_posting_cpt' );
 
 			$supported_post_types = (array) \get_option( 'activitypub_support_post_types', array( 'post' ) );
-			$supported_post_types[] = \Enable_Mastodon_Apps\Mastodon_API::POST_CPT;
+			$supported_post_types[] = $default_ema_post_type;
 			\update_option( 'activitypub_support_post_types', $supported_post_types );
 		}
 

--- a/includes/class-mastodon-api.php
+++ b/includes/class-mastodon-api.php
@@ -49,7 +49,7 @@ class Mastodon_API {
 		$this->oauth = new Mastodon_OAuth();
 		$this->register_hooks();
 		$this->register_taxonomy();
-		self::register_custom_post_types();
+		$this->register_custom_post_types();
 		new Mastodon_Admin( $this->oauth );
 
 		// Register Handlers.
@@ -169,7 +169,7 @@ class Mastodon_API {
 		register_term_meta( self::REMAP_TAXONOMY, 'meta', array( 'type' => 'string' ) );
 	}
 
-	public static function register_custom_post_types() {
+	public function register_custom_post_types() {
 		$args = array(
 			'labels'       => array(
 				'name'          => 'Mapping',
@@ -195,6 +195,7 @@ class Mastodon_API {
 			'show_in_rest' => false,
 			'rewrite'      => false,
 			'menu_icon'    => 'dashicons-megaphone',
+			'supports'     => array( 'post-formats' ),
 		);
 
 		register_post_type( self::POST_CPT, $args );

--- a/includes/class-mastodon-api.php
+++ b/includes/class-mastodon-api.php
@@ -191,7 +191,7 @@ class Mastodon_API {
 				'singular_name' => __( 'Mastodon Post', 'enable-mastodon-apps' ),
 				'menu_name'     => __( 'Mastodon Posts', 'enable-mastodon-apps' ),
 			),
-			'description'  => __( 'Posted through a Mastodon app', 'enable-mastodon-apps' ),
+			'description'  => __( 'Posted through a Mastodon app.', 'enable-mastodon-apps' ),
 			'public'       => ! get_option( 'mastodon_api_posting_cpt' ),
 			'show_in_rest' => false,
 			'rewrite'      => false,

--- a/includes/class-mastodon-api.php
+++ b/includes/class-mastodon-api.php
@@ -191,6 +191,7 @@ class Mastodon_API {
 				'singular_name' => __( 'Mastodon Post', 'enable-mastodon-apps' ),
 				'menu_name'     => __( 'Mastodon Posts', 'enable-mastodon-apps' ),
 			),
+			'description'  => __( 'Posted through a Mastodon app', 'enable-mastodon-apps' ),
 			'public'       => ! get_option( 'mastodon_api_posting_cpt' ),
 			'show_in_rest' => false,
 			'rewrite'      => false,

--- a/includes/class-mastodon-api.php
+++ b/includes/class-mastodon-api.php
@@ -2150,6 +2150,10 @@ class Mastodon_API {
 		 *
 		 * Example:
 		 * ```php
+		 * add_filter( 'mastodon_api_public_timeline', function( $statuses, $request ) {
+		 *    array_unshift( $statuses, new Entity\Status( array( 'content' => 'Hello World' ) ) );
+		 *    return $statuses;
+		 * } );
 		 * ```
 		 */
 		return \apply_filters( 'mastodon_api_public_timeline', null, $request );

--- a/includes/class-mastodon-app.php
+++ b/includes/class-mastodon-app.php
@@ -661,7 +661,7 @@ class Mastodon_App {
 		$post_formats = apply_filters( 'mastodon_api_new_app_post_formats', $post_formats, $app_metadata );
 		$app_metadata['query_args'] = array( 'post_formats' => $post_formats );
 
-		$app_metadata['create_post_type'] = get_option( 'mastodon_api_posting_cpt', \Enable_Mastodon_Apps\Mastodon_API::POST_CPT );
+		$app_metadata['create_post_type'] = get_option( 'mastodon_api_posting_cpt', apply_filters( 'mastodon_api_default_post_type', \Enable_Mastodon_Apps\Mastodon_API::POST_CPT ) );
 		$view_post_types = array( 'post', 'comment' );
 		if ( ! in_array( $app_metadata['create_post_type'], $view_post_types ) ) {
 			$view_post_types[] = $app_metadata['create_post_type'];

--- a/includes/class-mastodon-app.php
+++ b/includes/class-mastodon-app.php
@@ -658,6 +658,21 @@ class Mastodon_App {
 		);
 
 		$post_formats = get_option( 'mastodon_api_default_post_formats', array() );
+		/**
+		 * Post formats to be enabled for new apps.
+		 *
+		 * @param array $post_formats    The post formats.
+		 *
+		 * @return array The post formats.
+		 *
+		 * Example:
+		 * ```php
+		 * add_filter( 'mastodon_api_new_app_post_formats', function( $post_formats ) {
+		 *    // This will enable standard and aside post formats for new apps.
+		 *    return array( 'standard', 'aside' );
+		 * } );
+		 * ```
+		 */
 		$post_formats = apply_filters( 'mastodon_api_new_app_post_formats', $post_formats, $app_metadata );
 		$app_metadata['query_args'] = array( 'post_formats' => $post_formats );
 
@@ -667,6 +682,21 @@ class Mastodon_App {
 			$view_post_types[] = $app_metadata['create_post_type'];
 		}
 
+		/**
+		 * Standard post types that the app can view.
+		 *
+		 * @param array $view_post_types    The post types.
+		 *
+		 * @return array The post types.
+		 *
+		 * Example:
+		 * ```php
+		 * add_filter( 'mastodon_api_view_post_types', function( $view_post_types ) {
+		 *   // This will allow the app to view pages.
+		 *   return array_merge( $view_post_types, array( 'page' ) );
+		 * } );
+		 * ```
+		 */
 		$app_metadata['view_post_types'] = apply_filters( 'mastodon_api_view_post_types', $view_post_types );
 
 		$term_id = $term['term_id'];

--- a/includes/class-mastodon-app.php
+++ b/includes/class-mastodon-app.php
@@ -660,9 +660,10 @@ class Mastodon_App {
 		$post_formats = get_option( 'mastodon_api_default_post_formats', array() );
 		$post_formats = apply_filters( 'mastodon_api_new_app_post_formats', $post_formats, $app_metadata );
 		$app_metadata['query_args'] = array( 'post_formats' => $post_formats );
+
 		$app_metadata['create_post_type'] = get_option( 'mastodon_api_posting_cpt', \Enable_Mastodon_Apps\Mastodon_API::POST_CPT );
-		$view_post_types = array( 'post' );
-		if ( 'post' !== $app_metadata['create_post_type'] ) {
+		$view_post_types = array( 'post', 'comment' );
+		if ( ! in_array( $app_metadata['create_post_type'], $view_post_types ) ) {
 			$view_post_types[] = $app_metadata['create_post_type'];
 		}
 

--- a/includes/class-mastodon-app.php
+++ b/includes/class-mastodon-app.php
@@ -100,7 +100,7 @@ class Mastodon_App {
 		if ( ! $create_post_type ) {
 			$create_post_type = 'post';
 		}
-		return apply_filters( 'mastodon_api_create_post_type', $create_post_type );
+		return $create_post_type;
 	}
 
 	public function get_view_post_types() {
@@ -111,7 +111,7 @@ class Mastodon_App {
 		if ( ! is_array( $view_post_types ) ) {
 			$view_post_types = array( $view_post_types );
 		}
-		return apply_filters( 'mastodon_api_view_post_types', $view_post_types );
+		return $view_post_types;
 	}
 
 	public function get_disable_blocks() {
@@ -659,6 +659,14 @@ class Mastodon_App {
 
 		$post_formats = get_option( 'mastodon_api_default_post_formats', array() );
 		$post_formats = apply_filters( 'mastodon_api_new_app_post_formats', $post_formats, $app_metadata );
+		$app_metadata['query_args'] = array( 'post_formats' => $post_formats );
+		$app_metadata['create_post_type'] = get_option( 'mastodon_api_posting_cpt', \Enable_Mastodon_Apps\Mastodon_API::POST_CPT );
+		$view_post_types = array( 'post' );
+		if ( 'post' !== $app_metadata['create_post_type'] ) {
+			$view_post_types[] = $app_metadata['create_post_type'];
+		}
+
+		$app_metadata['view_post_types'] = apply_filters( 'mastodon_api_view_post_types', $view_post_types );
 
 		$term_id = $term['term_id'];
 		foreach ( $app_metadata as $key => $value ) {

--- a/includes/handler/class-handler.php
+++ b/includes/handler/class-handler.php
@@ -9,7 +9,6 @@
 
 namespace Enable_Mastodon_Apps\Handler;
 
-use Enable_Mastodon_Apps\Mastodon_API;
 use Enable_Mastodon_Apps\Mastodon_App;
 
 /**
@@ -25,7 +24,7 @@ class Handler {
 		$app = Mastodon_App::get_current_app();
 
 		if ( ! isset( $args['post_type'] ) ) {
-			$post_types = array( 'post' );
+			$post_types = array( 'post', 'comment' );
 			if ( $app ) {
 				$post_types = $app->get_view_post_types();
 			}

--- a/includes/oauth2/class-mastodon-app-storage.php
+++ b/includes/oauth2/class-mastodon-app-storage.php
@@ -105,6 +105,15 @@ class Mastodon_App_Storage implements ClientCredentialsInterface {
 
 			$post_formats = get_option( 'mastodon_api_default_post_formats', array() );
 			$post_formats = apply_filters( 'mastodon_api_new_app_post_formats', $post_formats, $app_metadata );
+			$app_metadata['query_args'] = array( 'post_formats' => $post_formats );
+
+			$app_metadata['create_post_type'] = get_option( 'mastodon_api_posting_cpt', apply_filters( 'mastodon_api_default_post_type', \Enable_Mastodon_Apps\Mastodon_API::POST_CPT ) );
+			$view_post_types = array( 'post', 'comment' );
+			if ( ! in_array( $app_metadata['create_post_type'], $view_post_types ) ) {
+				$view_post_types[] = $app_metadata['create_post_type'];
+			}
+
+			$app_metadata['view_post_types'] = apply_filters( 'mastodon_api_view_post_types', $view_post_types );
 
 			$term_id = $term['term_id'];
 			foreach ( $app_metadata as $key => $value ) {

--- a/templates/app.php
+++ b/templates/app.php
@@ -13,6 +13,15 @@ use Enable_Mastodon_Apps\Mastodon_App;
 
 $rest_nonce  = wp_create_nonce( 'wp_rest' );
 $_post_types = \get_post_types( array( 'show_ui' => true ), 'objects' );
+if ( ! isset( $_post_types[ \Enable_Mastodon_Apps\Mastodon_Api::POST_CPT ] ) ) {
+	$_post_types = array_merge(
+		array(
+			\Enable_Mastodon_Apps\Mastodon_Api::POST_CPT => get_post_type_object( \Enable_Mastodon_Apps\Mastodon_Api::POST_CPT ),
+		),
+		$_post_types
+	);
+}
+
 $app         = $args['app'];
 $confirm     = esc_html(
 	sprintf(
@@ -130,6 +139,34 @@ $confirm     = esc_html(
 						</select>
 						<p class="description">
 							<span><?php esc_html_e( 'When posting through the app, this post type will be created.', 'enable-mastodon-apps' ); ?></span>
+							<br>
+							<span>
+								<?php
+								echo wp_kses(
+									sprintf(
+										// translators: %s is a post type singular name that appears in the dropdown above.
+										__( 'Choose %s to make posts through Mastodon apps appear on this WordPress.', 'enable-mastodon-apps' ),
+										'<strong>' . get_post_type_object( 'post' )->labels->singular_name . '</strong>'
+									),
+									array( 'strong' => true )
+								);
+
+								?>
+							</span>
+							<br>
+							<span>
+								<?php
+								echo wp_kses(
+									sprintf(
+									// translators: %s is a post type singular name that appears in the dropdown above.
+										__( 'Choose %s if you want to <strong>hide posts through Mastodon apps</strong> from this WordPress.', 'enable-mastodon-apps' ),
+										'<strong>' . __( 'Mastodon Post', 'enable-mastodon-apps' ) . '</strong>'
+									),
+									array( 'strong' => true )
+								);
+
+								?>
+							</span>
 						</p>
 					</td>
 				</tr>

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -28,6 +28,44 @@
 					</td>
 				</tr>
 				<tr>
+					<th scope="row"><?php esc_html_e( 'Posting', 'enable-mastodon-apps' ); ?></th>
+					<td>
+						<fieldset>
+							<label for="mastodon_api_posting_cpt">
+								<input name="mastodon_api_posting_cpt" type="checkbox" id="mastodon_api_posting_cpt" value="1" <?php checked( 'post' === get_option( 'mastodon_api_posting_cpt' ) ); ?> />
+								<span><?php esc_html_e( 'Make posts through Mastodon apps appear on this WordPress', 'enable-mastodon-apps' ); ?></span>
+							</label>
+						</fieldset>
+						<p class="description">
+							<span><?php esc_html_e( 'New apps will be automatically assigned to this setting.', 'enable-mastodon-apps' ); ?></span>
+							<span>
+								<?php
+								echo wp_kses(
+									sprintf(
+										// translators: %s: URL to the Mastodon API settings.
+										__( 'You can change this setting for each app on the <a href="%s">Mastodon API settings</a>.', 'enable-mastodon-apps' ),
+										esc_url( admin_url( 'admin.php?page=enable-mastodon-apps-settings' ) )
+									),
+									array( 'a' => array( 'href' => array() ) )
+								);
+								?>
+							</span><br>
+							<span>
+								<?php
+								echo wp_kses(
+									sprintf(
+										// translators: %s: Post type.
+										__( 'When set, posts through Mastodon apps will have the post type: %s', 'enable-mastodon-apps' ),
+										'<tt>' . \Enable_Mastodon_Apps\Mastodon_API::POST_CPT . '</tt>'
+									),
+									array( 'tt' => true )
+								);
+								?>
+							</span>
+						</p>
+					</td>
+				</tr>
+				<tr>
 					<th scope="row"><?php esc_html_e( 'Debugging', 'enable-mastodon-apps' ); ?></th>
 					<td>
 						<fieldset>

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -56,7 +56,7 @@
 									sprintf(
 										// translators: %s: Post type.
 										__( 'When set, posts through Mastodon apps will have the post type: %s', 'enable-mastodon-apps' ),
-										'<tt>' . \Enable_Mastodon_Apps\Mastodon_API::POST_CPT . '</tt>'
+										'<tt>' . apply_filters( 'mastodon_api_default_post_type', \Enable_Mastodon_Apps\Mastodon_API::POST_CPT ) . '</tt>'
 									),
 									array( 'tt' => true )
 								);

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -8,6 +8,10 @@
 		'enable_debug' => $args['enable_debug'],
 	)
 );
+
+$ema_post_cpt = get_post_type_object( apply_filters( 'mastodon_api_default_post_type', \Enable_Mastodon_Apps\Mastodon_API::POST_CPT ) );
+$post_cpt = get_post_type_object( 'post' );
+
 ?>
 
 <div class="enable-mastodon-apps-settings enable-mastodon-apps-settings-page">
@@ -37,14 +41,14 @@
 							</label>
 						</fieldset>
 						<p class="description">
-							<span><?php esc_html_e( 'New apps will be automatically assigned to this setting.', 'enable-mastodon-apps' ); ?></span>
 							<span>
 								<?php
 								echo wp_kses(
 									sprintf(
-										// translators: %s: URL to the Mastodon API settings.
-										__( 'You can change this setting for each app on the <a href="%s">Mastodon API settings</a>.', 'enable-mastodon-apps' ),
-										esc_url( admin_url( 'admin.php?page=enable-mastodon-apps-settings' ) )
+										// translators: %1$s: URL to the Mastodon API settings page Registered Apps tab, %2$s: Registered Apps tab title.
+										__( 'New apps will be automatically configured according to this setting, but you can change it individually for each app on the <a href="%1$s">%2$s</a> page.', 'enable-mastodon-apps' ),
+										esc_url( admin_url( 'admin.php?page=enable-mastodon-apps-settings&tab=registered-apps' ) ),
+										__( 'Registered Apps', 'enable-mastodon-apps' )
 									),
 									array( 'a' => array( 'href' => array() ) )
 								);
@@ -54,11 +58,12 @@
 								<?php
 								echo wp_kses(
 									sprintf(
-										// translators: %s: Post type.
-										__( 'When set, posts through Mastodon apps will have the post type: %s', 'enable-mastodon-apps' ),
-										'<tt>' . apply_filters( 'mastodon_api_default_post_type', \Enable_Mastodon_Apps\Mastodon_API::POST_CPT ) . '</tt>'
+										// translators: %1$s and %2$s: a post type.
+										__( 'New posts made through Mastodon apps will have the post type %1$s when checked, otherwise %2$s.', 'enable-mastodon-apps' ),
+										'<strong>' . $post_cpt->labels->singular_name . '</strong>',
+										'<strong>' . $ema_post_cpt->labels->singular_name . '</strong>'
 									),
-									array( 'tt' => true )
+									array( 'strong' => true )
 								);
 								?>
 							</span>

--- a/tests/class-mastodon-api-testcase.php
+++ b/tests/class-mastodon-api-testcase.php
@@ -46,7 +46,7 @@ class Mastodon_API_TestCase extends \WP_UnitTestCase {
 				'post_content' => 'Test post',
 				'post_title'   => '',
 				'post_status'  => 'publish',
-				'post_type'    => 'post',
+				'post_type'    => Mastodon_API::POST_CPT,
 				'post_date'    => '2023-01-03 00:00:00',
 			)
 		);
@@ -58,7 +58,7 @@ class Mastodon_API_TestCase extends \WP_UnitTestCase {
 				'post_content' => 'Private post',
 				'post_title'   => '',
 				'post_status'  => 'private',
-				'post_type'    => 'post',
+				'post_type'    => Mastodon_API::POST_CPT,
 				'post_date'    => '2023-01-03 00:00:01',
 			)
 		);
@@ -120,11 +120,6 @@ class Mastodon_API_TestCase extends \WP_UnitTestCase {
 		);
 
 		set_post_format( $this->friend_post, 'status' );
-		$this->app = Mastodon_App::save( 'Test App', array( 'https://test' ), 'read write follow push', 'https://mastodon.local' );
-		$oauth = new Mastodon_OAuth();
-		$this->token = wp_generate_password( 128, false );
-		$userdata = get_userdata( $this->administrator );
-		$oauth->get_token_storage()->setAccessToken( $this->token, $this->app->get_client_id(), $userdata->ID, time() + HOUR_IN_SECONDS, $this->app->get_scopes() );
 
 		add_filter(
 			'default_option_mastodon_api_default_post_formats',
@@ -133,6 +128,12 @@ class Mastodon_API_TestCase extends \WP_UnitTestCase {
 			},
 			20
 		);
+
+		$this->app = Mastodon_App::save( 'Test App', array( 'https://test' ), 'read write follow push', 'https://mastodon.local' );
+		$oauth = new Mastodon_OAuth();
+		$this->token = wp_generate_password( 128, false );
+		$userdata = get_userdata( $this->administrator );
+		$oauth->get_token_storage()->setAccessToken( $this->token, $this->app->get_client_id(), $userdata->ID, time() + HOUR_IN_SECONDS, $this->app->get_scopes() );
 
 		add_filter( 'pre_http_request', array( $this, 'block_http_requests' ), 10 );
 	}

--- a/tests/test-activitypub.php
+++ b/tests/test-activitypub.php
@@ -27,7 +27,7 @@ class ActivityPub_Test extends Mastodon_API_TestCase {
 				'post_content' => 'Test post',
 				'post_title'   => '',
 				'post_status'  => 'publish',
-				'post_type'    => 'post',
+				'post_type'    => Mastodon_API::POST_CPT,
 				'post_date'    => '2023-01-03 00:00:00',
 			)
 		);


### PR DESCRIPTION
This checkbox will be off by default, this means that now posting through Mastodon apps will not appear in the main feed of your WordPress site, as this was surprising people (see https://github.com/akirk/friends/issues/451).

Already before you could register your own post type and configure an app to post in that new post type, this now makes it a defaulf behavior. There is migration code for older apps to maintain the old behavior.

![Screenshot 2025-02-08 at 19 15 33](https://github.com/user-attachments/assets/5b60c323-b20b-4df6-8f9e-a3e6d71c13a5)

On app pages there is this new explanation:
![Screenshot 2025-02-08 at 13 03 54](https://github.com/user-attachments/assets/b494869c-db60-421f-999e-15af7a461993)

The new option automatically is automatically checked (and unchecked) in the ActivityPub plugin:
![Screenshot 2025-02-08 at 18 10 39](https://github.com/user-attachments/assets/ac32596d-7a83-4752-88c8-0bd013752dd7)


