### PR TITLE
Add configurable reaction mapping

### DIFF
--- a/includes/class-mastodon-admin.php
+++ b/includes/class-mastodon-admin.php
@@ -795,6 +795,14 @@ class Mastodon_Admin {
 			$app->set_media_only( false );
 		}
 
+		if ( class_exists( 'Friends\Reactions' ) && isset( $_POST['favourite_reaction'] ) ) {
+			$app->set_favourite_reaction( sanitize_key( wp_unslash( $_POST['favourite_reaction'] ) ) );
+		}
+
+		if ( class_exists( 'Friends\Reactions' ) && isset( $_POST['bookmark_reaction'] ) ) {
+			$app->set_bookmark_reaction( sanitize_key( wp_unslash( $_POST['bookmark_reaction'] ) ) );
+		}
+
 		$app->post_current_settings();
 	}
 

--- a/includes/class-mastodon-api.php
+++ b/includes/class-mastodon-api.php
@@ -79,6 +79,8 @@ class Mastodon_API {
 		add_filter( 'rest_request_before_callbacks', array( $this, 'rest_request_before_callbacks' ), 10, 3 );
 		add_filter( 'rest_authentication_errors', array( $this, 'rest_authentication_errors' ), 20 );
 		add_filter( 'mastodon_api_mapback_user_id', array( $this, 'mapback_user_id' ) );
+		add_filter( 'mastodon_api_favourite_reaction', array( $this, 'mastodon_api_favourite_reaction' ), 10, 2 );
+		add_filter( 'mastodon_api_bookmark_reaction', array( $this, 'mastodon_api_bookmark_reaction' ), 10, 2 );
 		add_filter( 'mastodon_api_in_reply_to_id', array( self::class, 'maybe_get_remapped_reblog_id' ), 15 );
 		add_filter( 'mastodon_api_in_reply_to_id', array( self::class, 'maybe_get_remapped_url' ), 20 );
 		add_filter( 'activitypub_support_post_types', array( $this, 'activitypub_support_post_types' ) );
@@ -448,6 +450,8 @@ class Mastodon_API {
 				'api/v1/statuses/([0-9]+)/favourited_by' => 'api/v1/statuses/$matches[1]/favourited_by',
 				'api/v1/statuses/([0-9]+)/favourite'     => 'api/v1/statuses/$matches[1]/favourite',
 				'api/v1/statuses/([0-9]+)/unfavourite'   => 'api/v1/statuses/$matches[1]/unfavourite',
+				'api/v1/statuses/([0-9]+)/bookmark'      => 'api/v1/statuses/$matches[1]/bookmark',
+				'api/v1/statuses/([0-9]+)/unbookmark'    => 'api/v1/statuses/$matches[1]/unbookmark',
 				'api/v1/statuses/([0-9]+)/reblog'        => 'api/v1/statuses/$matches[1]/reblog',
 				'api/v1/statuses/([0-9]+)/unreblog'      => 'api/v1/statuses/$matches[1]/unreblog',
 				'api/v1/conversations/([0-9]+)/read'     => 'api/v1/conversations/$matches[1]/read',
@@ -1239,6 +1243,26 @@ class Mastodon_API {
 				'methods'             => array( 'POST', 'OPTIONS' ),
 				'callback'            => array( $this, 'api_unfavourite_post' ),
 				'permission_callback' => $this->required_scope( 'write:favourites' ),
+			)
+		);
+
+		register_rest_route(
+			self::PREFIX,
+			'api/v1/statuses/(?P<post_id>[0-9]+)/bookmark',
+			array(
+				'methods'             => array( 'POST', 'OPTIONS' ),
+				'callback'            => array( $this, 'api_bookmark_post' ),
+				'permission_callback' => $this->required_scope( 'write:bookmarks' ),
+			)
+		);
+
+		register_rest_route(
+			self::PREFIX,
+			'api/v1/statuses/(?P<post_id>[0-9]+)/unbookmark',
+			array(
+				'methods'             => array( 'POST', 'OPTIONS' ),
+				'callback'            => array( $this, 'api_unbookmark_post' ),
+				'permission_callback' => $this->required_scope( 'write:bookmarks' ),
 			)
 		);
 
@@ -2634,42 +2658,58 @@ class Mastodon_API {
 		return apply_filters( 'mastodon_api_status_context', $context, $context_post_id, $url );
 	}
 
-	public function api_favourite_post( $request ) {
-		$post_id = $request->get_param( 'post_id' );
-		if ( ! $post_id ) {
-			return false;
+	protected function get_reaction_for_status_action( string $action ) {
+		if ( 'bookmark' === $action ) {
+			$reaction = apply_filters( 'mastodon_api_default_bookmark_reaction', apply_filters( 'friends_bookmarks_emoji', '2b50' ), null );
+			return apply_filters( 'mastodon_api_bookmark_reaction', $reaction, Mastodon_App::get_current_app() );
 		}
 
-		$post_id = self::maybe_get_remapped_reblog_id( $post_id );
+		$reaction = apply_filters( 'mastodon_api_default_favourite_reaction', apply_filters( 'friends_favourites_emoji', '2764' ), null );
+		return apply_filters( 'mastodon_api_favourite_reaction', $reaction, Mastodon_App::get_current_app() );
+	}
 
-		// 2b50 = star
-		// 2764 = heart
-		do_action( 'mastodon_api_react', $post_id, '2b50' );
+	public function mastodon_api_favourite_reaction( $reaction, $app = null ) {
+		if ( ! $app ) {
+			$app = Mastodon_App::get_current_app();
+		}
 
-		/**
-		 * Modify the status data.
-		 *
-		 * @param Entity\Status|null $status  The status data.
-		 * @param int                $post_id The object ID to get the status from.
-		 * @param array              $data    Additional status data.
-		 * @return Entity\Status|null The modified status data.
-		 */
-		$status = apply_filters( 'mastodon_api_status', null, $post_id, array() );
+		if ( $app ) {
+			return $app->get_favourite_reaction();
+		}
+
+		return $reaction;
+	}
+
+	public function mastodon_api_bookmark_reaction( $reaction, $app = null ) {
+		if ( ! $app ) {
+			$app = Mastodon_App::get_current_app();
+		}
+
+		if ( $app ) {
+			return $app->get_bookmark_reaction();
+		}
+
+		return $reaction;
+	}
+
+	protected function get_requested_reblog_status( $status, $requested_id ) {
+		if ( $status && isset( $status->reblog ) && strval( $status->reblog->id ) === strval( $requested_id ) ) {
+			return $status->reblog;
+		}
 
 		return $status;
 	}
 
-	public function api_unfavourite_post( $request ) {
-		$post_id = $request->get_param( 'post_id' );
+	public function api_favourite_post( $request ) {
+		$post_id       = $request->get_param( 'post_id' );
+		$requested_id  = $post_id;
 		if ( ! $post_id ) {
 			return false;
 		}
 
 		$post_id = self::maybe_get_remapped_reblog_id( $post_id );
 
-		// 2b50 = star
-		// 2764 = heart
-		do_action( 'mastodon_api_unreact', $post_id, '2b50' );
+		do_action( 'mastodon_api_react', $post_id, $this->get_reaction_for_status_action( 'favourite' ) );
 
 		/**
 		 * Modify the status data.
@@ -2681,7 +2721,79 @@ class Mastodon_API {
 		 */
 		$status = apply_filters( 'mastodon_api_status', null, $post_id, array() );
 
-		return $status;
+		return $this->get_requested_reblog_status( $status, $requested_id );
+	}
+
+	public function api_unfavourite_post( $request ) {
+		$post_id      = $request->get_param( 'post_id' );
+		$requested_id = $post_id;
+		if ( ! $post_id ) {
+			return false;
+		}
+
+		$post_id = self::maybe_get_remapped_reblog_id( $post_id );
+
+		do_action( 'mastodon_api_unreact', $post_id, $this->get_reaction_for_status_action( 'favourite' ) );
+
+		/**
+		 * Modify the status data.
+		 *
+		 * @param Entity\Status|null $status  The status data.
+		 * @param int                $post_id The object ID to get the status from.
+		 * @param array              $data    Additional status data.
+		 * @return Entity\Status|null The modified status data.
+		 */
+		$status = apply_filters( 'mastodon_api_status', null, $post_id, array() );
+
+		return $this->get_requested_reblog_status( $status, $requested_id );
+	}
+
+	public function api_bookmark_post( $request ) {
+		$post_id      = $request->get_param( 'post_id' );
+		$requested_id = $post_id;
+		if ( ! $post_id ) {
+			return false;
+		}
+
+		$post_id = self::maybe_get_remapped_reblog_id( $post_id );
+
+		do_action( 'mastodon_api_react', $post_id, $this->get_reaction_for_status_action( 'bookmark' ) );
+
+		/**
+		 * Modify the status data.
+		 *
+		 * @param Entity\Status|null $status  The status data.
+		 * @param int                $post_id The object ID to get the status from.
+		 * @param array              $data    Additional status data.
+		 * @return Entity\Status|null The modified status data.
+		 */
+		$status = apply_filters( 'mastodon_api_status', null, $post_id, array() );
+
+		return $this->get_requested_reblog_status( $status, $requested_id );
+	}
+
+	public function api_unbookmark_post( $request ) {
+		$post_id      = $request->get_param( 'post_id' );
+		$requested_id = $post_id;
+		if ( ! $post_id ) {
+			return false;
+		}
+
+		$post_id = self::maybe_get_remapped_reblog_id( $post_id );
+
+		do_action( 'mastodon_api_unreact', $post_id, $this->get_reaction_for_status_action( 'bookmark' ) );
+
+		/**
+		 * Modify the status data.
+		 *
+		 * @param Entity\Status|null $status  The status data.
+		 * @param int                $post_id The object ID to get the status from.
+		 * @param array              $data    Additional status data.
+		 * @return Entity\Status|null The modified status data.
+		 */
+		$status = apply_filters( 'mastodon_api_status', null, $post_id, array() );
+
+		return $this->get_requested_reblog_status( $status, $requested_id );
 	}
 
 	public function api_reblog_post( $request ) {

--- a/includes/class-mastodon-app.php
+++ b/includes/class-mastodon-app.php
@@ -153,6 +153,24 @@ class Mastodon_App {
 		return boolval( $options['first_line_as_excerpt'] ?? false );
 	}
 
+	public function get_favourite_reaction() {
+		$options = get_term_meta( $this->term->term_id, 'options', true );
+		if ( ! is_array( $options ) || empty( $options['favourite_reaction'] ) ) {
+			return apply_filters( 'mastodon_api_default_favourite_reaction', apply_filters( 'friends_favourites_emoji', '2764' ), $this );
+		}
+
+		return $options['favourite_reaction'];
+	}
+
+	public function get_bookmark_reaction() {
+		$options = get_term_meta( $this->term->term_id, 'options', true );
+		if ( ! is_array( $options ) || empty( $options['bookmark_reaction'] ) ) {
+			return apply_filters( 'mastodon_api_default_bookmark_reaction', apply_filters( 'friends_bookmarks_emoji', '2b50' ), $this );
+		}
+
+		return $options['bookmark_reaction'];
+	}
+
 	public function set_client_secret( $client_secret ) {
 		return update_term_meta( $this->term->term_id, 'client_secret', $client_secret );
 	}
@@ -194,6 +212,24 @@ class Mastodon_App {
 			$options = array();
 		}
 		$options['first_line_as_excerpt'] = $first_line_as_excerpt;
+		return update_term_meta( $this->term->term_id, 'options', $options );
+	}
+
+	public function set_favourite_reaction( $reaction ) {
+		$options = get_term_meta( $this->term->term_id, 'options', true );
+		if ( ! is_array( $options ) ) {
+			$options = array();
+		}
+		$options['favourite_reaction'] = $reaction;
+		return update_term_meta( $this->term->term_id, 'options', $options );
+	}
+
+	public function set_bookmark_reaction( $reaction ) {
+		$options = get_term_meta( $this->term->term_id, 'options', true );
+		if ( ! is_array( $options ) ) {
+			$options = array();
+		}
+		$options['bookmark_reaction'] = $reaction;
 		return update_term_meta( $this->term->term_id, 'options', $options );
 	}
 
@@ -371,6 +407,9 @@ class Mastodon_App {
 		if ( $this->get_media_only() ) {
 			$content .= PHP_EOL . __( 'Only show posts with media attachments', 'enable-mastodon-apps' );
 		}
+
+		$content .= PHP_EOL . __( 'Favourite reaction', 'enable-mastodon-apps' ) . ': ' . $this->get_favourite_reaction();
+		$content .= PHP_EOL . __( 'Bookmark reaction', 'enable-mastodon-apps' ) . ': ' . $this->get_bookmark_reaction();
 
 		return trim( $content );
 	}
@@ -705,6 +744,10 @@ class Mastodon_App {
 					foreach ( array_keys( $value ) as $key ) {
 						if ( 'blocks' === $key || 'media_only' === $key || 'first_line_as_excerpt' === $key ) {
 							$value[ $key ] = boolval( $value[ $key ] );
+							continue;
+						}
+						if ( 'favourite_reaction' === $key || 'bookmark_reaction' === $key ) {
+							$value[ $key ] = strtolower( sanitize_key( $value[ $key ] ) );
 							continue;
 						}
 						unset( $value[ $key ] );

--- a/templates/app.php
+++ b/templates/app.php
@@ -39,6 +39,10 @@ $selected_post_format = $app->get_create_post_format();
 if ( ! $selected_post_format ) {
 	$selected_post_format = 'standard';
 }
+$available_reactions = array();
+if ( class_exists( 'Friends\Reactions' ) ) {
+	$available_reactions = Friends\Reactions::get_available_emojis();
+}
 ?>
 <div class="enable-mastodon-apps-settings enable-mastodon-apps-registered-apps-page <?php echo $args['enable_debug'] ? 'enable-debug' : 'disable-debug'; ?>">
 	<form method="post">
@@ -217,22 +221,65 @@ if ( ! $selected_post_format ) {
 					</td>
 				</tr>
 				<tr>
-					<th scope="row"><?php esc_html_e( 'Options', 'enable-mastodon-apps' ); ?></th>
+					<th scope="row"><?php esc_html_e( 'Content formatting', 'enable-mastodon-apps' ); ?></th>
 					<td>
 						<label><input type="checkbox" name="disable_blocks" value="1" <?php checked( $app->get_disable_blocks() ); ?> /> <?php esc_html_e( 'Disable automatic conversion to blocks', 'enable-mastodon-apps' ); ?></label>
 						<p class="description">
 							<span><?php esc_html_e( 'If checked, post content will not be converted to blocks.', 'enable-mastodon-apps' ); ?></span>
 						</p>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row"><?php esc_html_e( 'Excerpt', 'enable-mastodon-apps' ); ?></th>
+					<td>
 						<label><input type="checkbox" name="first_line_as_excerpt" value="1" <?php checked( $app->get_first_line_as_excerpt() ); ?> /> <?php esc_html_e( 'Use first content line as excerpt', 'enable-mastodon-apps' ); ?></label>
 						<p class="description">
 							<span><?php esc_html_e( 'If checked, the first line after the title will be used as the WordPress excerpt for standard posts.', 'enable-mastodon-apps' ); ?></span>
 						</p>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row"><?php esc_html_e( 'Timeline filtering', 'enable-mastodon-apps' ); ?></th>
+					<td>
 						<label><input type="checkbox" name="media_only" value="1" <?php checked( $app->get_media_only() ); ?> /> <?php esc_html_e( 'Only show posts with media attachments', 'enable-mastodon-apps' ); ?></label>
 						<p class="description">
 							<span><?php esc_html_e( 'If checked, posts without images or videos will be hidden from timelines.', 'enable-mastodon-apps' ); ?></span>
 						</p>
 					</td>
 				</tr>
+				<?php if ( ! empty( $available_reactions ) ) : ?>
+				<tr>
+					<th scope="row"><?php esc_html_e( 'Reactions', 'enable-mastodon-apps' ); ?></th>
+					<td>
+						<fieldset>
+							<label for="favourite_reaction"><?php esc_html_e( 'Favourite reaction', 'enable-mastodon-apps' ); ?></label>
+							<select id="favourite_reaction" name="favourite_reaction">
+								<?php foreach ( $available_reactions as $reaction_id => $reaction ) : ?>
+									<option value="<?php echo esc_attr( $reaction_id ); ?>" title="<?php echo esc_attr( $reaction->name ); ?>" <?php selected( $reaction_id, $app->get_favourite_reaction() ); ?>><?php echo esc_html( $reaction->char ); ?></option>
+								<?php endforeach; ?>
+								<?php if ( ! isset( $available_reactions[ $app->get_favourite_reaction() ] ) ) : ?>
+									<option value="<?php echo esc_attr( $app->get_favourite_reaction() ); ?>" selected><?php echo esc_html( $app->get_favourite_reaction() ); ?></option>
+								<?php endif; ?>
+							</select>
+							<p class="description">
+								<span><?php esc_html_e( 'Reaction to use when a Mastodon app favourites a status.', 'enable-mastodon-apps' ); ?></span>
+							</p>
+							<label for="bookmark_reaction"><?php esc_html_e( 'Bookmark reaction', 'enable-mastodon-apps' ); ?></label>
+							<select id="bookmark_reaction" name="bookmark_reaction">
+								<?php foreach ( $available_reactions as $reaction_id => $reaction ) : ?>
+									<option value="<?php echo esc_attr( $reaction_id ); ?>" title="<?php echo esc_attr( $reaction->name ); ?>" <?php selected( $reaction_id, $app->get_bookmark_reaction() ); ?>><?php echo esc_html( $reaction->char ); ?></option>
+								<?php endforeach; ?>
+								<?php if ( ! isset( $available_reactions[ $app->get_bookmark_reaction() ] ) ) : ?>
+									<option value="<?php echo esc_attr( $app->get_bookmark_reaction() ); ?>" selected><?php echo esc_html( $app->get_bookmark_reaction() ); ?></option>
+								<?php endif; ?>
+							</select>
+							<p class="description">
+								<span><?php esc_html_e( 'Reaction to use when a Mastodon app bookmarks a status.', 'enable-mastodon-apps' ); ?></span>
+							</p>
+						</fieldset>
+					</td>
+				</tr>
+				<?php endif; ?>
 			</tbody>
 		</table>
 

--- a/tests/test-statuses-endpoint.php
+++ b/tests/test-statuses-endpoint.php
@@ -60,6 +60,78 @@ class StatusesEndpoint_Test extends Mastodon_API_TestCase {
 		$this->assertEquals( 200, $response->get_status() );
 	}
 
+	public function test_favourite_returns_requested_reblog_status() {
+		$this->app->set_favourite_reaction( '1f44d' );
+		$reblog_id = Mastodon_API::remap_reblog_id( $this->friend_post );
+		$reacted   = array();
+
+		$react = function ( $post_id, $reaction ) use ( &$reacted ) {
+			$reacted[] = compact( 'post_id', 'reaction' );
+		};
+		add_action( 'mastodon_api_react', $react, 10, 2 );
+
+		$add_reblog = function ( $status, $post_id ) use ( $reblog_id ) {
+			if ( intval( $post_id ) !== intval( $reblog_id ) ) {
+				return $status;
+			}
+
+			$original = apply_filters( 'mastodon_api_status', null, $this->friend_post, array() );
+			$status   = clone $original;
+
+			$status->id         = strval( $reblog_id );
+			$status->reblog     = clone $original;
+			$status->reblog->id = strval( $this->friend_post );
+			return $status;
+		};
+		add_filter( 'mastodon_api_status', $add_reblog, 20, 2 );
+
+		$request  = $this->api_request( 'POST', '/api/v1/statuses/' . $this->friend_post . '/favourite' );
+		$response = $this->dispatch_authenticated( $request );
+
+		remove_action( 'mastodon_api_react', $react, 10 );
+		remove_filter( 'mastodon_api_status', $add_reblog, 20 );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$status = $response->get_data();
+		$this->assertEquals( strval( $this->friend_post ), $status->id );
+		$this->assertNull( $status->reblog );
+		$this->assertSame(
+			array(
+				array(
+					'post_id'  => strval( $reblog_id ),
+					'reaction' => '1f44d',
+				),
+			),
+			$reacted
+		);
+	}
+
+	public function test_bookmark_route_uses_mapped_reaction() {
+		$this->app->set_bookmark_reaction( '2b50' );
+		$reacted = array();
+
+		$react = function ( $post_id, $reaction ) use ( &$reacted ) {
+			$reacted[] = compact( 'post_id', 'reaction' );
+		};
+		add_action( 'mastodon_api_react', $react, 10, 2 );
+
+		$request  = $this->api_request( 'POST', '/api/v1/statuses/' . $this->friend_post . '/bookmark' );
+		$response = $this->dispatch_authenticated( $request );
+
+		remove_action( 'mastodon_api_react', $react, 10 );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame(
+			array(
+				array(
+					'post_id'  => strval( $this->friend_post ),
+					'reaction' => '2b50',
+				),
+			),
+			$reacted
+		);
+	}
+
 	public function test_statuses_delete() {
 		$request = $this->api_request( 'DELETE', '/api/v1/statuses/' . $this->post );
 		$response = $this->dispatch_authenticated( $request );

--- a/tests/test-statuses-endpoint.php
+++ b/tests/test-statuses-endpoint.php
@@ -66,7 +66,10 @@ class StatusesEndpoint_Test extends Mastodon_API_TestCase {
 		$reacted   = array();
 
 		$react = function ( $post_id, $reaction ) use ( &$reacted ) {
-			$reacted[] = compact( 'post_id', 'reaction' );
+			$reacted[] = array(
+				'post_id'  => $post_id,
+				'reaction' => $reaction,
+			);
 		};
 		add_action( 'mastodon_api_react', $react, 10, 2 );
 
@@ -111,7 +114,10 @@ class StatusesEndpoint_Test extends Mastodon_API_TestCase {
 		$reacted = array();
 
 		$react = function ( $post_id, $reaction ) use ( &$reacted ) {
-			$reacted[] = compact( 'post_id', 'reaction' );
+			$reacted[] = array(
+				'post_id'  => $post_id,
+				'reaction' => $reaction,
+			);
 		};
 		add_action( 'mastodon_api_react', $react, 10, 2 );
 


### PR DESCRIPTION

<img width="1902" height="750" alt="Screenshot 2026-07-06 at 15 39 39" src="https://github.com/user-attachments/assets/9e06323e-0177-468b-92c7-b49b6f4afc91" />

## Summary
- add per-app mappings for Mastodon favourite and bookmark reactions
- expose mappings on app settings when Friends reactions are available
- add bookmark and unbookmark status routes using the mapped reaction
- Related: https://github.com/akirk/friends/pull/684

## Testing
- php -l templates/app.php
- php -l includes/class-mastodon-admin.php
- php -l includes/class-mastodon-app.php
- php -l includes/class-mastodon-api.php
- live POST /api/v1/statuses/3537126/favourite returned favourited=true