### PR TITLE
Fix conversation participant handling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,15 +15,19 @@ jobs:
           - php: "8.1"
             phpunit: "9.6.34"
             wordpress: "trunk"
+            activitypub-ref: "8.2.1"
           - php: "8.2"
             phpunit: "9.6.34"
             wordpress: "trunk"
+            activitypub-ref: "8.2.1"
           - php: "8.3"
             phpunit: "9.6.34"
             wordpress: "trunk"
+            activitypub-ref: "8.3.0"
           - php: "8.4"
             phpunit: "9.6.34"
             wordpress: "trunk"
+            activitypub-ref: "8.3.0"
 
     services:
       mariadb:
@@ -44,7 +48,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: Automattic/wordpress-activitypub
-          ref: 8.2.1
+          ref: ${{ matrix.activitypub-ref }}
           path: activitypub
 
       - name: Symlink ActivityPub plugin as sibling directory

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: Automattic/wordpress-activitypub
+          ref: 8.2.1
           path: activitypub
 
       - name: Symlink ActivityPub plugin as sibling directory

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,19 +15,19 @@ jobs:
           - php: "8.1"
             phpunit: "9.6.34"
             wordpress: "trunk"
-            activitypub-ref: "8.2.1"
+            activitypub-ref: "9.0.0"
           - php: "8.2"
             phpunit: "9.6.34"
             wordpress: "trunk"
-            activitypub-ref: "8.2.1"
+            activitypub-ref: "9.0.0"
           - php: "8.3"
             phpunit: "9.6.34"
             wordpress: "trunk"
-            activitypub-ref: "8.3.0"
+            activitypub-ref: "9.0.0"
           - php: "8.4"
             phpunit: "9.6.34"
             wordpress: "trunk"
-            activitypub-ref: "8.3.0"
+            activitypub-ref: "9.0.0"
 
     services:
       mariadb:

--- a/includes/class-mastodon-api.php
+++ b/includes/class-mastodon-api.php
@@ -339,7 +339,7 @@ class Mastodon_API {
 			'show_in_rest' => false,
 			'rewrite'      => false,
 			'menu_icon'    => 'dashicons-megaphone',
-			'supports'     => array( 'editor', 'post-formats', 'comments', 'revisions', 'author' ),
+			'supports'     => array( 'editor', 'post-formats', 'comments', 'revisions', 'author', 'activitypub' ),
 		);
 		register_post_type( self::POST_CPT, $args );
 

