### PR TITLE
Add first line excerpt option

### DIFF
--- a/includes/class-mastodon-admin.php
+++ b/includes/class-mastodon-admin.php
@@ -783,6 +783,12 @@ class Mastodon_Admin {
 			$app->set_disable_blocks( false );
 		}
 
+		if ( isset( $_POST['first_line_as_excerpt'] ) ) {
+			$app->set_first_line_as_excerpt( true );
+		} else {
+			$app->set_first_line_as_excerpt( false );
+		}
+
 		if ( isset( $_POST['media_only'] ) ) {
 			$app->set_media_only( true );
 		} else {

--- a/includes/class-mastodon-app.php
+++ b/includes/class-mastodon-app.php
@@ -142,7 +142,15 @@ class Mastodon_App {
 		if ( ! is_array( $options ) ) {
 			return false;
 		}
-		return boolval( $options['blocks'] );
+		return boolval( $options['blocks'] ?? false );
+	}
+
+	public function get_first_line_as_excerpt() {
+		$options = get_term_meta( $this->term->term_id, 'options', true );
+		if ( ! is_array( $options ) ) {
+			return false;
+		}
+		return boolval( $options['first_line_as_excerpt'] ?? false );
 	}
 
 	public function set_client_secret( $client_secret ) {
@@ -177,6 +185,15 @@ class Mastodon_App {
 			$options = array();
 		}
 		$options['blocks'] = $disable_blocks;
+		return update_term_meta( $this->term->term_id, 'options', $options );
+	}
+
+	public function set_first_line_as_excerpt( $first_line_as_excerpt ) {
+		$options = get_term_meta( $this->term->term_id, 'options', true );
+		if ( ! is_array( $options ) ) {
+			$options = array();
+		}
+		$options['first_line_as_excerpt'] = $first_line_as_excerpt;
 		return update_term_meta( $this->term->term_id, 'options', $options );
 	}
 
@@ -345,6 +362,10 @@ class Mastodon_App {
 
 		if ( $this->get_disable_blocks() ) {
 			$content .= PHP_EOL . __( 'Automatic conversion to blocks is disabled', 'enable-mastodon-apps' );
+		}
+
+		if ( $this->get_first_line_as_excerpt() ) {
+			$content .= PHP_EOL . __( 'Use first content line as excerpt', 'enable-mastodon-apps' );
 		}
 
 		if ( $this->get_media_only() ) {
@@ -682,7 +703,7 @@ class Mastodon_App {
 					}
 
 					foreach ( array_keys( $value ) as $key ) {
-						if ( 'blocks' === $key || 'media_only' === $key ) {
+						if ( 'blocks' === $key || 'media_only' === $key || 'first_line_as_excerpt' === $key ) {
 							$value[ $key ] = boolval( $value[ $key ] );
 							continue;
 						}

--- a/includes/handler/class-status.php
+++ b/includes/handler/class-status.php
@@ -27,6 +27,10 @@ class Status extends Handler {
 		$this->register_hooks();
 	}
 
+	protected static function get_line_split_pattern() {
+		return '/(<br>|<br \/>|<\/p>|' . PHP_EOL . ')/i';
+	}
+
 	public function register_hooks() {
 		add_filter( 'mastodon_api_status', array( $this, 'api_status' ), 10, 2 );
 		add_filter( 'mastodon_api_status', array( $this, 'api_status_ensure_numeric_id' ), 100 );
@@ -229,7 +233,7 @@ class Status extends Handler {
 	}
 
 	public static function convert_to_blocks( $post_content ) {
-		$post_content = preg_split( '/(<br>|<br \/>|<\/p>|' . PHP_EOL . ')/i', $post_content );
+		$post_content = preg_split( self::get_line_split_pattern(), $post_content );
 		$post_content = array_map( 'trim', $post_content );
 		$post_content = array_map(
 			function ( $el ) {
@@ -245,6 +249,15 @@ class Status extends Handler {
 		}
 		$post_content = '<!-- wp:paragraph -->' . PHP_EOL . '<p>' . implode( '</p>' . PHP_EOL . '<!-- /wp:paragraph -->' . PHP_EOL . PHP_EOL . '<!-- wp:paragraph -->' . PHP_EOL . '<p>', $post_content ) . '</p>' . PHP_EOL . '<!-- /wp:paragraph -->';
 		return $post_content;
+	}
+
+	public static function extract_first_line( $post_content ) {
+		$post_content_parts = preg_split( self::get_line_split_pattern(), $post_content, 2 );
+		if ( empty( $post_content_parts ) ) {
+			return '';
+		}
+
+		return trim( wp_strip_all_tags( $post_content_parts[0] ) );
 	}
 
 	public function prepare_post_data( $post_id, $status_text, $in_reply_to_id, $media_ids, $post_format, $visibility, $scheduled_at ) {
@@ -286,13 +299,17 @@ class Status extends Handler {
 		$post_data['post_title'] = '';
 
 		if ( ! $post_format || 'standard' === $post_format ) {
-			$post_content_parts = preg_split( '/(<br>|<br \/>|<\/p>|' . PHP_EOL . ')/i', $status_text, 2 );
+			$post_content_parts = preg_split( self::get_line_split_pattern(), $status_text, 2 );
 			if ( count( $post_content_parts ) === 2 ) {
 				$post_data['post_title']   = wp_strip_all_tags( $post_content_parts[0] );
 				$post_data['post_content'] = trim( $post_content_parts[1] );
 			} elseif ( ! empty( $media_ids ) ) {
 				$post_data['post_title']   = wp_strip_all_tags( $status_text );
 				$post_data['post_content'] = '';
+			}
+
+			if ( $app->get_first_line_as_excerpt() && ! empty( $post_data['post_content'] ) ) {
+				$post_data['post_excerpt'] = self::extract_first_line( $post_data['post_content'] );
 			}
 		}
 
@@ -340,6 +357,22 @@ class Status extends Handler {
 				}
 			}
 		}
+
+		/**
+		 * Allow modifying the post data before it gets inserted or updated.
+		 *
+		 * @param array        $post_data      The post data for wp_insert_post() or wp_update_post().
+		 * @param string       $status_text    The user submitted status text after filtering.
+		 * @param int|string|null $in_reply_to_id The ID of the status to reply to.
+		 * @param array        $media_ids      The media attachment IDs.
+		 * @param string       $post_format    The post format to create.
+		 * @param string       $visibility     The requested status visibility.
+		 * @param string|null  $scheduled_at   The scheduled post date.
+		 * @param int|null     $post_id        The post ID when updating.
+		 * @param Mastodon_App $app            The app creating or updating the post.
+		 * @return array The potentially modified post data.
+		 */
+		$post_data = apply_filters( 'mastodon_api_submit_post_data', $post_data, $status_text, $in_reply_to_id, $media_ids, $post_format, $visibility, $scheduled_at, $post_id, $app );
 
 		return $post_data;
 	}

--- a/templates/app.php
+++ b/templates/app.php
@@ -223,6 +223,10 @@ if ( ! $selected_post_format ) {
 						<p class="description">
 							<span><?php esc_html_e( 'If checked, post content will not be converted to blocks.', 'enable-mastodon-apps' ); ?></span>
 						</p>
+						<label><input type="checkbox" name="first_line_as_excerpt" value="1" <?php checked( $app->get_first_line_as_excerpt() ); ?> /> <?php esc_html_e( 'Use first content line as excerpt', 'enable-mastodon-apps' ); ?></label>
+						<p class="description">
+							<span><?php esc_html_e( 'If checked, the first line after the title will be used as the WordPress excerpt for standard posts.', 'enable-mastodon-apps' ); ?></span>
+						</p>
 						<label><input type="checkbox" name="media_only" value="1" <?php checked( $app->get_media_only() ); ?> /> <?php esc_html_e( 'Only show posts with media attachments', 'enable-mastodon-apps' ); ?></label>
 						<p class="description">
 							<span><?php esc_html_e( 'If checked, posts without images or videos will be hidden from timelines.', 'enable-mastodon-apps' ); ?></span>

--- a/tests/test-statuses-endpoint.php
+++ b/tests/test-statuses-endpoint.php
@@ -233,6 +233,49 @@ class StatusesEndpoint_Test extends Mastodon_API_TestCase {
 		$this->assertEquals( 'just a short toot', $p->post_content );
 	}
 
+	public function test_submit_standard_uses_first_content_line_as_excerpt() {
+		$this->app->set_post_formats( 'standard' );
+		$this->app->set_create_post_format( 'standard' );
+		$this->app->set_create_post_type( 'post' );
+		$this->app->set_disable_blocks( true );
+		$this->app->set_first_line_as_excerpt( true );
+
+		$request = $this->api_request( 'POST', '/api/v1/statuses' );
+		$request->set_param( 'status', 'headline' . PHP_EOL . 'summary' . PHP_EOL . 'post content' );
+		$response = $this->dispatch_authenticated( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$p = get_post( $response->get_data()->id );
+		$this->assertEquals( 'headline', $p->post_title );
+		$this->assertEquals( 'summary', $p->post_excerpt );
+		$this->assertEquals( 'summary' . PHP_EOL . 'post content', $p->post_content );
+	}
+
+	public function test_submit_status_post_data_filter() {
+		$this->app->set_post_formats( 'standard' );
+		$this->app->set_create_post_format( 'standard' );
+		$this->app->set_create_post_type( 'post' );
+		$this->app->set_disable_blocks( true );
+
+		$filter = function ( $post_data ) {
+			$post_data['post_excerpt'] = 'filtered excerpt';
+			return $post_data;
+		};
+
+		add_filter( 'mastodon_api_submit_post_data', $filter, 10, 9 );
+		try {
+			$request = $this->api_request( 'POST', '/api/v1/statuses' );
+			$request->set_param( 'status', 'headline' . PHP_EOL . 'post content' );
+			$response = $this->dispatch_authenticated( $request );
+			$this->assertEquals( 200, $response->get_status() );
+		} finally {
+			remove_filter( 'mastodon_api_submit_post_data', $filter, 10 );
+		}
+
+		$p = get_post( $response->get_data()->id );
+		$this->assertEquals( 'filtered excerpt', $p->post_excerpt );
+	}
+
 	public function test_submit_status_reply() {
 		$query = new \WP_Comment_Query();
 		$count = $query->query(


### PR DESCRIPTION
## Summary
- Add a per-app option to copy the first content line into `post_excerpt` for standard posts.
- Add `mastodon_api_submit_post_data` so plugins can filter prepared post data before insert/update.
- Cover the excerpt option and post data filter in status endpoint tests.

Fixes #200

## Tests
- `git diff --check`
- `./vendor/bin/phpcs includes/class-mastodon-app.php includes/class-mastodon-admin.php includes/handler/class-status.php templates/app.php tests/test-statuses-endpoint.php`

PHPUnit was not run locally because `/tmp/wordpress-tests-lib/includes/functions.php` is missing.