### PR TITLE
Enable OPTIONS and api/apps endpoint even with rest_login_required

### DIFF
--- a/includes/class-mastodon-api.php
+++ b/includes/class-mastodon-api.php
@@ -1894,6 +1894,15 @@ class Mastodon_API {
 	 * @return WP_Error WP_Error object.
 	 */
 	public function rest_authentication_errors( $errors ) {
+		if ( empty( $GLOBALS['wp']->query_vars['rest_route'] ) ) {
+			return $errors;
+		}
+
+		$route = ltrim( $GLOBALS['wp']->query_vars['rest_route'], '/' );
+		if ( 0 !== strpos( $route, self::PREFIX ) ) {
+			return $errors;
+		}
+
 		if ( $errors && get_option( 'mastodon_api_debug_mode' ) > time() ) {
 			$request = new WP_REST_Request( $_SERVER['REQUEST_METHOD'], $_SERVER['REQUEST_URI'] ); // phpcs:ignore
 			$request->set_query_params( $_GET ); // phpcs:ignore
@@ -1908,6 +1917,15 @@ class Mastodon_API {
 					'errors'     => $errors,
 				)
 			);
+		}
+
+		if ( $errors && 'rest_login_required' === $errors->get_error_code() ) {
+			if ( 'OPTIONS' === $_SERVER['REQUEST_METHOD'] ) { // phpcs:ignore
+				$errors = null;
+			}
+			if ( self::PREFIX . '/api/v1/apps' === $route ) {
+				$errors = null;
+			}
 		}
 
 		return $errors;

--- a/includes/class-mastodon-api.php
+++ b/includes/class-mastodon-api.php
@@ -74,7 +74,7 @@ class Mastodon_API {
 		add_filter( 'template_include', array( $this, 'log_404s' ) );
 		add_filter( 'rest_json_encode_options', array( $this, 'rest_json_encode_options' ), 10, 2 );
 		add_filter( 'rest_request_before_callbacks', array( $this, 'rest_request_before_callbacks' ), 10, 3 );
-		add_filter( 'rest_authentication_errors', array( $this, 'rest_authentication_errors' ) );
+		add_filter( 'rest_authentication_errors', array( $this, 'rest_authentication_errors' ), 20 );
 		add_filter( 'mastodon_api_mapback_user_id', array( $this, 'mapback_user_id' ) );
 		add_filter( 'mastodon_api_in_reply_to_id', array( self::class, 'maybe_get_remapped_reblog_id' ), 15 );
 		add_filter( 'activitypub_support_post_types', array( $this, 'activitypub_support_post_types' ) );


### PR DESCRIPTION
This enables signing in and using the Mastodon API Tester even when a plugin like [Network Privacy](https://github.com/akirk/ra-network-privacy/) is active.