### PR TITLE
Use a Github action to extract the wp hooks

### DIFF
--- a/.github/workflows/extract-wp-hooks.yml
+++ b/.github/workflows/extract-wp-hooks.yml
@@ -1,0 +1,16 @@
+name: Extract WordPress Hooks
+
+on:
+  push:
+    branches: [main]
+    paths: ["**.php"]
+  workflow_dispatch:
+
+jobs:
+  extract-hooks:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to push to wiki repository
+    steps:
+      - uses: actions/checkout@v4
+      - uses: akirk/extract-wp-hooks@1.1.0


### PR DESCRIPTION
Make use of the [new Github action I added to the extract-wp-hooks repo](https://github.com/akirk/extract-wp-hooks). It will update the [Hooks documentation in the Github wiki of this repo](https://github.com/akirk/enable-mastodon-apps/wiki/Hooks).