### PR TITLE
Ignore the text when authorizing to avoid language problems

### DIFF
--- a/includes/oauth2/class-authenticate-handler.php
+++ b/includes/oauth2/class-authenticate-handler.php
@@ -106,6 +106,7 @@ class Authenticate_Handler {
 	}
 
 	private function render_consent_screen( $data ) {
+		switch_to_user_locale( $data['user']->ID );
 		$scope_explanations = array(
 			'read'   => __( 'Read information from your account, for example read your statuses.', 'enable-mastodon-apps' ),
 			'write'  => __( 'Write information to your account, for example post a status on your behalf, or edit your profile.', 'enable-mastodon-apps' ),

--- a/includes/oauth2/class-authorize-handler.php
+++ b/includes/oauth2/class-authorize-handler.php
@@ -45,7 +45,8 @@ class Authorize_Handler {
 		}
 
 		$user = wp_get_current_user();
-		if ( empty( $_POST['authorize'] ) ) {
+		switch_to_user_locale( $user->ID );
+		if ( ! isset( $_POST['authorize'] ) || __( 'Authorize', 'enable-mastodon-apps' ) !== $_POST['authorize'] ) {
 			$response->setError( 403, 'user_authorization_required', 'This application requires your consent.' );
 			return $response;
 		}

--- a/includes/oauth2/class-authorize-handler.php
+++ b/includes/oauth2/class-authorize-handler.php
@@ -45,7 +45,7 @@ class Authorize_Handler {
 		}
 
 		$user = wp_get_current_user();
-		if ( ! isset( $_POST['authorize'] ) || __( 'Authorize', 'enable-mastodon-apps' ) !== $_POST['authorize'] ) {
+		if ( empty( $_POST['authorize'] ) ) {
 			$response->setError( 403, 'user_authorization_required', 'This application requires your consent.' );
 			return $response;
 		}


### PR DESCRIPTION
In the current code we might compare a user language text to a blog language text which might have different languages.
