### PR TITLE
Use single-line status as post title when media is attached

### DIFF
--- a/includes/handler/class-status.php
+++ b/includes/handler/class-status.php
@@ -290,6 +290,9 @@ class Status extends Handler {
 			if ( count( $post_content_parts ) === 2 ) {
 				$post_data['post_title']   = wp_strip_all_tags( $post_content_parts[0] );
 				$post_data['post_content'] = trim( $post_content_parts[1] );
+			} elseif ( ! empty( $media_ids ) ) {
+				$post_data['post_title']   = wp_strip_all_tags( $status_text );
+				$post_data['post_content'] = '';
 			}
 		}
 

--- a/tests/test-statuses-endpoint.php
+++ b/tests/test-statuses-endpoint.php
@@ -207,12 +207,8 @@ class StatusesEndpoint_Test extends Mastodon_API_TestCase {
 
 		$request = $this->api_request( 'POST', '/api/v1/statuses' );
 		$request->set_param( 'status', 'caption text' );
-		$request->set_param( 'media_ids', array( $this->friend_attachment_id ) );
+		$request->set_param( 'media_ids', array( (string) $this->friend_attachment_id ) );
 		$response = $this->dispatch_authenticated( $request );
-		if ( 200 !== $response->get_status() ) {
-			fwrite( STDERR, "\nDEBUG response status={$response->get_status()} data=" . var_export( $response->get_data(), true ) . "\n" );
-			fwrite( STDERR, "friend_attachment_id={$this->friend_attachment_id} post=" . var_export( get_post( $this->friend_attachment_id ), true ) . "\n" );
-		}
 		$this->assertEquals( 200, $response->get_status() );
 
 		$p = get_post( $response->get_data()->id );

--- a/tests/test-statuses-endpoint.php
+++ b/tests/test-statuses-endpoint.php
@@ -199,6 +199,40 @@ class StatusesEndpoint_Test extends Mastodon_API_TestCase {
 		$this->assertEquals( $p->post_type, $new_post_type );
 	}
 
+	public function test_submit_single_line_standard_with_media() {
+		$this->app->set_post_formats( 'standard' );
+		$this->app->set_create_post_format( 'standard' );
+		$this->app->set_create_post_type( 'post' );
+		$this->app->set_disable_blocks( true );
+
+		$request = $this->api_request( 'POST', '/api/v1/statuses' );
+		$request->set_param( 'status', 'caption text' );
+		$request->set_param( 'media_ids', array( $this->friend_attachment_id ) );
+		$response = $this->dispatch_authenticated( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$p = get_post( $response->get_data()->id );
+		$this->assertEquals( 'caption text', $p->post_title );
+		$this->assertStringNotContainsString( 'caption text', $p->post_content );
+		$this->assertStringContainsString( 'wp:image', $p->post_content );
+	}
+
+	public function test_submit_single_line_standard_without_media() {
+		$this->app->set_post_formats( 'standard' );
+		$this->app->set_create_post_format( 'standard' );
+		$this->app->set_create_post_type( 'post' );
+		$this->app->set_disable_blocks( true );
+
+		$request = $this->api_request( 'POST', '/api/v1/statuses' );
+		$request->set_param( 'status', 'just a short toot' );
+		$response = $this->dispatch_authenticated( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$p = get_post( $response->get_data()->id );
+		$this->assertEquals( '', $p->post_title );
+		$this->assertEquals( 'just a short toot', $p->post_content );
+	}
+
 	public function test_submit_status_reply() {
 		$query = new \WP_Comment_Query();
 		$count = $query->query(

--- a/tests/test-statuses-endpoint.php
+++ b/tests/test-statuses-endpoint.php
@@ -209,6 +209,10 @@ class StatusesEndpoint_Test extends Mastodon_API_TestCase {
 		$request->set_param( 'status', 'caption text' );
 		$request->set_param( 'media_ids', array( $this->friend_attachment_id ) );
 		$response = $this->dispatch_authenticated( $request );
+		if ( 200 !== $response->get_status() ) {
+			fwrite( STDERR, "\nDEBUG response status={$response->get_status()} data=" . var_export( $response->get_data(), true ) . "\n" );
+			fwrite( STDERR, "friend_attachment_id={$this->friend_attachment_id} post=" . var_export( get_post( $this->friend_attachment_id ), true ) . "\n" );
+		}
 		$this->assertEquals( 200, $response->get_status() );
 
 		$p = get_post( $response->get_data()->id );


### PR DESCRIPTION
## Summary

- For the `standard` post format, submitting a single line of text alongside media now promotes the line to the post title and leaves the media blocks as the content — previously the title was empty and the single line became the content, so the media ended up attached to a titleless post.
- Multi-line input (`"headline\nbody"`, `"<p>…</p><p>…</p>"`, etc.) keeps its existing split-on-first-delimiter behavior.
- Single-line input *without* media is unchanged (title stays empty, line becomes content), so short toots without attachments still render normally on the blog.
- The `status` post format and other non-standard formats are untouched.

## Test plan

- [ ] `test_submit_single_line_standard_with_media` — caption + image → title = caption, content contains only the image block
- [ ] `test_submit_single_line_standard_without_media` — single line without media → title empty, content = line (unchanged)
- [ ] Existing `submit_status_data_provider` cases still pass (no expectations changed)