### PR TITLE
Update PHPCompatibility and restrict PHPUnit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
 		"wp-coding-standards/wpcs": "*",
 		"yoast/phpunit-polyfills": "*",
 		"php-parallel-lint/php-parallel-lint": "^1.3",
-		"phpunit/phpunit": "*",
+		"phpunit/phpunit": "9.*",
 		"akirk/extract-wp-hooks": "*"
 	},
 	"config": {

--- a/composer.json
+++ b/composer.json
@@ -1,52 +1,51 @@
 {
-  "name": "akirk/enable-mastodon-apps",
-  "description": "A WordPress plugin that implements the Mastodon API to enable access through Mastodon apps",
-  "type": "wordpress-plugin",
-  "license": "GPL-2.0-or-later",
-  "require-dev": {
-    "dealerdirect/phpcodesniffer-composer-installer": "*",
-    "phpcompatibility/php-compatibility": "*",
-    "wp-coding-standards/wpcs": "*",
-    "yoast/phpunit-polyfills": "*",
-    "php-parallel-lint/php-parallel-lint": "^1.3",
-    "phpunit/phpunit": "*",
-    "akirk/extract-wp-hooks": "*"
-  },
-  "config": {
-    "allow-plugins": {
-      "dealerdirect/phpcodesniffer-composer-installer": true
-    }
-  },
-  "prefer-stable": true,
-  "scripts": {
-    "lint7": [
-      "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git --exclude src/Exceptions/Error.php --exclude src/Exceptions/TypeError.php --exclude tests/Polyfills/Fixtures/ValueObjectUnion.php --exclude tests/Polyfills/Fixtures/ValueObjectUnionNoReturnType.php"
-    ],
-    "lint-lt70": [
-      "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git --exclude src/TestCases/TestCasePHPUnitGte8.php --exclude src/TestListeners/TestListenerDefaultImplementationPHPUnitGte7.php --exclude tests/Polyfills/Fixtures/ChildValueObject.php --exclude tests/Polyfills/Fixtures/ValueObject.php --exclude tests/Polyfills/Fixtures/ValueObjectUnion.php --exclude tests/Polyfills/Fixtures/ValueObjectUnionNoReturnType.php"
-    ],
-    "lint-gte80": [
-      "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"
-    ],
-    "check-cs": [
-      "@php ./vendor/bin/phpcs"
-    ],
-    "fix-cs": [
-      "@php ./vendor/bin/phpcbf"
-    ],
-    "test": [
-      "@php ./vendor/phpunit/phpunit/phpunit --testdox --no-coverage"
-    ],
-    "docker-test": [
-      "composer install",
-      "bin/install-wp-tests.sh ema-test root ema-test test-db latest true",
-      "@php ./vendor/phpunit/phpunit/phpunit --no-coverage"
-    ],
-    "update-wiki": [
-      "test -d ../enable-mastodon-apps.wiki && php ./vendor/akirk/extract-wp-hooks/extract-wp-hooks.php && cd ../enable-mastodon-apps.wiki/ && git add . && git commit -m 'Update hooks'; git push"
-    ]
-  },
-  "require": {
-    "bshaffer/oauth2-server-php": "^1.10"
-  }
+	"name": "akirk/enable-mastodon-apps",
+	"description": "A WordPress plugin that implements the Mastodon API to enable access through Mastodon apps",
+	"license": "GPL-2.0-or-later",
+	"require-dev": {
+		"phpcompatibility/php-compatibility": "dev-develop as 9.99.99",
+		"phpcompatibility/phpcompatibility-wp": "*",
+		"wp-coding-standards/wpcs": "*",
+		"yoast/phpunit-polyfills": "*",
+		"php-parallel-lint/php-parallel-lint": "^1.3",
+		"phpunit/phpunit": "*",
+		"akirk/extract-wp-hooks": "*"
+	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
+	},
+	"prefer-stable": true,
+	"scripts": {
+		"lint7": [
+			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git --exclude src/Exceptions/Error.php --exclude src/Exceptions/TypeError.php --exclude tests/Polyfills/Fixtures/ValueObjectUnion.php --exclude tests/Polyfills/Fixtures/ValueObjectUnionNoReturnType.php"
+		],
+		"lint-lt70": [
+			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git --exclude src/TestCases/TestCasePHPUnitGte8.php --exclude src/TestListeners/TestListenerDefaultImplementationPHPUnitGte7.php --exclude tests/Polyfills/Fixtures/ChildValueObject.php --exclude tests/Polyfills/Fixtures/ValueObject.php --exclude tests/Polyfills/Fixtures/ValueObjectUnion.php --exclude tests/Polyfills/Fixtures/ValueObjectUnionNoReturnType.php"
+		],
+		"lint-gte80": [
+			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"
+		],
+		"check-cs": [
+			"@php ./vendor/bin/phpcs"
+		],
+		"fix-cs": [
+			"@php ./vendor/bin/phpcbf"
+		],
+		"test": [
+			"@php ./vendor/phpunit/phpunit/phpunit --no-coverage"
+		],
+		"docker-test": [
+			"composer install",
+			"bin/install-wp-tests.sh ema-test root ema-test test-db latest true",
+			"@php ./vendor/phpunit/phpunit/phpunit --no-coverage"
+		],
+		"update-wiki": [
+			"test -d ../enable-mastodon-apps.wiki && php ./vendor/akirk/extract-wp-hooks/extract-wp-hooks.php && cd ../enable-mastodon-apps.wiki/ && git add . && git commit -m 'Update hooks'; git push"
+		]
+	},
+	"require": {
+		"bshaffer/oauth2-server-php": "^1.10"
+	}
 }

--- a/vendor/bshaffer/oauth2-server-php/src/OAuth2/ClientAssertionType/HttpBasic.php
+++ b/vendor/bshaffer/oauth2-server-php/src/OAuth2/ClientAssertionType/HttpBasic.php
@@ -112,7 +112,7 @@ class HttpBasic implements ClientAssertionTypeInterface
      *
      * @ingroup oauth2_section_2
      */
-    public function getClientCredentials(RequestInterface $request, ResponseInterface $response = null)
+    public function getClientCredentials(RequestInterface $request, ?ResponseInterface $response = null)
     {
         if (!is_null($request->headers('PHP_AUTH_USER')) && !is_null($request->headers('PHP_AUTH_PW'))) {
             return array('client_id' => $request->headers('PHP_AUTH_USER'), 'client_secret' => $request->headers('PHP_AUTH_PW'));

--- a/vendor/bshaffer/oauth2-server-php/src/OAuth2/Controller/AuthorizeController.php
+++ b/vendor/bshaffer/oauth2-server-php/src/OAuth2/Controller/AuthorizeController.php
@@ -78,7 +78,7 @@ class AuthorizeController implements AuthorizeControllerInterface
      *     );
      * @endcode
      */
-    public function __construct(ClientInterface $clientStorage, array $responseTypes = array(), array $config = array(), ScopeInterface $scopeUtil = null)
+    public function __construct(ClientInterface $clientStorage, array $responseTypes = array(), array $config = array(), ?ScopeInterface $scopeUtil = null)
     {
         $this->clientStorage = $clientStorage;
         $this->responseTypes = $responseTypes;

--- a/vendor/bshaffer/oauth2-server-php/src/OAuth2/Controller/ResourceController.php
+++ b/vendor/bshaffer/oauth2-server-php/src/OAuth2/Controller/ResourceController.php
@@ -47,7 +47,7 @@ class ResourceController implements ResourceControllerInterface
      * @param array                $config
      * @param ScopeInterface       $scopeUtil
      */
-    public function __construct(TokenTypeInterface $tokenType, AccessTokenInterface $tokenStorage, $config = array(), ScopeInterface $scopeUtil = null)
+    public function __construct(TokenTypeInterface $tokenType, AccessTokenInterface $tokenStorage, $config = array(), ?ScopeInterface $scopeUtil = null)
     {
         $this->tokenType = $tokenType;
         $this->tokenStorage = $tokenStorage;

--- a/vendor/bshaffer/oauth2-server-php/src/OAuth2/Controller/TokenController.php
+++ b/vendor/bshaffer/oauth2-server-php/src/OAuth2/Controller/TokenController.php
@@ -54,7 +54,7 @@ class TokenController implements TokenControllerInterface
      * @param ScopeInterface               $scopeUtil
      * @throws InvalidArgumentException
      */
-    public function __construct(AccessTokenInterface $accessToken, ClientInterface $clientStorage, array $grantTypes = array(), ClientAssertionTypeInterface $clientAssertionType = null, ScopeInterface $scopeUtil = null)
+    public function __construct(AccessTokenInterface $accessToken, ClientInterface $clientStorage, array $grantTypes = array(), ?ClientAssertionTypeInterface $clientAssertionType = null, ?ScopeInterface $scopeUtil = null)
     {
         if (is_null($clientAssertionType)) {
             foreach ($grantTypes as $grantType) {

--- a/vendor/bshaffer/oauth2-server-php/src/OAuth2/Request.php
+++ b/vendor/bshaffer/oauth2-server-php/src/OAuth2/Request.php
@@ -34,7 +34,7 @@ class Request implements RequestInterface
      *
      * @api
      */
-    public function __construct(array $query = array(), array $request = array(), array $attributes = array(), array $cookies = array(), array $files = array(), array $server = array(), $content = null, array $headers = null)
+    public function __construct(array $query = array(), array $request = array(), array $attributes = array(), array $cookies = array(), array $files = array(), array $server = array(), $content = null, ?array $headers = null)
     {
         $this->initialize($query, $request, $attributes, $cookies, $files, $server, $content, $headers);
     }
@@ -55,7 +55,7 @@ class Request implements RequestInterface
      *
      * @api
      */
-    public function initialize(array $query = array(), array $request = array(), array $attributes = array(), array $cookies = array(), array $files = array(), array $server = array(), $content = null, array $headers = null)
+    public function initialize(array $query = array(), array $request = array(), array $attributes = array(), array $cookies = array(), array $files = array(), array $server = array(), $content = null, ?array $headers = null)
     {
         $this->request = $request;
         $this->query = $query;

--- a/vendor/bshaffer/oauth2-server-php/src/OAuth2/ResponseType/AccessToken.php
+++ b/vendor/bshaffer/oauth2-server-php/src/OAuth2/ResponseType/AccessToken.php
@@ -38,7 +38,7 @@ class AccessToken implements AccessTokenInterface
      *     );
      * @endcode
      */
-    public function __construct(AccessTokenStorageInterface $tokenStorage, RefreshTokenInterface $refreshStorage = null, array $config = array())
+    public function __construct(AccessTokenStorageInterface $tokenStorage, ?RefreshTokenInterface $refreshStorage = null, ?array $config = array())
     {
         $this->tokenStorage = $tokenStorage;
         $this->refreshStorage = $refreshStorage;

--- a/vendor/bshaffer/oauth2-server-php/src/OAuth2/Server.php
+++ b/vendor/bshaffer/oauth2-server-php/src/OAuth2/Server.php
@@ -150,7 +150,7 @@ class Server implements ResourceControllerInterface,
      *
      * @ingroup oauth2_section_7
      */
-    public function __construct($storage = array(), array $config = array(), array $grantTypes = array(), array $responseTypes = array(), TokenTypeInterface $tokenType = null, ScopeInterface $scopeUtil = null, ClientAssertionTypeInterface $clientAssertionType = null)
+    public function __construct($storage = array(), array $config = array(), array $grantTypes = array(), array $responseTypes = array(), ?TokenTypeInterface $tokenType = null, ?ScopeInterface $scopeUtil = null, ?ClientAssertionTypeInterface $clientAssertionType = null)
     {
         $storage = is_array($storage) ? $storage : array($storage);
         $this->storages = array();
@@ -289,7 +289,7 @@ class Server implements ResourceControllerInterface,
      *
      * @see http://openid.net/specs/openid-connect-core-1_0.html#UserInfo
      */
-    public function handleUserInfoRequest(RequestInterface $request, ResponseInterface $response = null)
+    public function handleUserInfoRequest(RequestInterface $request, ?ResponseInterface $response = null)
     {
         $this->response = is_null($response) ? new Response() : $response;
         $this->getUserInfoController()->handleUserInfoRequest($request, $this->response);
@@ -315,7 +315,7 @@ class Server implements ResourceControllerInterface,
      *
      * @ingroup oauth2_section_4
      */
-    public function handleTokenRequest(RequestInterface $request, ResponseInterface $response = null)
+    public function handleTokenRequest(RequestInterface $request, ?ResponseInterface $response = null)
     {
         $this->response = is_null($response) ? new Response() : $response;
         $this->getTokenController()->handleTokenRequest($request, $this->response);
@@ -328,7 +328,7 @@ class Server implements ResourceControllerInterface,
      * @param ResponseInterface $response - Response object
      * @return mixed
      */
-    public function grantAccessToken(RequestInterface $request, ResponseInterface $response = null)
+    public function grantAccessToken(RequestInterface $request, ?ResponseInterface $response = null)
     {
         $this->response = is_null($response) ? new Response() : $response;
         $value = $this->getTokenController()->grantAccessToken($request, $this->response);
@@ -346,7 +346,7 @@ class Server implements ResourceControllerInterface,
      * @param ResponseInterface $response
      * @return Response|ResponseInterface
      */
-    public function handleRevokeRequest(RequestInterface $request, ResponseInterface $response = null)
+    public function handleRevokeRequest(RequestInterface $request, ?ResponseInterface $response = null)
     {
         $this->response = is_null($response) ? new Response() : $response;
         $this->getTokenController()->handleRevokeRequest($request, $this->response);
@@ -408,7 +408,7 @@ class Server implements ResourceControllerInterface,
      *
      * @ingroup oauth2_section_3
      */
-    public function validateAuthorizeRequest(RequestInterface $request, ResponseInterface $response = null)
+    public function validateAuthorizeRequest(RequestInterface $request, ?ResponseInterface $response = null)
     {
         $this->response = is_null($response) ? new Response() : $response;
         $value = $this->getAuthorizeController()->validateAuthorizeRequest($request, $this->response);
@@ -422,7 +422,7 @@ class Server implements ResourceControllerInterface,
      * @param string            $scope    - Scope
      * @return mixed
      */
-    public function verifyResourceRequest(RequestInterface $request, ResponseInterface $response = null, $scope = null)
+    public function verifyResourceRequest(RequestInterface $request, ?ResponseInterface $response = null, $scope = null)
     {
         $this->response = is_null($response) ? new Response() : $response;
         $value = $this->getResourceController()->verifyResourceRequest($request, $this->response, $scope);
@@ -435,7 +435,7 @@ class Server implements ResourceControllerInterface,
      * @param ResponseInterface $response - Response object
      * @return mixed
      */
-    public function getAccessTokenData(RequestInterface $request, ResponseInterface $response = null)
+    public function getAccessTokenData(RequestInterface $request, ?ResponseInterface $response = null)
     {
         $this->response = is_null($response) ? new Response() : $response;
         $value = $this->getResourceController()->getAccessTokenData($request, $this->response);


### PR DESCRIPTION
- Restrict to PHPUnit 9 since otherwise it fails with `Class test-activitypub cannot be found in /Users/alex/Sites/localhost/wp/wp-content/plugins/friends/tests/test-activitypub.php` → need to investigate what changed in the naming convention.
- Upgrade for ActivityPub 5.0.0
