### PR TITLE
Change Rewrite Rule loading

### DIFF
--- a/includes/class-mastodon-admin.php
+++ b/includes/class-mastodon-admin.php
@@ -826,6 +826,8 @@ class Mastodon_Admin {
 			update_option( 'ema_plugin_version', ENABLE_MASTODON_APPS_VERSION );
 		}
 
+		flush_rewrite_rules( false );
+
 		if ( ! get_option( 'mastodon_api_disable_ema_announcements' ) ) {
 			$post_id = false;
 			if ( ! $old_version ) {

--- a/includes/class-mastodon-api.php
+++ b/includes/class-mastodon-api.php
@@ -68,7 +68,7 @@ class Mastodon_API {
 	}
 
 	public function register_hooks() {
-		add_action( 'wp_loaded', array( $this, 'rewrite_rules' ) );
+		add_action( 'generate_rewrite_rules', array( $this, 'generate_rewrite_rules' ) );
 		add_action( 'query_vars', array( $this, 'query_vars' ) );
 		add_action( 'rest_api_init', array( $this, 'add_rest_routes' ) );
 		add_filter( 'rest_post_dispatch', array( $this, 'send_http_links' ), 10, 3 );
@@ -392,9 +392,8 @@ class Mastodon_API {
 		return $post_types;
 	}
 
-	public function rewrite_rules() {
-		$existing_rules = get_option( 'rewrite_rules' );
-		$needs_flush    = false;
+	public function generate_rewrite_rules( $wp_rewrite ) {
+		$existing_rules = $wp_rewrite->rules;
 
 		$generic      = apply_filters(
 			'mastodon_api_generic_routes',
@@ -472,7 +471,7 @@ class Mastodon_API {
 				// Add a specific rewrite rule so that we can also catch requests without our prefix.
 				$needs_flush = true;
 			}
-			add_rewrite_rule( '^' . $rule, 'index.php?rest_route=/' . self::PREFIX . '/' . $rule, 'top' );
+			$wp_rewrite->add_rule( '^' . $rule, 'index.php?rest_route=/' . self::PREFIX . '/' . $rule, 'top' );
 		}
 
 		foreach ( $parametrized as $rule => $rewrite ) {
@@ -480,11 +479,7 @@ class Mastodon_API {
 				// Add a specific rewrite rule so that we can also catch requests without our prefix.
 				$needs_flush = true;
 			}
-			add_rewrite_rule( '^' . $rule, 'index.php?rest_route=/' . self::PREFIX . '/' . $rewrite, 'top' );
-		}
-
-		if ( $needs_flush ) {
-			flush_rewrite_rules();
+			$wp_rewrite->add_rule( '^' . $rule, 'index.php?rest_route=/' . self::PREFIX . '/' . $rewrite, 'top' );
 		}
 	}
 

--- a/includes/class-mastodon-api.php
+++ b/includes/class-mastodon-api.php
@@ -463,14 +463,17 @@ class Mastodon_API {
 				'api/v[12]/search'                       => 'api/v2/search',
 			)
 		);
+		$new_rules = array();
 
 		foreach ( $generic as $rule ) {
-			$wp_rewrite->rules[ '^' . $rule ] = 'index.php?rest_route=/' . self::PREFIX . '/' . $rule;
+			$new_rules[ '^' . $rule ] = 'index.php?rest_route=/' . self::PREFIX . '/' . $rule;
 		}
 
 		foreach ( $parametrized as $rule => $rewrite ) {
-			$wp_rewrite->rules[ '^' . $rule ] = 'index.php?rest_route=/' . self::PREFIX . '/' . $rewrite;
+			$new_rules[ '^' . $rule ] = 'index.php?rest_route=/' . self::PREFIX . '/' . $rewrite;
 		}
+
+		$wp_rewrite->rules = $new_rules + $wp_rewrite->rules;
 	}
 
 	public function add_rest_routes() {

--- a/includes/class-mastodon-api.php
+++ b/includes/class-mastodon-api.php
@@ -393,8 +393,6 @@ class Mastodon_API {
 	}
 
 	public function generate_rewrite_rules( $wp_rewrite ) {
-		$existing_rules = $wp_rewrite->rules;
-
 		$generic      = apply_filters(
 			'mastodon_api_generic_routes',
 			array(
@@ -467,19 +465,11 @@ class Mastodon_API {
 		);
 
 		foreach ( $generic as $rule ) {
-			if ( empty( $existing_rules[ '^' . $rule ] ) ) {
-				// Add a specific rewrite rule so that we can also catch requests without our prefix.
-				$needs_flush = true;
-			}
-			$wp_rewrite->add_rule( '^' . $rule, 'index.php?rest_route=/' . self::PREFIX . '/' . $rule, 'top' );
+			$wp_rewrite->rules[ '^' . $rule ] = 'index.php?rest_route=/' . self::PREFIX . '/' . $rule;
 		}
 
 		foreach ( $parametrized as $rule => $rewrite ) {
-			if ( empty( $existing_rules[ '^' . $rule ] ) ) {
-				// Add a specific rewrite rule so that we can also catch requests without our prefix.
-				$needs_flush = true;
-			}
-			$wp_rewrite->add_rule( '^' . $rule, 'index.php?rest_route=/' . self::PREFIX . '/' . $rewrite, 'top' );
+			$wp_rewrite->rules[ '^' . $rule ] = 'index.php?rest_route=/' . self::PREFIX . '/' . $rewrite;
 		}
 	}
 


### PR DESCRIPTION
## What this changes

Fixes #252.

- Register the Mastodon API rewrite rules during `generate_rewrite_rules` instead of adding them on `wp_loaded`.
- Inject the API routes directly into `$wp_rewrite->rules` while WordPress is compiling the rewrite array.
- Soft-flush rewrite rules when EMA records a new plugin version, so existing installs and future route additions get persisted without requiring a manual Permalinks save.

## Backstory

Issue #252 reports that after plugin updates, normal site links could return 404 until the user visited Settings > Permalinks and saved the page. The reporter was using the `%postname%` permalink structure and Falang, and similar symptoms were seen around ActivityPub and Friends updates.

PR #257 tried to fix this by moving EMA's existing `add_rewrite_rule()` plus conditional flush from `wp_loaded` to `plugins_loaded`. That broke rewrite registration because `Mastodon_API` is constructed on `init`, after `plugins_loaded` has already fired.

PR #261 reverted the hook timing and switched back to the public `flush_rewrite_rules()` wrapper, restoring the previous behavior. However, it still left EMA depending on request-time rewrite registration and a request-time flush when a stored rule was missing.

## Why this approach

`generate_rewrite_rules` is the WordPress lifecycle point for modifying the compiled rewrite array. Registering EMA's API routes there means the routes are present whenever WordPress regenerates the stored `rewrite_rules` option, including manual permalink saves and the soft flush performed on EMA upgrades.

This avoids flushing during normal frontend requests and makes EMA less dependent on repairing stale rewrite state after the fact. Falang may still be the plugin creating the bad rewrite state in #252, but this keeps EMA on the normal rewrite-generation path instead of trying to patch the stored option during regular requests.

## Testing

- `php -l includes/class-mastodon-api.php`
- `php -l includes/class-mastodon-admin.php`
- `composer lint-gte80`
- `php ./vendor/phpunit/phpunit/phpunit --no-coverage tests/test-comments-cpt.php` could not run locally because `/tmp/wordpress-tests-lib/includes/functions.php` is missing.
- The reporter tested the beta branch with Falang active and did not need to refresh permalinks manually.
