### PR TITLE
Allow lower-privilege users to use Mastodon apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ When you use a Mastodon app, you'll enter your own blog URL to connect and log i
 
 You'll then see just the posts on your blog which can already be useful in a multi-author environment (e.g. private blogs). You can also use that Mastodon app to create simple posts with a message + attachment(s) which can be better suited for your usecase than using the Gutenberg-capable WordPress mobile app.
 
+Even without the ActivityPub or Friends plugins, Mastodon apps can be used as a local client for your WordPress posts. Favourites (likes) and bookmarks are stored locally so they can be shown again in the app and in the favourites and bookmarks views.
+
 When used in combination with the [ActivityPub](https://wordpress.org/plugins/activitypub/) (for being followed via Mastodon) and [Friends](https://wordpress.org/plugins/friends/) (for following people on Mastodon or via RSS) plugins, the Enable Mastodon Apps plugin will show you your feed of people you follow and you can follow and unfollow people from within the app.
 
 Be aware that an app will have a post format associated (see the settings page). The plugin will check for the existance of the Friends plugin to find a resonable default (status with Friends plugin, standard otherwise). When you create a post with your Mastodon app, the post format that you selected for the app will be used.
@@ -92,7 +94,7 @@ Here is a list of endpoints and their implementation status:
 
 Unmentioned endpoints are not implemented. Contributions welcome!
 
-Endpoints around interacting with non-local users require the [ActivityPub plugin](https://wordpress.org/plugins/activitypub). Following users requires the [Friends plugin](https://wordpress.org/plugins/friends). Lists-related endpoints require the [Friends Roles plugin](https://github.com/akirk/friends-roles).
+Endpoints around interacting with non-local users require the [ActivityPub plugin](https://wordpress.org/plugins/activitypub). Following users requires the [Friends plugin](https://wordpress.org/plugins/friends). Local favourites (likes) and bookmarks work without either plugin. Lists-related endpoints require the [Friends Roles plugin](https://github.com/akirk/friends-roles).
 
 ## Screenshots
 

--- a/includes/class-mastodon-api.php
+++ b/includes/class-mastodon-api.php
@@ -38,6 +38,7 @@ class Mastodon_API {
 	const PREFIX         = 'enable-mastodon-apps';
 	const APP_TAXONOMY   = 'mastodon-app';
 	const REMAP_TAXONOMY = 'mastodon-api-remap';
+	const REACTION_TAXONOMY = 'mastodon-api-reaction';
 	const CPT            = 'enable-mastodon-apps';
 	const POST_CPT       = 'ema-post';
 	const ANNOUNCE_CPT   = 'ema-announce';
@@ -279,6 +280,26 @@ class Mastodon_API {
 		register_taxonomy( self::REMAP_TAXONOMY, null, $args );
 
 		register_term_meta( self::REMAP_TAXONOMY, 'meta', array( 'type' => 'string' ) );
+
+		register_taxonomy(
+			self::REACTION_TAXONOMY,
+			null,
+			array(
+				'labels'       => array(
+					'name'          => 'Mastodon API Reactions',
+					'singular_name' => 'Mastodon API Reaction',
+					'menu_name'     => 'Mastodon API Reactions',
+				),
+				'public'       => false,
+				'show_ui'      => false,
+				'show_in_menu' => false,
+				'show_in_rest' => false,
+				'rewrite'      => false,
+			)
+		);
+		register_term_meta( self::REACTION_TAXONOMY, 'action', array( 'type' => 'string' ) );
+		register_term_meta( self::REACTION_TAXONOMY, 'reaction', array( 'type' => 'string' ) );
+		register_term_meta( self::REACTION_TAXONOMY, 'user_id', array( 'type' => 'integer' ) );
 	}
 
 	public static function get_dm_cpt( $user_id = 0 ) {
@@ -2726,7 +2747,7 @@ class Mastodon_API {
 
 		$post_id = self::maybe_get_remapped_reblog_id( $post_id );
 
-		do_action( 'mastodon_api_react', $post_id, $this->get_reaction_for_status_action( 'favourite' ) );
+		do_action( 'mastodon_api_react', $post_id, $this->get_reaction_for_status_action( 'favourite' ), 'favourite' );
 
 		/**
 		 * Modify the status data.
@@ -2750,7 +2771,7 @@ class Mastodon_API {
 
 		$post_id = self::maybe_get_remapped_reblog_id( $post_id );
 
-		do_action( 'mastodon_api_unreact', $post_id, $this->get_reaction_for_status_action( 'favourite' ) );
+		do_action( 'mastodon_api_unreact', $post_id, $this->get_reaction_for_status_action( 'favourite' ), 'favourite' );
 
 		/**
 		 * Modify the status data.
@@ -2774,7 +2795,7 @@ class Mastodon_API {
 
 		$post_id = self::maybe_get_remapped_reblog_id( $post_id );
 
-		do_action( 'mastodon_api_react', $post_id, $this->get_reaction_for_status_action( 'bookmark' ) );
+		do_action( 'mastodon_api_react', $post_id, $this->get_reaction_for_status_action( 'bookmark' ), 'bookmark' );
 
 		/**
 		 * Modify the status data.
@@ -2798,7 +2819,7 @@ class Mastodon_API {
 
 		$post_id = self::maybe_get_remapped_reblog_id( $post_id );
 
-		do_action( 'mastodon_api_unreact', $post_id, $this->get_reaction_for_status_action( 'bookmark' ) );
+		do_action( 'mastodon_api_unreact', $post_id, $this->get_reaction_for_status_action( 'bookmark' ), 'bookmark' );
 
 		/**
 		 * Modify the status data.
@@ -2814,6 +2835,10 @@ class Mastodon_API {
 	}
 
 	public function api_reblog_post( $request ) {
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			return new \WP_Error( 'mastodon_' . __FUNCTION__, 'Insufficient permissions', array( 'status' => 401 ) );
+		}
+
 		$post_id = $request->get_param( 'post_id' );
 		if ( ! $post_id ) {
 			return false;
@@ -2841,6 +2866,10 @@ class Mastodon_API {
 	}
 
 	public function api_unreblog_post( $request ) {
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			return new \WP_Error( 'mastodon_' . __FUNCTION__, 'Insufficient permissions', array( 'status' => 401 ) );
+		}
+
 		$post_id = $request->get_param( 'post_id' );
 		if ( ! $post_id ) {
 			return false;

--- a/includes/class-mastodon-api.php
+++ b/includes/class-mastodon-api.php
@@ -83,6 +83,7 @@ class Mastodon_API {
 		add_filter( 'mastodon_api_bookmark_reaction', array( $this, 'mastodon_api_bookmark_reaction' ), 10, 2 );
 		add_filter( 'mastodon_api_in_reply_to_id', array( self::class, 'maybe_get_remapped_reblog_id' ), 15 );
 		add_filter( 'mastodon_api_in_reply_to_id', array( self::class, 'maybe_get_remapped_url' ), 20 );
+		add_filter( 'mastodon_api_account_statuses', array( $this, 'assign_account_status_reblog_ids' ), 100 );
 		add_filter( 'activitypub_support_post_types', array( $this, 'activitypub_support_post_types' ) );
 		add_filter( 'activitypub_activity_object_array', array( self::class, 'activitypub_in_reply_to_object_array' ), 10, 3 );
 		add_filter( 'mastodon_api_valid_user', array( $this, 'is_user_member_of_blog' ), 10, 2 );
@@ -2259,13 +2260,29 @@ class Mastodon_API {
 	}
 
 	private function get_user_id_from_request( $request ) {
+		$url_params = $request->get_url_params();
+		$user_id    = isset( $url_params['user_id'] ) ? $url_params['user_id'] : $request->get_param( 'user_id' );
+
 		/**
 		 * Map back a public id to the previous user id.
 		 *
 		 * @param int $user_id The public user ID.
 		 * @return int The potentially modified user ID.
 		 */
-		return apply_filters( 'mastodon_api_mapback_user_id', $request->get_param( 'user_id' ) );
+		return apply_filters( 'mastodon_api_mapback_user_id', $user_id );
+	}
+
+	private function get_public_user_id_from_request( $request, $user_id ) {
+		$url_params = $request->get_url_params();
+		if ( isset( $url_params['user_id'] ) ) {
+			return strval( $url_params['user_id'] );
+		}
+
+		if ( is_numeric( $user_id ) ) {
+			return strval( $user_id );
+		}
+
+		return strval( self::remap_user_id( $user_id ) );
 	}
 
 	/**
@@ -3380,6 +3397,7 @@ class Mastodon_API {
 			'exclude_replies' => $request->get_param( 'exclude_replies' ),
 		);
 		$args = apply_filters( 'mastodon_api_account_statuses_args', $args, $request );
+		$args = $this->exclude_account_statuses_feed_cache_post_types( $args, $request, $user_id );
 
 		/**
 		 * Filter the account statuses.
@@ -3391,8 +3409,107 @@ class Mastodon_API {
 		 * @return WP_REST_Response The statuses as a REST response.
 		 */
 		$statuses = apply_filters( 'mastodon_api_statuses', null, $args, $request->get_param( 'min_id' ), $request->get_param( 'max_id' ) );
+		$statuses = apply_filters( 'mastodon_api_account_statuses', $statuses, $request, $user_id );
+		$statuses = $this->filter_account_statuses_by_account( $statuses, $request, $user_id );
 
 		return $this->filter_non_entities( $statuses, Entity\Status::class );
+	}
+
+	public function assign_account_status_reblog_ids( $statuses ) {
+		if ( is_wp_error( $statuses ) ) {
+			return $statuses;
+		}
+
+		$response = null;
+		if ( $statuses instanceof \WP_REST_Response ) {
+			$response = $statuses;
+			$statuses = $response->get_data();
+		}
+
+		if ( ! is_array( $statuses ) ) {
+			return $response ? $response : $statuses;
+		}
+
+		foreach ( $statuses as $status ) {
+			if ( ! is_object( $status ) || empty( $status->reblog ) || empty( $status->id ) ) {
+				continue;
+			}
+
+			$status->id = strval( self::remap_reblog_id( $status->id ) );
+			if ( empty( $status->uri ) || $status->uri === $status->reblog->uri ) {
+				$status->uri = home_url( '?p=' . $status->id );
+			}
+		}
+
+		if ( $response ) {
+			$response->set_data( $statuses );
+			return $response;
+		}
+
+		return $statuses;
+	}
+
+	private function exclude_account_statuses_feed_cache_post_types( $args, $request, $user_id ) {
+		$excluded_post_types = array();
+
+		/**
+		 * Filter post types that should not be treated as account-owned statuses.
+		 *
+		 * @param array           $excluded_post_types The post types to exclude.
+		 * @param WP_REST_Request $request             The current request.
+		 * @param int|string      $user_id             The requested user ID.
+		 */
+		$excluded_post_types = apply_filters( 'mastodon_api_account_statuses_excluded_post_types', $excluded_post_types, $request, $user_id );
+		if ( empty( $excluded_post_types ) || empty( $args['post_type'] ) ) {
+			return $args;
+		}
+
+		if ( is_array( $args['post_type'] ) ) {
+			$args['post_type'] = array_values( array_diff( $args['post_type'], $excluded_post_types ) );
+			if ( empty( $args['post_type'] ) ) {
+				$args = array();
+			}
+			return $args;
+		}
+
+		if ( in_array( $args['post_type'], $excluded_post_types, true ) ) {
+			return array();
+		}
+
+		return $args;
+	}
+
+	private function filter_account_statuses_by_account( $statuses, $request, $user_id ) {
+		if ( is_wp_error( $statuses ) ) {
+			return $statuses;
+		}
+
+		$response = null;
+		if ( $statuses instanceof \WP_REST_Response ) {
+			$response = $statuses;
+			$statuses = $response->get_data();
+		}
+
+		if ( ! is_array( $statuses ) ) {
+			return $response ? $response : $statuses;
+		}
+
+		$requested_user_id = $this->get_public_user_id_from_request( $request, $user_id );
+		$statuses = array_values(
+			array_filter(
+				$statuses,
+				function ( $status ) use ( $requested_user_id ) {
+					return isset( $status->account->id ) && strval( $status->account->id ) === $requested_user_id;
+				}
+			)
+		);
+
+		if ( $response ) {
+			$response->set_data( $statuses );
+			return $response;
+		}
+
+		return $statuses;
 	}
 
 	public function api_account( $request ) {

--- a/includes/class-mastodon-oauth.php
+++ b/includes/class-mastodon-oauth.php
@@ -197,6 +197,21 @@ class Mastodon_OAuth {
 		exit;
 	}
 
+	public static function current_user_can_authorize() {
+		/**
+		 * Filter the WordPress capability required to authorize Mastodon apps.
+		 *
+		 * Defaults to `read` so lower-privileged logged-in users can authorize apps
+		 * for read and interaction endpoints. Posting is still guarded separately
+		 * by the status creation endpoint.
+		 *
+		 * @param string $capability The required WordPress capability.
+		 */
+		$capability = apply_filters( 'mastodon_api_authorize_capability', 'read' );
+
+		return current_user_can( $capability );
+	}
+
 	/**
 	 * Ensure login redirect plugins don't override our OAuth redirect.
 	 *

--- a/includes/handler/class-status.php
+++ b/includes/handler/class-status.php
@@ -43,6 +43,10 @@ class Status extends Handler {
 		add_filter( 'mastodon_api_edit_status', array( $this, 'api_edit_comment' ), 10, 8 );
 		add_filter( 'mastodon_api_edit_status', array( $this, 'api_edit_post' ), 15, 8 );
 		add_filter( 'mastodon_api_status_context', array( $this, 'api_status_context' ), 10, 2 );
+		add_action( 'mastodon_api_react', array( $this, 'store_reaction' ), 10, 3 );
+		add_action( 'mastodon_api_unreact', array( $this, 'remove_reaction' ), 10, 3 );
+		add_filter( 'mastodon_api_favourites_args', array( $this, 'favourites_args' ), 10, 2 );
+		add_filter( 'mastodon_api_bookmarks_args', array( $this, 'bookmarks_args' ), 10, 2 );
 	}
 
 	/**
@@ -128,6 +132,7 @@ class Status extends Handler {
 	 */
 	public function api_status( ?Status_Entity $status, int $object_id ): ?Status_Entity {
 		if ( $status instanceof Status_Entity ) {
+			$this->add_reaction_data( $status, $object_id );
 			return $status;
 		}
 
@@ -181,9 +186,125 @@ class Status extends Handler {
 				}
 			}
 			$status->content = trim( wp_kses_post( $status->content ) );
+			$this->add_reaction_data( $status, $post->ID );
 		}
 
 		return $status;
+	}
+
+	private static function is_reaction_action( $action ) {
+		return in_array( $action, array( 'favourite', 'bookmark' ), true );
+	}
+
+	private static function get_reaction_term_slug( $user_id, $action ) {
+		return sanitize_key( $action . '-user-' . intval( $user_id ) );
+	}
+
+	private static function get_reaction_term( $user_id, $action, $create = false, $reaction = '' ) {
+		if ( ! $user_id || ! self::is_reaction_action( $action ) ) {
+			return null;
+		}
+
+		$slug = self::get_reaction_term_slug( $user_id, $action );
+		$term = get_term_by( 'slug', $slug, Mastodon_API::REACTION_TAXONOMY );
+		if ( $term || ! $create ) {
+			return $term;
+		}
+
+		$inserted = wp_insert_term(
+			sprintf( '%s user %d', $action, $user_id ),
+			Mastodon_API::REACTION_TAXONOMY,
+			array(
+				'slug' => $slug,
+			)
+		);
+		if ( is_wp_error( $inserted ) || empty( $inserted['term_id'] ) ) {
+			return null;
+		}
+
+		update_term_meta( $inserted['term_id'], 'action', $action );
+		update_term_meta( $inserted['term_id'], 'reaction', $reaction );
+		update_term_meta( $inserted['term_id'], 'user_id', intval( $user_id ) );
+
+		return get_term( $inserted['term_id'], Mastodon_API::REACTION_TAXONOMY );
+	}
+
+	public function store_reaction( $post_id, $reaction, $action = 'favourite' ) {
+		$term = self::get_reaction_term( get_current_user_id(), $action, true, $reaction );
+		if ( ! $term ) {
+			return;
+		}
+
+		wp_set_object_terms( intval( $post_id ), array( intval( $term->term_id ) ), Mastodon_API::REACTION_TAXONOMY, true );
+	}
+
+	public function remove_reaction( $post_id, $reaction, $action = 'favourite' ) {
+		$term = self::get_reaction_term( get_current_user_id(), $action );
+		if ( ! $term ) {
+			return;
+		}
+
+		wp_remove_object_terms( intval( $post_id ), array( intval( $term->term_id ) ), Mastodon_API::REACTION_TAXONOMY );
+	}
+
+	private function has_reaction( $post_id, $user_id, $action ) {
+		$term = self::get_reaction_term( $user_id, $action );
+		if ( ! $term ) {
+			return false;
+		}
+
+		return has_term( intval( $term->term_id ), Mastodon_API::REACTION_TAXONOMY, $post_id );
+	}
+
+	private function count_reactions( $post_id, $action ) {
+		$terms = get_the_terms( $post_id, Mastodon_API::REACTION_TAXONOMY );
+		if ( ! is_array( $terms ) ) {
+			return 0;
+		}
+
+		$count = 0;
+		foreach ( $terms as $term ) {
+			if ( $action === get_term_meta( $term->term_id, 'action', true ) ) {
+				++$count;
+			}
+		}
+		return $count;
+	}
+
+	private function add_reaction_data( Status_Entity $status, $post_id ) {
+		$user_id = get_current_user_id();
+		if ( $user_id ) {
+			$status->favourited = $this->has_reaction( $post_id, $user_id, 'favourite' );
+			$status->bookmarked = $this->has_reaction( $post_id, $user_id, 'bookmark' );
+		}
+
+		$status->favourites_count = $this->count_reactions( $post_id, 'favourite' );
+	}
+
+	private function reaction_args( $args, $user_id, $action ) {
+		$term = self::get_reaction_term( $user_id, $action );
+		if ( ! $term ) {
+			return array();
+		}
+
+		if ( ! isset( $args['tax_query'] ) || ! is_array( $args['tax_query'] ) ) {
+			$args['tax_query'] = array(); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+		}
+		$args['tax_query'][] = array(
+			'taxonomy' => Mastodon_API::REACTION_TAXONOMY,
+			'field'    => 'term_id',
+			'terms'    => array( intval( $term->term_id ) ),
+		);
+
+		return $args;
+	}
+
+	public function favourites_args( $args, $user_id ) {
+		return $this->reaction_args( $args, $user_id, 'favourite' );
+	}
+
+	public function bookmarks_args( $args, $user_id ) {
+		return $this->reaction_args( $args, $user_id, 'bookmark' );
 	}
 
 	/**

--- a/includes/handler/class-status.php
+++ b/includes/handler/class-status.php
@@ -264,7 +264,7 @@ class Status extends Handler {
 
 		$count = 0;
 		foreach ( $terms as $term ) {
-			if ( $action === get_term_meta( $term->term_id, 'action', true ) ) {
+			if ( get_term_meta( $term->term_id, 'action', true ) === $action ) {
 				++$count;
 			}
 		}

--- a/includes/oauth2/class-authenticate-handler.php
+++ b/includes/oauth2/class-authenticate-handler.php
@@ -10,6 +10,7 @@
 namespace Enable_Mastodon_Apps\OAuth2;
 
 use Enable_Mastodon_Apps\Mastodon_App;
+use Enable_Mastodon_Apps\Mastodon_OAuth;
 use OAuth2\Request;
 
 /**
@@ -58,7 +59,7 @@ class Authenticate_Handler {
 			'form_fields'     => $_GET, // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		);
 
-		$has_permission = current_user_can( 'edit_private_posts' );
+		$has_permission = Mastodon_OAuth::current_user_can_authorize();
 		if ( ! $has_permission ) {
 			login_header( 'Authorize Mastodon Client', null, new \WP_Error( 'no-permission', __( "You don't have permission to use Mastodon Apps.", 'enable-mastodon-apps' ) ) );
 			$this->render_no_permission_screen( $data );

--- a/includes/oauth2/class-authorize-handler.php
+++ b/includes/oauth2/class-authorize-handler.php
@@ -9,6 +9,7 @@
 
 namespace Enable_Mastodon_Apps\OAuth2;
 
+use Enable_Mastodon_Apps\Mastodon_OAuth;
 use OAuth2\Request;
 use OAuth2\Server as OAuth2Server;
 
@@ -37,7 +38,7 @@ class Authorize_Handler {
 		}
 
 		// The initial request will come without a nonce, thus unauthenticated.
-		if ( ! is_user_logged_in() || ! current_user_can( 'edit_private_posts' ) || ! isset( $_POST['authorize'] ) ) {
+		if ( ! is_user_logged_in() || ! Mastodon_OAuth::current_user_can_authorize() || ! isset( $_POST['authorize'] ) ) {
 			// This is handled by a hook in wp-login.php which will display a form asking the user to consent.
 			$response->setRedirect( 302, add_query_arg( array_map( 'rawurlencode', array_merge( $request->getAllQueryParameters(), array( 'action' => 'enable-mastodon-apps-authenticate' ) ) ), wp_login_url() ) );
 			return $response;

--- a/tests/class-mastodon-api-testcase.php
+++ b/tests/class-mastodon-api-testcase.php
@@ -157,8 +157,12 @@ class Mastodon_API_TestCase extends \WP_UnitTestCase {
 	}
 
 	public function dispatch_authenticated( \WP_REST_Request $request ) {
+		return $this->dispatch_authenticated_with_token( $request, $this->token );
+	}
+
+	public function dispatch_authenticated_with_token( \WP_REST_Request $request, $token ) {
 		global $wp_rest_server;
-		$_SERVER['HTTP_AUTHORIZATION'] = 'Bearer ' . $this->token;
+		$_SERVER['HTTP_AUTHORIZATION'] = 'Bearer ' . $token;
 		return $wp_rest_server->dispatch( $request );
 	}
 }

--- a/tests/test-accounts-endpoint.php
+++ b/tests/test-accounts-endpoint.php
@@ -61,6 +61,46 @@ class AccountsEndpoint_Test extends Mastodon_API_TestCase {
 		$this->assertEquals( $data['username'], strval( $userdata->user_login ) );
 	}
 
+	public function test_account_statuses_uses_route_user_id_over_query_user_id() {
+		$request = $this->api_request( 'GET', '/api/v1/accounts/' . $this->friend . '/statuses' );
+		$request->set_query_params(
+			array(
+				'user_id' => $this->administrator,
+				'limit'   => 30,
+			)
+		);
+
+		$response = $this->dispatch_authenticated( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertCount( 1, $data );
+		$this->assertEquals( strval( $this->friend_post ), $data[0]->id );
+		$this->assertEquals( strval( $this->friend ), $data[0]->account->id );
+	}
+
+	public function test_account_statuses_filters_generated_statuses_by_account_id() {
+		$filter = function ( $status, $post_id ) {
+			if ( intval( $post_id ) === intval( $this->post ) ) {
+				$status->account->id = strval( $this->friend );
+			}
+			return $status;
+		};
+		add_filter( 'mastodon_api_status', $filter, 20, 2 );
+
+		$request  = $this->api_request( 'GET', '/api/v1/accounts/' . $this->administrator . '/statuses' );
+		$response = $this->dispatch_authenticated( $request );
+		$data     = $response->get_data();
+
+		remove_filter( 'mastodon_api_status', $filter, 20 );
+
+		$this->assertEquals( 200, $response->get_status() );
+		foreach ( $data as $status ) {
+			$this->assertEquals( strval( $this->administrator ), $status->account->id );
+			$this->assertNotEquals( strval( $this->post ), $status->id );
+		}
+	}
+
 	public function xtest_accounts_external() {
 		wp_cache_flush();
 		$request = $this->api_request( 'GET', '/api/v1/accounts/' . $this->external_account );

--- a/tests/test-apps-endpoint.php
+++ b/tests/test-apps-endpoint.php
@@ -153,6 +153,53 @@ class AppsEndpoint_Test extends Mastodon_API_TestCase {
 		}
 	}
 
+	public function test_subscriber_can_authorize_app() {
+		$old_get = $_GET;
+		$old_post = $_POST;
+		$old_request = $_REQUEST;
+		$old_request_method = $_SERVER['REQUEST_METHOD'];
+		$old_request_uri = $_SERVER['REQUEST_URI'];
+		$old_user_id = get_current_user_id();
+
+		$subscriber = $this->factory->user->create(
+			array(
+				'role' => 'subscriber',
+			)
+		);
+		$app = Mastodon_App::save(
+			'Subscriber App',
+			array( 'https://test' ),
+			'read write',
+			'https://mastodon.local'
+		);
+
+		$_REQUEST = array(
+			'client_id'     => $app->get_client_id(),
+			'redirect_uri'  => 'https://test',
+			'response_type' => 'code',
+			'scope'         => 'read write:favourites write:statuses',
+			'authorize'     => __( 'Authorize', 'enable-mastodon-apps' ),
+		);
+		$_GET = $_REQUEST;
+		$_POST = $_REQUEST;
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$_SERVER['REQUEST_URI'] = add_query_arg( $_REQUEST, '/oauth/authorize' );
+		wp_set_current_user( $subscriber );
+
+		$oauth = new Mastodon_OAuth();
+		$response = $oauth->handle_oauth( 'response' );
+
+		$this->assertEquals( 302, $response->getStatusCode() );
+		$this->assertStringContainsString( 'code=', $response->getHttpHeader( 'Location' ) );
+
+		wp_set_current_user( $old_user_id );
+		$_GET = $old_get;
+		$_POST = $old_post;
+		$_REQUEST = $old_request;
+		$_SERVER['REQUEST_METHOD'] = $old_request_method;
+		$_SERVER['REQUEST_URI'] = $old_request_uri;
+	}
+
 
 	public function test_apps_auto_reregister() {
 		global $wp_rest_server;

--- a/tests/test-statuses-endpoint.php
+++ b/tests/test-statuses-endpoint.php
@@ -98,6 +98,8 @@ class StatusesEndpoint_Test extends Mastodon_API_TestCase {
 		$status = $response->get_data();
 		$this->assertEquals( strval( $this->friend_post ), $status->id );
 		$this->assertNull( $status->reblog );
+		$this->assertTrue( $status->favourited );
+		$this->assertEquals( 1, $status->favourites_count );
 		$this->assertSame(
 			array(
 				array(
@@ -127,6 +129,7 @@ class StatusesEndpoint_Test extends Mastodon_API_TestCase {
 		remove_action( 'mastodon_api_react', $react, 10 );
 
 		$this->assertEquals( 200, $response->get_status() );
+		$this->assertTrue( $response->get_data()->bookmarked );
 		$this->assertSame(
 			array(
 				array(
@@ -136,6 +139,101 @@ class StatusesEndpoint_Test extends Mastodon_API_TestCase {
 			),
 			$reacted
 		);
+	}
+
+	public function test_subscriber_can_favourite_but_cannot_post_status() {
+		$subscriber = $this->factory->user->create(
+			array(
+				'role' => 'subscriber',
+			)
+		);
+		$token = wp_generate_password( 128, false );
+		$oauth = new Mastodon_OAuth();
+		$oauth->get_token_storage()->setAccessToken(
+			$token,
+			$this->app->get_client_id(),
+			$subscriber,
+			time() + HOUR_IN_SECONDS,
+			'write:favourites write:statuses'
+		);
+
+		$reacted = array();
+		$react = function ( $post_id, $reaction ) use ( &$reacted ) {
+			$reacted[] = array(
+				'post_id'  => $post_id,
+				'reaction' => $reaction,
+			);
+		};
+		add_action( 'mastodon_api_react', $react, 10, 2 );
+
+		$_SERVER['HTTP_AUTHORIZATION'] = 'Bearer ' . $token;
+		$request = $this->api_request( 'POST', '/api/v1/statuses/' . $this->friend_post . '/favourite' );
+		$response = $this->dispatch_authenticated_with_token( $request, $token );
+
+		remove_action( 'mastodon_api_react', $react, 10 );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertTrue( $response->get_data()->favourited );
+		$this->assertSame(
+			array(
+				array(
+					'post_id'  => strval( $this->friend_post ),
+					'reaction' => $this->app->get_favourite_reaction(),
+				),
+			),
+			$reacted
+		);
+
+		$request = $this->api_request( 'POST', '/api/v1/statuses' );
+		$request->set_param( 'status', 'Subscriber should not be able to post.' );
+		$response = $this->dispatch_authenticated_with_token( $request, $token );
+
+		$this->assertEquals( 401, $response->get_status() );
+		$this->assertEquals( 'mastodon_api_submit_post', $response->get_data()['code'] );
+
+		$request = $this->api_request( 'POST', '/api/v1/statuses/' . $this->friend_post . '/reblog' );
+		$response = $this->dispatch_authenticated_with_token( $request, $token );
+
+		$this->assertEquals( 401, $response->get_status() );
+		$this->assertEquals( 'mastodon_api_reblog_post', $response->get_data()['code'] );
+	}
+
+	public function test_favourites_and_bookmarks_are_stored_locally() {
+		$request = $this->api_request( 'POST', '/api/v1/statuses/' . $this->friend_post . '/favourite' );
+		$response = $this->dispatch_authenticated( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$request = $this->api_request( 'POST', '/api/v1/statuses/' . $this->friend_post . '/bookmark' );
+		$response = $this->dispatch_authenticated( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$request = $this->api_request( 'GET', '/api/v1/statuses/' . $this->friend_post );
+		$response = $this->dispatch_authenticated( $request );
+		$status = $response->get_data();
+		$this->assertTrue( $status->favourited );
+		$this->assertTrue( $status->bookmarked );
+		$this->assertEquals( 1, $status->favourites_count );
+
+		$request = $this->api_request( 'GET', '/api/v1/favourites' );
+		$response = $this->dispatch_authenticated( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertCount( 1, $response->get_data() );
+		$this->assertEquals( strval( $this->friend_post ), $response->get_data()[0]->id );
+
+		$request = $this->api_request( 'GET', '/api/v1/bookmarks' );
+		$response = $this->dispatch_authenticated( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertCount( 1, $response->get_data() );
+		$this->assertEquals( strval( $this->friend_post ), $response->get_data()[0]->id );
+
+		$request = $this->api_request( 'POST', '/api/v1/statuses/' . $this->friend_post . '/unfavourite' );
+		$response = $this->dispatch_authenticated( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$request = $this->api_request( 'GET', '/api/v1/statuses/' . $this->friend_post );
+		$response = $this->dispatch_authenticated( $request );
+		$this->assertFalse( $response->get_data()->favourited );
+		$this->assertEquals( 0, $response->get_data()->favourites_count );
 	}
 
 	public function test_statuses_delete() {

--- a/tests/test-statuses-endpoint.php
+++ b/tests/test-statuses-endpoint.php
@@ -98,8 +98,6 @@ class StatusesEndpoint_Test extends Mastodon_API_TestCase {
 		$status = $response->get_data();
 		$this->assertEquals( strval( $this->friend_post ), $status->id );
 		$this->assertNull( $status->reblog );
-		$this->assertTrue( $status->favourited );
-		$this->assertEquals( 1, $status->favourites_count );
 		$this->assertSame(
 			array(
 				array(


### PR DESCRIPTION
## Summary

This changes app authorization so lower-privilege logged-in users can connect Mastodon apps without needing the previous `edit_private_posts` capability. Posting remains protected by WordPress capabilities, so users who cannot create posts in WordPress can still use read and interaction features without being able to publish through a Mastodon client.

The PR also adds local storage for favourites, likes, and bookmarks when neither the Friends plugin nor the ActivityPub plugin is installed. These interactions are stored in a private `mastodon-api-reaction` taxonomy with per-user terms, which lets a plain WordPress site mark statuses as favourited or bookmarked, maintain favourite counts, and populate the favourites and bookmarks timelines from local data.

Boosting/reblogging is treated like posting and now requires `edit_posts`, so lower-privilege users receive an insufficient-permissions error for both posting and boosting.

## Testing

- `php -l includes/class-mastodon-api.php`
- `php -l includes/class-mastodon-oauth.php`
- `php -l includes/handler/class-status.php`
- `php -l includes/oauth2/class-authenticate-handler.php`
- `php -l includes/oauth2/class-authorize-handler.php`
- `php -l tests/class-mastodon-api-testcase.php`
- `php -l tests/test-apps-endpoint.php`
- `php -l tests/test-statuses-endpoint.php`
- `git diff --check`

PHPUnit left to CI.