### PR TITLE
Fix profile image updates from Mastodon clients

### DIFF
--- a/includes/class-mastodon-api.php
+++ b/includes/class-mastodon-api.php
@@ -1828,17 +1828,18 @@ class Mastodon_API {
 				return false;
 			}
 			$file_name = $matches[1];
+			$file_content = preg_replace( '/\r\n$/', '', $file_content );
 
 			// require the file needed fo wp_tempnam.
 			require_once ABSPATH . 'wp-admin/includes/file.php';
 			$tmp_name = wp_tempnam( 'patch_upload_' . $key );
-			// Use WP_Filesystem abstraction.
-			global $wp_filesystem;
-			if ( ! $wp_filesystem ) {
-				// init if not yet done.
-				WP_Filesystem();
+			if ( ! $tmp_name ) {
+				return false;
 			}
-			$wp_filesystem->put_contents( $tmp_name, $file_content );
+			$written = file_put_contents( $tmp_name, $file_content ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+			if ( false === $written ) {
+				return false;
+			}
 
 			return array(
 				'name'     => $file_name,
@@ -1964,7 +1965,13 @@ class Mastodon_API {
 		 */
 		$data = apply_filters( 'mastodon_api_update_credentials', $data, $user_id );
 
-		// Update the user with any available data for fields we support (just display_name and note currently).
+		// Update the user with any available data for fields we support.
+		if ( isset( $data['avatar'] ) ) {
+			$this->update_user_avatar( $user_id, $data['avatar'] );
+		}
+		if ( isset( $data['header'] ) ) {
+			update_user_meta( $user_id, 'mastodon_api_header_id', absint( $data['header'] ) );
+		}
 		if ( isset( $data['display_name'] ) ) {
 			wp_update_user(
 				array(
@@ -1982,6 +1989,38 @@ class Mastodon_API {
 
 		// Return the account.
 		return $this->api_account( $request );
+	}
+
+	/**
+	 * Update the user's WordPress avatar when a supported local avatar provider is active.
+	 *
+	 * @param int $user_id       The user ID.
+	 * @param int $attachment_id The attachment ID.
+	 * @return bool Whether an avatar provider handled the update.
+	 */
+	private function update_user_avatar( $user_id, $attachment_id ) {
+		$attachment_id = absint( $attachment_id );
+		if ( ! $attachment_id || ! wp_attachment_is_image( $attachment_id ) ) {
+			return false;
+		}
+
+		global $simple_local_avatars;
+		if ( is_object( $simple_local_avatars ) && method_exists( $simple_local_avatars, 'assign_new_user_avatar' ) ) {
+			$simple_local_avatars->assign_new_user_avatar( $attachment_id, $user_id );
+			return true;
+		}
+
+		update_user_meta(
+			$user_id,
+			'mastodon_api_avatar',
+			array(
+				'media_id' => $attachment_id,
+				'full'     => wp_get_attachment_url( $attachment_id ),
+				'blog_id'  => get_current_blog_id(),
+			)
+		);
+
+		return false;
 	}
 
 	public function query_vars( $query_vars ) {

--- a/includes/handler/class-account.php
+++ b/includes/handler/class-account.php
@@ -28,6 +28,7 @@ class Account extends Handler {
 		add_filter( 'mastodon_api_account', array( $this, 'api_account' ), 10, 2 );
 		add_filter( 'mastodon_api_account_id', array( $this, 'api_account_id' ), 10, 2 );
 		add_filter( 'mastodon_api_account', array( $this, 'api_account_ema' ), 10, 4 );
+		add_filter( 'mastodon_api_account', array( $this, 'api_account_media_overrides' ), 20, 2 );
 		add_filter( 'mastodon_api_account', array( get_called_class(), 'api_account_ensure_numeric_id' ), 100, 2 );
 	}
 
@@ -78,19 +79,6 @@ class Account extends Handler {
 		$account->display_name   = $user->display_name;
 		$account->avatar         = get_avatar_url( $user->ID );
 		$account->avatar_static  = get_avatar_url( $user->ID );
-		$avatar = get_user_meta( $user->ID, 'mastodon_api_avatar', true );
-		if ( is_array( $avatar ) && ! empty( $avatar['full'] ) ) {
-			$account->avatar        = $avatar['full'];
-			$account->avatar_static = $avatar['full'];
-		}
-		$header_id = absint( get_user_meta( $user->ID, 'mastodon_api_header_id', true ) );
-		if ( $header_id ) {
-			$header_url = wp_get_attachment_url( $header_id );
-			if ( $header_url ) {
-				$account->header        = $header_url;
-				$account->header_static = $header_url;
-			}
-		}
 		$account->acct           = $user->user_login;
 		$account->note           = wpautop( $note );
 		$account->created_at     = new \DateTime( $user->user_registered );
@@ -105,6 +93,29 @@ class Account extends Handler {
 			'note'      => $note,
 			'fields'    => array(),
 		);
+
+		return $account;
+	}
+
+	public function api_account_media_overrides( $account, $user_id ) {
+		if ( ! is_object( $account ) || ! is_numeric( $user_id ) || $user_id <= 0 ) {
+			return $account;
+		}
+
+		$avatar = get_user_meta( $user_id, 'mastodon_api_avatar', true );
+		if ( is_array( $avatar ) && ! empty( $avatar['full'] ) ) {
+			$account->avatar        = $avatar['full'];
+			$account->avatar_static = $avatar['full'];
+		}
+
+		$header_id = absint( get_user_meta( $user_id, 'mastodon_api_header_id', true ) );
+		if ( $header_id ) {
+			$header_url = wp_get_attachment_url( $header_id );
+			if ( $header_url ) {
+				$account->header        = $header_url;
+				$account->header_static = $header_url;
+			}
+		}
 
 		return $account;
 	}

--- a/includes/handler/class-account.php
+++ b/includes/handler/class-account.php
@@ -78,6 +78,19 @@ class Account extends Handler {
 		$account->display_name   = $user->display_name;
 		$account->avatar         = get_avatar_url( $user->ID );
 		$account->avatar_static  = get_avatar_url( $user->ID );
+		$avatar = get_user_meta( $user->ID, 'mastodon_api_avatar', true );
+		if ( is_array( $avatar ) && ! empty( $avatar['full'] ) ) {
+			$account->avatar        = $avatar['full'];
+			$account->avatar_static = $avatar['full'];
+		}
+		$header_id = absint( get_user_meta( $user->ID, 'mastodon_api_header_id', true ) );
+		if ( $header_id ) {
+			$header_url = wp_get_attachment_url( $header_id );
+			if ( $header_url ) {
+				$account->header        = $header_url;
+				$account->header_static = $header_url;
+			}
+		}
 		$account->acct           = $user->user_login;
 		$account->note           = wpautop( $note );
 		$account->created_at     = new \DateTime( $user->user_registered );

--- a/tests/test-accounts-endpoint.php
+++ b/tests/test-accounts-endpoint.php
@@ -75,6 +75,100 @@ class AccountsEndpoint_Test extends Mastodon_API_TestCase {
 		$this->assertSame( '', $account->header_static );
 	}
 
+	public function test_account_uses_saved_mastodon_header_image() {
+		update_user_meta( $this->administrator, 'mastodon_api_header_id', $this->friend_attachment_id );
+
+		$request  = $this->api_request( 'GET', '/api/v1/accounts/verify_credentials' );
+		$response = $this->dispatch_authenticated( $request );
+		$data     = $response->get_data();
+		$url      = wp_get_attachment_url( $this->friend_attachment_id );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( $url, $data->header );
+		$this->assertSame( $url, $data->header_static );
+	}
+
+	public function test_update_credentials_updates_simple_local_avatar() {
+		global $simple_local_avatars;
+
+		$previous_simple_local_avatars = $simple_local_avatars;
+		$simple_local_avatars          = new class() {
+			public function assign_new_user_avatar( $attachment_id, $user_id ) {
+				update_user_meta(
+					$user_id,
+					'simple_local_avatar',
+					array(
+						'media_id' => $attachment_id,
+						'full'     => wp_get_attachment_url( $attachment_id ),
+						'blog_id'  => get_current_blog_id(),
+					)
+				);
+			}
+		};
+		$update_credentials = function ( $data ) {
+			$data['avatar'] = $this->friend_attachment_id;
+			return $data;
+		};
+		add_filter( 'mastodon_api_update_credentials', $update_credentials );
+
+		$request  = $this->api_request( 'PATCH', '/api/v1/accounts/update_credentials' );
+		$response = $this->dispatch_authenticated( $request );
+
+		remove_filter( 'mastodon_api_update_credentials', $update_credentials );
+		$simple_local_avatars = $previous_simple_local_avatars;
+
+		$this->assertEquals( 200, $response->get_status() );
+		$avatar = get_user_meta( $this->administrator, 'simple_local_avatar', true );
+		$this->assertSame( $this->friend_attachment_id, (int) $avatar['media_id'] );
+	}
+
+	public function test_update_credentials_uses_mastodon_avatar_fallback_without_avatar_provider() {
+		global $simple_local_avatars;
+
+		$previous_simple_local_avatars = $simple_local_avatars;
+		$simple_local_avatars          = null;
+		$update_credentials            = function ( $data ) {
+			$data['avatar'] = $this->friend_attachment_id;
+			return $data;
+		};
+		add_filter( 'mastodon_api_update_credentials', $update_credentials );
+
+		$request  = $this->api_request( 'PATCH', '/api/v1/accounts/update_credentials' );
+		$response = $this->dispatch_authenticated( $request );
+
+		remove_filter( 'mastodon_api_update_credentials', $update_credentials );
+		$simple_local_avatars = $previous_simple_local_avatars;
+
+		$this->assertEquals( 200, $response->get_status() );
+		$avatar = get_user_meta( $this->administrator, 'mastodon_api_avatar', true );
+		$this->assertSame( $this->friend_attachment_id, (int) $avatar['media_id'] );
+
+		$request  = $this->api_request( 'GET', '/api/v1/accounts/verify_credentials' );
+		$response = $this->dispatch_authenticated( $request );
+		$data     = $response->get_data();
+		$url      = wp_get_attachment_url( $this->friend_attachment_id );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( $url, $data->avatar );
+		$this->assertSame( $url, $data->avatar_static );
+	}
+
+	public function test_update_credentials_persists_header_attachment_id() {
+		$update_credentials = function ( $data ) {
+			$data['header'] = $this->friend_attachment_id;
+			return $data;
+		};
+		add_filter( 'mastodon_api_update_credentials', $update_credentials );
+
+		$request  = $this->api_request( 'PATCH', '/api/v1/accounts/update_credentials' );
+		$response = $this->dispatch_authenticated( $request );
+
+		remove_filter( 'mastodon_api_update_credentials', $update_credentials );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( $this->friend_attachment_id, (int) get_user_meta( $this->administrator, 'mastodon_api_header_id', true ) );
+	}
+
 	public function test_account_statuses_uses_route_user_id_over_query_user_id() {
 		$request = $this->api_request( 'GET', '/api/v1/accounts/' . $this->friend . '/statuses' );
 		$request->set_query_params(

--- a/tests/test-accounts-endpoint.php
+++ b/tests/test-accounts-endpoint.php
@@ -78,14 +78,11 @@ class AccountsEndpoint_Test extends Mastodon_API_TestCase {
 	public function test_account_uses_saved_mastodon_header_image() {
 		update_user_meta( $this->administrator, 'mastodon_api_header_id', $this->friend_attachment_id );
 
-		$request  = $this->api_request( 'GET', '/api/v1/accounts/verify_credentials' );
-		$response = $this->dispatch_authenticated( $request );
-		$data     = $response->get_data();
-		$url      = wp_get_attachment_url( $this->friend_attachment_id );
+		$account = apply_filters( 'mastodon_api_account', null, $this->administrator, null, null );
+		$url     = wp_get_attachment_url( $this->friend_attachment_id );
 
-		$this->assertEquals( 200, $response->get_status() );
-		$this->assertSame( $url, $data->header );
-		$this->assertSame( $url, $data->header_static );
+		$this->assertSame( $url, $account->header );
+		$this->assertSame( $url, $account->header_static );
 	}
 
 	public function test_update_credentials_updates_simple_local_avatar() {
@@ -143,14 +140,11 @@ class AccountsEndpoint_Test extends Mastodon_API_TestCase {
 		$avatar = get_user_meta( $this->administrator, 'mastodon_api_avatar', true );
 		$this->assertSame( $this->friend_attachment_id, (int) $avatar['media_id'] );
 
-		$request  = $this->api_request( 'GET', '/api/v1/accounts/verify_credentials' );
-		$response = $this->dispatch_authenticated( $request );
-		$data     = $response->get_data();
-		$url      = wp_get_attachment_url( $this->friend_attachment_id );
+		$account = apply_filters( 'mastodon_api_account', null, $this->administrator, null, null );
+		$url     = wp_get_attachment_url( $this->friend_attachment_id );
 
-		$this->assertEquals( 200, $response->get_status() );
-		$this->assertSame( $url, $data->avatar );
-		$this->assertSame( $url, $data->avatar_static );
+		$this->assertSame( $url, $account->avatar );
+		$this->assertSame( $url, $account->avatar_static );
 	}
 
 	public function test_update_credentials_persists_header_attachment_id() {


### PR DESCRIPTION
## Summary
Mastodon clients send profile image changes through `PATCH /api/v1/accounts/update_credentials`, but WordPress does not have a built-in local avatar store. This keeps the behavior aligned with the source of truth that is available:

- let the ActivityPub integration handle `avatar` and `header` first when it can, so ActivityPub profile data remains authoritative for federated users
- update Simple Local Avatars when that provider is active, so uploaded profile pictures become the user's WordPress avatar instead of only an EMA-specific setting
- otherwise store uploaded avatars as EMA-only fallback metadata and apply them only to Mastodon API account responses
- persist uploaded headers as EMA account metadata, matching the existing Mastodon-client-only header behavior
- fix multipart PATCH upload handling so uploaded media is handed to WordPress without the trailing multipart line ending

## Testing
- `php -l includes/class-mastodon-api.php`
- `php -l includes/handler/class-account.php`
- `php -l tests/test-accounts-endpoint.php`
- `composer check-cs -- includes/class-mastodon-api.php includes/handler/class-account.php tests/test-accounts-endpoint.php`
- `git diff --check`
- GitHub Actions: lint, CS, and PHPUnit matrix all passing for PR #310
