### PR TITLE
Don't show reblog mapping posts

### DIFF
--- a/includes/handler/class-handler.php
+++ b/includes/handler/class-handler.php
@@ -29,7 +29,7 @@ class Handler {
 			if ( $app ) {
 				$post_types = $app->get_view_post_types();
 			}
-			$args['post_type'] = array_merge( $post_types, array( Mastodon_API::CPT ) );
+			$args['post_type'] = $post_types;
 		}
 		$args['posts_per_page']   = $limit;
 		$args['suppress_filters'] = false;


### PR DESCRIPTION
Fixes #168

We do not need the reposts in the main feed, they are just used to have a separate id available for reposts as some clients crash otherwise. They will be automatically loaded and should not appear in the main timeline.
