### PR TITLE
Add option to limit posts with attachments

### DIFF
--- a/includes/class-mastodon-admin.php
+++ b/includes/class-mastodon-admin.php
@@ -768,6 +768,12 @@ class Mastodon_Admin {
 			$app->set_disable_blocks( false );
 		}
 
+		if ( isset( $_POST['media_only'] ) ) {
+			$app->set_media_only( true );
+		} else {
+			$app->set_media_only( false );
+		}
+
 		$app->post_current_settings();
 	}
 

--- a/includes/class-mastodon-app.php
+++ b/includes/class-mastodon-app.php
@@ -180,6 +180,23 @@ class Mastodon_App {
 		return update_term_meta( $this->term->term_id, 'options', $options );
 	}
 
+	public function get_media_only() {
+		$options = get_term_meta( $this->term->term_id, 'options', true );
+		if ( ! is_array( $options ) ) {
+			return false;
+		}
+		return boolval( $options['media_only'] ?? false );
+	}
+
+	public function set_media_only( $media_only ) {
+		$options = get_term_meta( $this->term->term_id, 'options', true );
+		if ( ! is_array( $options ) ) {
+			$options = array();
+		}
+		$options['media_only'] = $media_only;
+		return update_term_meta( $this->term->term_id, 'options', $options );
+	}
+
 	public function check_redirect_uri( $redirect_uri ) {
 		$redirect_uris = $this->get_redirect_uris();
 		if ( ! is_array( $redirect_uris ) ) {
@@ -328,6 +345,10 @@ class Mastodon_App {
 
 		if ( $this->get_disable_blocks() ) {
 			$content .= PHP_EOL . __( 'Automatic conversion to blocks is disabled', 'enable-mastodon-apps' );
+		}
+
+		if ( $this->get_media_only() ) {
+			$content .= PHP_EOL . __( 'Only show posts with media attachments', 'enable-mastodon-apps' );
 		}
 
 		return trim( $content );
@@ -661,7 +682,7 @@ class Mastodon_App {
 					}
 
 					foreach ( array_keys( $value ) as $key ) {
-						if ( 'blocks' === $key ) {
+						if ( 'blocks' === $key || 'media_only' === $key ) {
 							$value[ $key ] = boolval( $value[ $key ] );
 							continue;
 						}
@@ -905,6 +926,14 @@ class Mastodon_App {
 		}
 
 		$app = new self( $term );
+
+		/**
+		 * Fires after a new app is created.
+		 *
+		 * @param Mastodon_App $app The newly created app.
+		 */
+		do_action( 'mastodon_api_new_app', $app );
+
 		$app->post_current_settings(
 			sprintf(
 				// translators: %s: app name.

--- a/includes/handler/class-handler.php
+++ b/includes/handler/class-handler.php
@@ -120,6 +120,11 @@ class Handler {
 				}
 			}
 
+			$app = Mastodon_App::get_current_app();
+			if ( $app && $app->get_media_only() && empty( $status->media_attachments ) ) {
+				continue;
+			}
+
 			if ( ! $status->is_valid() ) {
 				error_log( wp_json_encode( compact( 'status', 'post' ) ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 				continue;

--- a/includes/integration/class-pixelfed.php
+++ b/includes/integration/class-pixelfed.php
@@ -21,6 +21,7 @@ class Pixelfed {
 	public function __construct() {
 		add_filter( 'mastodon_api_nodeinfo_software', array( $this, 'mastodon_api_pixelfed_nodeinfo_software' ) );
 		add_filter( 'mastodon_api_new_app_post_formats', array( $this, 'mastodon_api_pixelfed_post_formats' ), 10, 2 );
+		add_action( 'mastodon_api_new_app', array( $this, 'set_pixelfed_app_options' ) );
 	}
 
 	public function mastodon_api_pixelfed_nodeinfo_software( $software ) {
@@ -40,5 +41,11 @@ class Pixelfed {
 		}
 
 		return $post_formats;
+	}
+
+	public function set_pixelfed_app_options( $app ) {
+		if ( false !== strpos( $app->get_client_name(), 'Pixelfed' ) ) {
+			$app->set_media_only( true );
+		}
 	}
 }

--- a/templates/app.php
+++ b/templates/app.php
@@ -223,6 +223,10 @@ if ( ! $selected_post_format ) {
 						<p class="description">
 							<span><?php esc_html_e( 'If checked, post content will not be converted to blocks.', 'enable-mastodon-apps' ); ?></span>
 						</p>
+						<label><input type="checkbox" name="media_only" value="1" <?php checked( $app->get_media_only() ); ?> /> <?php esc_html_e( 'Only show posts with media attachments', 'enable-mastodon-apps' ); ?></label>
+						<p class="description">
+							<span><?php esc_html_e( 'If checked, posts without images or videos will be hidden from timelines.', 'enable-mastodon-apps' ); ?></span>
+						</p>
 					</td>
 				</tr>
 			</tbody>


### PR DESCRIPTION
Adds this checkbox in the settings for an app with which you can limit the posts to have attachments, useful for example for the Pixelfed client, see #280

<img width="1492" height="298" alt="Screenshot 2025-12-28 at 08 11 10" src="https://github.com/user-attachments/assets/90bab3af-06c8-443e-a964-998bd2ee8736" />
