### PR TITLE
Fix incorrect return types in timeline and statuses filter documentation

### DIFF
--- a/includes/class-mastodon-api.php
+++ b/includes/class-mastodon-api.php
@@ -2379,12 +2379,18 @@ class Mastodon_API {
 		/**
 		 * Modify the timelines data returned for `/api/timelines/(home)` requests.
 		 *
-		 * @param Entity\Status[] $statuses The statuses data.
-		 * @param WP_REST_Request $request  The request object.
-		 * @return Entity\Status[] The modified statuses data.
+		 * @param WP_REST_Response|null $statuses The statuses data.
+		 * @param WP_REST_Request       $request  The request object.
+		 * @return WP_REST_Response The modified statuses data.
 		 *
 		 * Example:
 		 * ```php
+		 * add_filter( 'mastodon_api_timelines', function( $statuses, $request ) {
+		 *     $status = new Entity\Status();
+		 *     $status->id = '1';
+		 *     $status->content = 'Hello from the timeline!';
+		 *     return new WP_REST_Response( array( $status ) );
+		 * }, 10, 2 );
 		 * ```
 		 */
 		return \apply_filters( 'mastodon_api_timelines', null, $request );
@@ -2405,12 +2411,22 @@ class Mastodon_API {
 		/**
 		 * Modify the timelines data returned for `/api/timelines/(tag)/` requests.
 		 *
-		 * @param Entity\Status[] $statuses The statuses data.
-		 * @param WP_REST_Request $request  The request object.
-		 * @return Entity\Status[] The modified statuses data.
+		 * @param WP_REST_Response|null $statuses The statuses data.
+		 * @param WP_REST_Request       $request  The request object.
+		 * @return WP_REST_Response The modified statuses data.
 		 *
 		 * Example:
 		 * ```php
+		 * add_filter( 'mastodon_api_tag_timeline', function( $statuses, $request ) {
+		 *     $tag = $request->get_param( 'hashtag' );
+		 *     $args = array( 'tag' => $tag );
+		 *     $posts = get_posts( $args );
+		 *     $statuses = array();
+		 *     foreach ( $posts as $post ) {
+		 *         $statuses[] = apply_filters( 'mastodon_api_status', null, $post->ID, array() );
+		 *     }
+		 *     return new WP_REST_Response( array_filter( $statuses ) );
+		 * }, 10, 2 );
 		 * ```
 		 */
 		return \apply_filters( 'mastodon_api_tag_timeline', null, $request );
@@ -2420,16 +2436,21 @@ class Mastodon_API {
 		/**
 		 * Modify the public timelines data returned for `/api/timelines/(public)` requests.
 		 *
-		 * @param Entity\Status[] $statuses The statuses data.
-		 * @param WP_REST_Request $request  The request object.
-		 * @return Entity\Status[] The modified statuses data.
+		 * @param WP_REST_Response|null $statuses The statuses data.
+		 * @param WP_REST_Request       $request  The request object.
+		 * @return WP_REST_Response The modified statuses data.
 		 *
 		 * Example:
 		 * ```php
 		 * add_filter( 'mastodon_api_public_timeline', function( $statuses, $request ) {
-		 *    array_unshift( $statuses, new Entity\Status( array( 'content' => 'Hello World' ) ) );
-		 *    return $statuses;
-		 * } );
+		 *     $args = array( 'post_status' => 'publish' );
+		 *     $posts = get_posts( $args );
+		 *     $statuses = array();
+		 *     foreach ( $posts as $post ) {
+		 *         $statuses[] = apply_filters( 'mastodon_api_status', null, $post->ID, array() );
+		 *     }
+		 *     return new WP_REST_Response( array_filter( $statuses ) );
+		 * }, 10, 2 );
 		 * ```
 		 */
 		return \apply_filters( 'mastodon_api_public_timeline', null, $request );
@@ -3131,10 +3152,11 @@ class Mastodon_API {
 		/**
 		 * Filter the account statuses.
 		 *
-		 * @param array|null $statuses Current statuses.
-		 * @param array $args Current statuses arguments.
-		 * @param int|null $min_id Optional minimum status ID.
-		 * @param int|null $max_id Optional maximum status ID.
+		 * @param WP_REST_Response|null $statuses Current statuses.
+		 * @param array                 $args     Current statuses arguments.
+		 * @param int|null              $min_id   Optional minimum status ID.
+		 * @param int|null              $max_id   Optional maximum status ID.
+		 * @return WP_REST_Response The statuses as a REST response.
 		 */
 		$statuses = apply_filters( 'mastodon_api_statuses', null, $args, $request->get_param( 'min_id' ), $request->get_param( 'max_id' ) );
 
@@ -3611,10 +3633,11 @@ class Mastodon_API {
 		/**
 		 * Filter the account statuses.
 		 *
-		 * @param array|null $statuses Current statuses.
-		 * @param array $args Current statuses arguments.
-		 * @param int|null $min_id Optional minimum status ID.
-		 * @param int|null $max_id Optional maximum status ID.
+		 * @param WP_REST_Response|null $statuses Current statuses.
+		 * @param array                 $args     Current statuses arguments.
+		 * @param int|null              $min_id   Optional minimum status ID.
+		 * @param int|null              $max_id   Optional maximum status ID.
+		 * @return WP_REST_Response The statuses as a REST response.
 		 */
 		$statuses = apply_filters( 'mastodon_api_statuses', null, $args, $request->get_param( 'min_id' ), $request->get_param( 'max_id' ) );
 
@@ -3641,10 +3664,11 @@ class Mastodon_API {
 		/**
 		 * Filter the account statuses.
 		 *
-		 * @param array|null $statuses Current statuses.
-		 * @param array $args Current statuses arguments.
-		 * @param int|null $min_id Optional minimum status ID.
-		 * @param int|null $max_id Optional maximum status ID.
+		 * @param WP_REST_Response|null $statuses Current statuses.
+		 * @param array                 $args     Current statuses arguments.
+		 * @param int|null              $min_id   Optional minimum status ID.
+		 * @param int|null              $max_id   Optional maximum status ID.
+		 * @return WP_REST_Response The statuses as a REST response.
 		 */
 		$statuses = apply_filters( 'mastodon_api_statuses', null, $args, $request->get_param( 'min_id' ), $request->get_param( 'max_id' ) );
 

--- a/includes/handler/class-handler.php
+++ b/includes/handler/class-handler.php
@@ -62,6 +62,14 @@ class Handler {
 		return $args;
 	}
 
+	/**
+	 * Get posts and return them as a WP_REST_Response with pagination links.
+	 *
+	 * @param array    $args   The query arguments for get_posts().
+	 * @param int|null $min_id Optional minimum post ID for pagination.
+	 * @param int|null $max_id Optional maximum post ID for pagination.
+	 * @return \WP_REST_Response The statuses as a REST response.
+	 */
 	protected function get_posts( $args, $min_id = null, $max_id = null ): \WP_REST_Response {
 		$posts = array();
 

--- a/includes/handler/class-timeline.php
+++ b/includes/handler/class-timeline.php
@@ -34,10 +34,10 @@ class Timeline extends Handler {
 	/**
 	 * Handle timeline requests.
 	 *
-	 * @param Entity\Status[] $statuses An array of Status objects.
-	 * @param WP_REST_Request $request  The request object.
+	 * @param WP_REST_Response|null $statuses The statuses data.
+	 * @param WP_REST_Request       $request  The request object.
 	 *
-	 * @return Entity\Status[]|array An array of Status objects.
+	 * @return WP_REST_Response The statuses as a REST response.
 	 */
 	public function api_timelines( $statuses, $request ) {
 		$args = $this->get_posts_query_args( array(), $request );
@@ -61,10 +61,10 @@ class Timeline extends Handler {
 	/**
 	 * Handle tag timeline requests.
 	 *
-	 * @param Entity\Status[] $statuses An array of Status objects.
-	 * @param WP_REST_Request $request The request object.
+	 * @param WP_REST_Response|null $statuses The statuses data.
+	 * @param WP_REST_Request       $request  The request object.
 	 *
-	 * @return Entity\Status[]|array An array of Status objects.
+	 * @return WP_REST_Response The statuses as a REST response.
 	 */
 	public function api_tag_timeline( $statuses, $request ) {
 		$args        = $this->get_posts_query_args( array(), $request );
@@ -89,12 +89,12 @@ class Timeline extends Handler {
 	}
 
 	/**
-	 * Handle public simeline requests
+	 * Handle public timeline requests.
 	 *
-	 * @param Entity\Status[] $statuses An array of Status objects.
-	 * @param WP_REST_Request $request The request object.
+	 * @param WP_REST_Response|null $statuses The statuses data.
+	 * @param WP_REST_Request       $request  The request object.
 	 *
-	 * @return Entity\Status[]|array An array of Status objects.
+	 * @return WP_REST_Response The statuses as a REST response.
 	 */
 	public function api_public_timeline( $statuses, $request ) {
 		$args = $this->get_posts_query_args( array(), $request );


### PR DESCRIPTION
## Summary
- Fixed `mastodon_api_timelines`, `mastodon_api_tag_timeline`, `mastodon_api_public_timeline`, and `mastodon_api_statuses` filter docblocks: they documented `Entity\Status[]` / `array|null` as param/return types but the handlers return `WP_REST_Response` via `get_posts()`
- Added missing docblock to `Handler::get_posts()` method
- Added concrete code examples to the three timeline filters that previously had empty `Example:` blocks
- Fixed "simeline" typo in `api_public_timeline` docblock

## Test plan
- [ ] Verify the docblock types match what the filter callbacks actually receive and return
- [ ] Review the examples for correctness