### PR TITLE
Keep EMA unread status out of public searches

### DIFF
--- a/includes/class-mastodon-api.php
+++ b/includes/class-mastodon-api.php
@@ -366,7 +366,7 @@ class Mastodon_API {
 			'ema_unread',
 			array(
 				'label'                     => _x( 'Unread', 'message', 'enable-mastodon-apps' ),
-				'public'                    => ! false,
+				'public'                    => false,
 				'exclude_from_search'       => true,
 				'show_in_admin_all_list'    => false,
 				'show_in_admin_status_list' => is_admin() && isset( $_GET['post_type'] ) && $dm_cpt === $_GET['post_type'], // phpcs:ignore WordPress.Security.NonceVerification.Recommended

--- a/tests/test-public-search.php
+++ b/tests/test-public-search.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Class PublicSearch_Test
+ *
+ * @package Enable_Mastodon_Apps
+ */
+
+namespace Enable_Mastodon_Apps;
+
+/**
+ * Testcases for public WordPress searches.
+ *
+ * @package
+ */
+class PublicSearch_Test extends \WP_UnitTestCase {
+	public function test_ema_unread_is_not_included_in_public_search_queries() {
+		$status = get_post_status_object( 'ema_unread' );
+
+		$this->assertNotNull( $status );
+		$this->assertFalse( $status->public );
+
+		$query = new \WP_Query(
+			array(
+				's'         => 'Associate-Cloud-Engineer',
+				'post_type' => array( 'post', 'page', 'attachment', Mastodon_API::POST_CPT ),
+				'fields'    => 'ids',
+			)
+		);
+
+		$this->assertStringNotContainsString( 'ema_unread', $query->request );
+	}
+}


### PR DESCRIPTION
## Summary
- register the EMA unread DM status as non-public, matching the read status
- add a regression test that normal WordPress public search SQL does not include ema_unread

## Context
Issue #279 shows a normal WordPress front-end search query, not a Mastodon API request. The query included post_status = ema_unread because EMA registered that status as public.

Fixes #279.

## Tests
- composer test -- --filter PublicSearch_Test
- composer test -- --filter ConversationsEndpoint_Test
- composer test -- --filter "PublicSearch_Test|ConversationsEndpoint_Test|NotificationsEndpoint_Test"

Note: these focused tests passed before opening the PR. A later accidental shell execution while creating the PR body reran the conversation-related tests and hit an environment-specific OpenSSL random state write error from the ActivityPub plugin.