### PR TITLE
Avoid stale block media attachment IDs

### DIFF
--- a/includes/handler/class-media-attachment.php
+++ b/includes/handler/class-media-attachment.php
@@ -168,6 +168,10 @@ class Media_Attachment extends Handler {
 			if ( ! isset( $block['src'] ) ) {
 				continue;
 			}
+			$parts = wp_parse_url( html_entity_decode( $block['src'], ENT_QUOTES ) );
+			if ( empty( $parts['scheme'] ) || ! in_array( $parts['scheme'], array( 'http', 'https' ), true ) ) {
+				continue;
+			}
 
 			$attachment              = new \Enable_Mastodon_Apps\Entity\Media_Attachment();
 			$attachment->id          = strval( 2e10 + crc32( $block['src'] ) );

--- a/includes/handler/class-status.php
+++ b/includes/handler/class-status.php
@@ -92,7 +92,7 @@ class Status extends Handler {
 				case 'core/audio':
 				case 'core/video':
 				case 'videopress/video':
-					if ( ! empty( $block['attrs']['id'] ) ) {
+					if ( ! empty( $block['attrs']['id'] ) && self::block_references_attachment( (int) $block['attrs']['id'], $block['innerHTML'] ?? '' ) ) {
 						$media_ids[ $block['attrs']['id'] ] = $block['innerHTML'];
 					}
 					break;
@@ -100,15 +100,23 @@ class Status extends Handler {
 				case 'jetpack/tiled-gallery':
 					if ( ! empty( $block['attrs']['ids'] ) ) {
 						foreach ( $block['attrs']['ids'] as $id ) {
-							$media_ids[ $id ] = $block['innerHTML'];
+							if ( self::block_references_attachment( (int) $id, $block['innerHTML'] ?? '' ) ) {
+								$media_ids[ $id ] = $block['innerHTML'];
+							}
 						}
 					}
 					break;
 				case 'jetpack/image-compare':
-					if ( ! empty( $block['attrs']['beforeImageId'] ) ) {
+					if (
+						! empty( $block['attrs']['beforeImageId'] ) &&
+						self::block_references_attachment( (int) $block['attrs']['beforeImageId'], $block['innerHTML'] ?? '' )
+					) {
 						$media_ids[ $block['attrs']['beforeImageId'] ] = $block['innerHTML'];
 					}
-					if ( ! empty( $block['attrs']['afterImageId'] ) ) {
+					if (
+						! empty( $block['attrs']['afterImageId'] ) &&
+						self::block_references_attachment( (int) $block['attrs']['afterImageId'], $block['innerHTML'] ?? '' )
+					) {
 						$media_ids[ $block['attrs']['afterImageId'] ] = $block['innerHTML'];
 					}
 					break;
@@ -121,6 +129,95 @@ class Status extends Handler {
 
 		// Still need to slice it because one gallery could knock us over the limit.
 		return array_slice( $media_ids, 0, $max_media, true );
+	}
+
+	/**
+	 * Check whether a block's rendered media source belongs to an attachment ID.
+	 *
+	 * @param int    $attachment_id The media attachment ID.
+	 * @param string $html The block HTML.
+	 * @return bool Whether the block references the attachment.
+	 */
+	private static function block_references_attachment( int $attachment_id, string $html ): bool {
+		if ( ! $attachment_id || ! get_post( $attachment_id ) ) {
+			return false;
+		}
+
+		$sources = self::get_media_sources_from_html( $html );
+		if ( empty( $sources ) ) {
+			return true;
+		}
+
+		$filenames = self::get_attachment_filenames( $attachment_id );
+		if ( empty( $filenames ) ) {
+			return false;
+		}
+
+		foreach ( $sources as $source ) {
+			$parts = wp_parse_url( html_entity_decode( $source, ENT_QUOTES ) );
+			if ( empty( $parts['path'] ) ) {
+				continue;
+			}
+
+			if ( in_array( rawurldecode( wp_basename( $parts['path'] ) ), $filenames, true ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Extract media sources from a block's rendered HTML.
+	 *
+	 * @param string $html The block HTML.
+	 * @return array The media source URLs.
+	 */
+	private static function get_media_sources_from_html( string $html ): array {
+		$sources = array();
+
+		if ( preg_match_all( '/\s(?:src|href|poster)=([\'"])(?P<src>.*?)\1/i', $html, $matches ) ) {
+			$sources = array_merge( $sources, $matches['src'] );
+		}
+
+		if ( preg_match_all( '/url\(([\'"]?)(?P<src>[^)\'"]+)\1\)/i', $html, $matches ) ) {
+			$sources = array_merge( $sources, $matches['src'] );
+		}
+
+		return array_values( array_unique( array_filter( $sources ) ) );
+	}
+
+	/**
+	 * Get the known filenames for an attachment and its generated sizes.
+	 *
+	 * @param int $attachment_id The media attachment ID.
+	 * @return array The attachment filenames.
+	 */
+	private static function get_attachment_filenames( int $attachment_id ): array {
+		$filenames = array();
+		$url       = wp_get_attachment_url( $attachment_id );
+		$meta      = wp_get_attachment_metadata( $attachment_id );
+
+		if ( $url ) {
+			$parts = wp_parse_url( $url );
+			if ( ! empty( $parts['path'] ) ) {
+				$filenames[] = rawurldecode( wp_basename( $parts['path'] ) );
+			}
+		}
+
+		if ( ! empty( $meta['file'] ) ) {
+			$filenames[] = wp_basename( $meta['file'] );
+		}
+
+		if ( ! empty( $meta['sizes'] ) && is_array( $meta['sizes'] ) ) {
+			foreach ( $meta['sizes'] as $size ) {
+				if ( ! empty( $size['file'] ) ) {
+					$filenames[] = $size['file'];
+				}
+			}
+		}
+
+		return array_values( array_unique( $filenames ) );
 	}
 
 	/**

--- a/tests/test-statuses-endpoint.php
+++ b/tests/test-statuses-endpoint.php
@@ -50,6 +50,32 @@ class StatusesEndpoint_Test extends Mastodon_API_TestCase {
 		$this->assertIsInt( $data->favourites_count );
 	}
 
+	public function test_status_does_not_use_attachment_id_when_block_src_does_not_match() {
+		$post_content = sprintf(
+			'<!-- wp:image {"id":%1$d} -->
+<figure class="wp-block-image"><img src="///data/user/0/org.wordpress.android/cache/img_20260718_193843348353428213156283.jpg" alt="" class="wp-image-%1$d" /></figure>
+<!-- /wp:image -->',
+			$this->friend_attachment_id
+		);
+		$post_id      = wp_insert_post(
+			array(
+				'post_author'  => $this->friend,
+				'post_content' => $post_content,
+				'post_title'   => 'Image with stale attachment ID',
+				'post_status'  => 'publish',
+				'post_type'    => 'post',
+			)
+		);
+		set_post_format( $post_id, 'status' );
+
+		$request  = $this->api_request( 'GET', '/api/v1/statuses/' . $post_id );
+		$response = $this->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertEmpty( $data->media_attachments );
+	}
+
 	public function test_statuses_private_id() {
 		$request = $this->api_request( 'GET', '/api/v1/statuses/' . $this->private_post );
 		$response = $this->dispatch( $request );


### PR DESCRIPTION
## Summary

Fix Mastodon API status media extraction so EMA does not trust a block attachment ID when the rendered media source points somewhere else.

WordPress remains authoritative for valid media library attachments: when a block's rendered `src`, `href`, `poster`, or CSS `url()` matches the attachment or one of its generated image sizes, EMA still emits that WordPress attachment as Mastodon media. When an integration leaves behind a stale block ID with a non-library source such as an Android app cache path, EMA now skips that ID instead of returning an unrelated media library item. Generic inline image fallback is also limited to `http` and `https` URLs so local device paths are not exposed as Mastodon media attachments.

## Validation

- `wp --url=ella-und-oskar.kirk.at post get 11718 --fields=ID,post_title,post_type,post_status,post_content --format=json`
- `wp --url=ella-und-oskar.kirk.at post get 4170 --fields=ID,post_title,post_type,post_status,guid,post_mime_type,post_parent --format=json`
- `wp --url=ella-und-oskar.kirk.at eval 'var_export(array("thumb"=>get_post_thumbnail_id(11718),"att_url"=>wp_get_attachment_url(4170),"image_src"=>wp_get_attachment_image_src(4170),"meta"=>wp_get_attachment_metadata(4170),"is_image"=>wp_attachment_is("image",4170)));'`
- `wp --url=ella-und-oskar.kirk.at eval '$post=get_post(11718); $blocks=parse_blocks($post->post_content); var_export(array("content"=>$post->post_content,"blocks"=>$blocks));'`
- `wp --url=ella-und-oskar.kirk.at eval '$status=apply_filters("mastodon_api_status", null, 11718); var_export(array_map(function($m){ return array("id"=>$m->id,"url"=>$m->url,"preview_url"=>$m->preview_url); }, $status->media_attachments));'`
- `php -l includes/handler/class-status.php`
- `php -l includes/handler/class-media-attachment.php`
- `php -l tests/test-statuses-endpoint.php`
- `php ./vendor/bin/phpcs includes/handler/class-status.php includes/handler/class-media-attachment.php tests/test-statuses-endpoint.php`
- `git diff --check`

`php ./vendor/phpunit/phpunit/phpunit --no-coverage tests/test-statuses-endpoint.php` could not run because `/tmp/wordpress-tests-lib/includes/functions.php` is missing in this environment.