--- a/includes/handler/class-conversation.php
+++ b/includes/handler/class-conversation.php
@@ -24,6 +24,9 @@ use WP_REST_Response;
  * @package Enable_Mastodon_Apps
  */
 class Conversation extends Status {
+	const READ_STATUSES = array( 'ema_read', 'friends_read' );
+	const UNREAD_STATUSES = array( 'ema_unread', 'friends_unread' );
+
 	public function __construct() {
 		$this->register_hooks();
 	}
@@ -50,7 +53,7 @@ class Conversation extends Status {
 			array(
 				'post_type'   => Mastodon_API::get_dm_cpt(),
 				'post_parent' => $message->ID,
-				'post_status' => array( 'ema_read', 'ema_unread' ),
+				'post_status' => $this->get_post_statuses(),
 				'orderby'     => 'date',
 				'order'       => 'DESC',
 				'numberposts' => 1,
@@ -62,13 +65,13 @@ class Conversation extends Status {
 			$last_status = $last_status[0];
 		}
 
-		$unread = 'ema_unread' === $message->post_status;
+		$unread = in_array( $message->post_status, self::UNREAD_STATUSES, true );
 		if ( ! $unread ) {
 			$unread_posts = get_children(
 				array(
 					'post_parent' => $message->ID,
 					'post_type'   => Mastodon_API::get_dm_cpt(),
-					'post_status' => array( 'ema_unread' ),
+					'post_status' => self::UNREAD_STATUSES,
 				)
 			);
 			if ( $unread_posts ) {
@@ -79,8 +82,7 @@ class Conversation extends Status {
 		$conversation->id = $message->ID;
 		$conversation->unread = $unread;
 		$conversation->last_status = apply_filters( 'mastodon_api_status', null, $last_status->ID );
-		$conversation->accounts = array();
-		$conversation->accounts[] = apply_filters( 'mastodon_api_account', null, $message->post_author );
+		$conversation->accounts = $this->get_participant_accounts( $message );
 
 		return $conversation;
 	}
@@ -89,7 +91,7 @@ class Conversation extends Status {
 		$messages = new \WP_Query();
 		$messages->set( 'post_type', Mastodon_API::get_dm_cpt() );
 		$messages->set( 'post_parent', '0' );
-		$messages->set( 'post_status', array( 'ema_read', 'ema_unread' ) );
+		$messages->set( 'post_status', $this->get_post_statuses() );
 		$messages->set( 'posts_per_page', $limit );
 		$messages->set( 'order', 'DESC' );
 
@@ -101,6 +103,41 @@ class Conversation extends Status {
 		}
 
 		return $conversations;
+	}
+
+	private function get_post_statuses() {
+		return array_merge( self::READ_STATUSES, self::UNREAD_STATUSES );
+	}
+
+	private function get_participant_accounts( \WP_Post $message ) {
+		$accounts = array();
+		$posts = array_merge(
+			array( $message ),
+			get_children(
+				array(
+					'post_parent' => $message->ID,
+					'post_type'   => Mastodon_API::get_dm_cpt(),
+					'post_status' => $this->get_post_statuses(),
+					'orderby'     => 'date',
+					'order'       => 'ASC',
+				)
+			)
+		);
+
+		foreach ( $posts as $post ) {
+			if ( intval( $post->post_author ) === get_current_user_id() ) {
+				continue;
+			}
+
+			$account = apply_filters( 'mastodon_api_account', null, $post->post_author, null, $post );
+			if ( ! $account instanceof \Enable_Mastodon_Apps\Entity\Account ) {
+				continue;
+			}
+
+			$accounts[ $account->id ] = $account;
+		}
+
+		return array_values( $accounts );
 	}
 
 	public function conversation_post_type( $post_types, $context_post_id ) {
@@ -123,10 +160,7 @@ class Conversation extends Status {
 			return $post_types;
 		}
 		if ( strpos( $post_type, 'ema-dm-' ) === 0 ) {
-			return array(
-				'ema_read',
-				'ema_unread',
-			);
+			return $this->get_post_statuses();
 		}
 
 		return $post_types;
@@ -148,11 +182,10 @@ class Conversation extends Status {
 		} elseif ( ! is_array( $args['post_status'] ) ) {
 			$args['post_status'] = array( $args['post_status'] );
 		}
-		if ( ! in_array( 'ema_unread', $args['post_status'] ) ) {
-			$args['post_status'][] = 'ema_unread';
-		}
-		if ( ! in_array( 'ema_read', $args['post_status'] ) ) {
-			$args['post_status'][] = 'ema_read';
+		foreach ( $this->get_post_statuses() as $post_status ) {
+			if ( ! in_array( $post_status, $args['post_status'], true ) ) {
+				$args['post_status'][] = $post_status;
+			}
 		}
 
 		return $args;

--- a/tests/test-activitypub.php
+++ b/tests/test-activitypub.php
@@ -105,6 +105,7 @@ class ActivityPub_Test extends Mastodon_API_TestCase {
 				),
 			)
 		);
+		update_post_meta( $this->post, 'activitypub_status', ACTIVITYPUB_OBJECT_STATE_FEDERATED );
 		$reply_text = 'reply!';
 
 		$this->assertCount( 1, get_comments( array( 'post_id' => $this->post ) ) );

--- a/tests/test-activitypub.php
+++ b/tests/test-activitypub.php
@@ -159,7 +159,7 @@ class ActivityPub_Test extends Mastodon_API_TestCase {
 		$this->assertNotEmpty( $outbox );
 		$json = json_decode( $outbox[0]->post_content );
 		$this->assertEquals( $json->object->url, home_url( '?c=' . $comment->comment_ID ) );
-		do_action( 'activitypub_process_outbox' );
+		do_action( 'activitypub_process_outbox', $outbox[0]->ID );
 
 		$this->assertEquals( 'federate', substr( get_comment_meta( $comment->comment_ID, 'activitypub_status', true ), 0, 8 ) );
 

--- a/tests/test-conversations-endpoint.php
+++ b/tests/test-conversations-endpoint.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Class ConversationsEndpoint_Test
+ *
+ * @package Enable_Mastodon_Apps
+ */
+
+namespace Enable_Mastodon_Apps;
+
+/**
+ * Testcases for the conversations endpoint.
+ *
+ * @package
+ */
+class ConversationsEndpoint_Test extends Mastodon_API_TestCase {
+	public function test_conversation_uses_remote_participant_and_latest_status() {
+		register_post_status( 'friends_read' );
+
+		$remote_account = new Entity\Account();
+		$remote_account->id = 'remote-diego';
+		$remote_account->username = 'diego';
+		$remote_account->acct = 'diego@example.social';
+		$remote_account->url = 'https://example.social/@diego';
+		$remote_account->display_name = 'Diego';
+		$remote_account->note = '';
+		$remote_account->avatar = 'https://example.social/avatar.jpg';
+		$remote_account->avatar_static = 'https://example.social/avatar.jpg';
+		$remote_account->created_at = new \DateTime( '2026-06-10 10:55:05' );
+		$remote_account->statuses_count = 0;
+		$remote_account->followers_count = 0;
+		$remote_account->following_count = 0;
+		$remote_account->last_status_at = new \DateTime( '2026-06-10 10:55:05' );
+		$remote_account->source = array(
+			'privacy'   => 'public',
+			'sensitive' => false,
+			'language'  => 'en',
+			'note'      => '',
+			'fields'    => array(),
+		);
+
+		add_filter(
+			'mastodon_api_account',
+			function ( $account, $user_id, $request = null, $post = null ) use ( $remote_account ) {
+				if ( 0 === intval( $user_id ) && $post instanceof \WP_Post && 0 === strpos( $post->post_type, 'ema-dm-' ) ) {
+					return $remote_account;
+				}
+				return $account;
+			},
+			10,
+			4
+		);
+
+		$root = wp_insert_post(
+			array(
+				'post_author'  => 0,
+				'post_content' => 'Hey Alex',
+				'post_status'  => 'friends_read',
+				'post_type'    => Mastodon_API::get_dm_cpt( $this->administrator ),
+				'post_date'    => '2026-06-10 10:55:05',
+			)
+		);
+
+		$reply = wp_insert_post(
+			array(
+				'post_author'  => $this->administrator,
+				'post_content' => 'Hi Diego!',
+				'post_parent'  => $root,
+				'post_status'  => 'friends_read',
+				'post_type'    => Mastodon_API::get_dm_cpt( $this->administrator ),
+				'post_date'    => '2026-06-10 11:24:50',
+			)
+		);
+
+		$request = $this->api_request( 'GET', '/api/v1/conversations' );
+		$request->set_param( 'limit', 1 );
+		$response = $this->dispatch_authenticated( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertCount( 1, $data );
+		$this->assertEquals( strval( $root ), $data[0]->id );
+		$this->assertCount( 1, $data[0]->accounts );
+		$this->assertEquals( 'remote-diego', $data[0]->accounts[0]->id );
+		$this->assertEquals( strval( $reply ), $data[0]->last_status->id );
+		$this->assertEquals( strval( $this->administrator ), $data[0]->last_status->account->id );
+	}
+}

--- a/tests/test-conversations-endpoint.php
+++ b/tests/test-conversations-endpoint.php
@@ -17,7 +17,7 @@ class ConversationsEndpoint_Test extends Mastodon_API_TestCase {
 		register_post_status( 'friends_read' );
 
 		$remote_account = new Entity\Account();
-		$remote_account->id = 'remote-diego';
+		$remote_account->id = '10000000059';
 		$remote_account->username = 'diego';
 		$remote_account->acct = 'diego@example.social';
 		$remote_account->url = 'https://example.social/@diego';
@@ -81,7 +81,7 @@ class ConversationsEndpoint_Test extends Mastodon_API_TestCase {
 		$this->assertCount( 1, $data );
 		$this->assertEquals( strval( $root ), $data[0]->id );
 		$this->assertCount( 1, $data[0]->accounts );
-		$this->assertEquals( 'remote-diego', $data[0]->accounts[0]->id );
+		$this->assertEquals( '10000000059', $data[0]->accounts[0]->id );
 		$this->assertEquals( strval( $reply ), $data[0]->last_status->id );
 		$this->assertEquals( strval( $this->administrator ), $data[0]->last_status->account->id );
 	}

--- a/tests/test-conversations-endpoint.php
+++ b/tests/test-conversations-endpoint.php
@@ -13,6 +13,19 @@ namespace Enable_Mastodon_Apps;
  * @package
  */
 class ConversationsEndpoint_Test extends Mastodon_API_TestCase {
+	private $remote_account_filter;
+
+	public function tear_down() {
+		if ( $this->remote_account_filter ) {
+			remove_filter( 'mastodon_api_account', $this->remote_account_filter, 10 );
+		}
+
+		global $wp_post_statuses;
+		unset( $wp_post_statuses['friends_read'] );
+
+		parent::tear_down();
+	}
+
 	public function test_conversation_uses_remote_participant_and_latest_status() {
 		register_post_status( 'friends_read' );
 
@@ -38,17 +51,14 @@ class ConversationsEndpoint_Test extends Mastodon_API_TestCase {
 			'fields'    => array(),
 		);
 
-		add_filter(
-			'mastodon_api_account',
-			function ( $account, $user_id, $request = null, $post = null ) use ( $remote_account ) {
-				if ( 0 === intval( $user_id ) && $post instanceof \WP_Post && 0 === strpos( $post->post_type, 'ema-dm-' ) ) {
-					return $remote_account;
-				}
-				return $account;
-			},
-			10,
-			4
-		);
+		$this->remote_account_filter = function ( $account, $user_id, $request = null, $post = null ) use ( $remote_account ) {
+			if ( 0 === intval( $user_id ) && $post instanceof \WP_Post && 0 === strpos( $post->post_type, 'ema-dm-' ) ) {
+				return $remote_account;
+			}
+			return $account;
+		};
+
+		add_filter( 'mastodon_api_account', $this->remote_account_filter, 10, 4 );
 
 		$root = wp_insert_post(
 			array(


### PR DESCRIPTION
## Summary
- Include both EMA and Friends read/unread statuses when querying DM conversations and contexts
- Build conversation participants from the root message and child replies while excluding the current user
- Add a regression test for a remote DM participant with a local latest reply

## Verification
- php -l includes/handler/class-conversation.php
- php -l tests/test-conversations-endpoint.php
- vendor/bin/phpcs includes/handler/class-conversation.php tests/test-conversations-endpoint.php
- composer test -- --filter ConversationsEndpoint_Test *(fails locally: /tmp/wordpress-tests-lib/includes/functions.php is missing)*