### PR TITLE
Ensure account headers are always serialized

### DIFF
--- a/includes/entity/class-account.php
+++ b/includes/entity/class-account.php
@@ -26,8 +26,8 @@ class Account extends Entity {
 		'note'            => 'string',
 		'avatar'          => 'string',
 		'avatar_static'   => 'string',
-		'header'          => 'string?',
-		'header_static'   => 'string?',
+		'header'          => 'string',
+		'header_static'   => 'string',
 
 		'locked'          => 'bool',
 		'bot'             => 'bool',

--- a/includes/handler/class-account.php
+++ b/includes/handler/class-account.php
@@ -100,6 +100,12 @@ class Account extends Handler {
 		if ( ! is_object( $user_data ) ) {
 			return $user_data;
 		}
+		if ( ! isset( $user_data->header ) ) {
+			$user_data->header = '';
+		}
+		if ( ! isset( $user_data->header_static ) ) {
+			$user_data->header_static = $user_data->header;
+		}
 		if ( ! is_numeric( $user_data->id ) ) {
 			$user_data->id = \Enable_Mastodon_Apps\Mastodon_API::remap_user_id( $user_data->id );
 		}

--- a/tests/test-accounts-endpoint.php
+++ b/tests/test-accounts-endpoint.php
@@ -59,6 +59,20 @@ class AccountsEndpoint_Test extends Mastodon_API_TestCase {
 
 		$this->assertIsString( $data['username'] );
 		$this->assertEquals( $data['username'], strval( $userdata->user_login ) );
+		$this->assertArrayHasKey( 'header', $data );
+		$this->assertIsString( $data['header'] );
+		$this->assertArrayHasKey( 'header_static', $data );
+		$this->assertIsString( $data['header_static'] );
+	}
+
+	public function test_account_filter_adds_missing_header_fields() {
+		$account = apply_filters( 'mastodon_api_account', null, $this->administrator, null, null );
+		unset( $account->header, $account->header_static );
+
+		$account = Handler\Account::api_account_ensure_numeric_id( $account, $this->administrator );
+
+		$this->assertSame( '', $account->header );
+		$this->assertSame( '', $account->header_static );
 	}
 
 	public function test_account_statuses_uses_route_user_id_over_query_user_id() {


### PR DESCRIPTION
## Summary
- Pinafore relies on this field being a string.
- require account header fields in the Account entity serialization schema
- fill missing header/header_static fields during final account normalization
- add regression coverage for verify_credentials and unset header fields

## Testing
- php -l includes/entity/class-account.php
- php -l includes/handler/class-account.php
- php -l tests/test-accounts-endpoint.php
- git diff --check
- live checked /api/v1/accounts/2 returns header/header_static as strings

PHPUnit not run: /tmp/wordpress-tests-lib/includes/functions.php is missing locally.