### PR TITLE
Add configurable media attachment limit

### DIFF
--- a/includes/class-mastodon-admin.php
+++ b/includes/class-mastodon-admin.php
@@ -238,6 +238,15 @@ class Mastodon_Admin {
 			}
 		}
 
+		if ( isset( $_POST['mastodon_api_max_media_attachments'] ) ) {
+			$max_media_attachments = absint( wp_unslash( $_POST['mastodon_api_max_media_attachments'] ) );
+			if ( $max_media_attachments && 4 !== $max_media_attachments ) {
+				update_option( 'mastodon_api_max_media_attachments', $max_media_attachments, false );
+			} else {
+				delete_option( 'mastodon_api_max_media_attachments' );
+			}
+		}
+
 		/**
 		 * The default post type for posting from Mastodon apps when the configured to do so.
 		 *

--- a/includes/class-mastodon-api.php
+++ b/includes/class-mastodon-api.php
@@ -44,6 +44,20 @@ class Mastodon_API {
 	const ANNOUNCE_CPT   = 'ema-announce';
 
 	/**
+	 * Get the maximum number of media attachments allowed per status.
+	 *
+	 * @return int The configured media attachment limit.
+	 */
+	public static function get_max_media_attachments(): int {
+		$max_media_attachments = absint( get_option( 'mastodon_api_max_media_attachments', 4 ) );
+		if ( $max_media_attachments < 1 ) {
+			return 4;
+		}
+
+		return $max_media_attachments;
+	}
+
+	/**
 	 * Constructor
 	 */
 	public function __construct() {
@@ -2434,6 +2448,18 @@ class Mastodon_API {
 		$in_reply_to_id = apply_filters( 'mastodon_api_in_reply_to_id', $request->get_param( 'in_reply_to_id' ), $request );
 
 		$media_ids    = $request->get_param( 'media_ids' );
+		$max_media_attachments = self::get_max_media_attachments();
+		if ( is_array( $media_ids ) && count( $media_ids ) > $max_media_attachments ) {
+			return new \WP_Error(
+				'mastodon_' . __FUNCTION__,
+				sprintf(
+					/* translators: %d: maximum number of media attachments per status. */
+					__( 'Validation failed: Media attachments can\'t exceed %d', 'enable-mastodon-apps' ),
+					$max_media_attachments
+				),
+				array( 'status' => 422 )
+			);
+		}
 		$scheduled_at = $request->get_param( 'scheduled_at' );
 
 		$app = Mastodon_App::get_current_app();
@@ -2962,6 +2988,18 @@ class Mastodon_API {
 		$in_reply_to_id = apply_filters( 'mastodon_api_in_reply_to_id', $request->get_param( 'in_reply_to_id' ), $request );
 
 		$media_ids    = $request->get_param( 'media_ids' );
+		$max_media_attachments = self::get_max_media_attachments();
+		if ( is_array( $media_ids ) && count( $media_ids ) > $max_media_attachments ) {
+			return new \WP_Error(
+				'mastodon_' . __FUNCTION__,
+				sprintf(
+					/* translators: %d: maximum number of media attachments per status. */
+					__( 'Validation failed: Media attachments can\'t exceed %d', 'enable-mastodon-apps' ),
+					$max_media_attachments
+				),
+				array( 'status' => 422 )
+			);
+		}
 		$scheduled_at = $request->get_param( 'scheduled_at' );
 
 		$app = Mastodon_App::get_current_app();

--- a/includes/handler/class-instance.php
+++ b/includes/handler/class-instance.php
@@ -64,16 +64,14 @@ class Instance extends Handler {
 		$instance->approval_required = false;
 		$instance->invites_enabled   = false;
 		$instance->languages         = empty( get_available_languages() ) ? array( 'en' ) : get_available_languages();
+		$media_attachments           = $this->media_attachment_configuration();
 		$instance->configuration     = array(
-			'statuses'         => array(
+			'statuses'          => array(
 				'max_media_attachments' => Mastodon_API::get_max_media_attachments(),
 			),
-			'media_attachment' => array(
-				'supported_mime_types' => array_values( get_allowed_mime_types() ),
-				'image_size_limit'     => \wp_max_upload_size(),
-				'video_size_limit'     => \wp_max_upload_size(),
-			),
-			'translation'      => array(
+			'media_attachments' => $media_attachments,
+			'media_attachment'  => $media_attachments,
+			'translation'       => array(
 				'enabled' => false,
 			),
 		);
@@ -105,16 +103,14 @@ class Instance extends Handler {
 		);
 		$instance->thumbnail     = array( 'url' => \get_site_icon_url() );
 		$instance->languages     = empty( get_available_languages() ) ? array( 'en' ) : get_available_languages();
+		$media_attachments       = $this->media_attachment_configuration();
 		$instance->configuration = array(
-			'statuses'         => array(
+			'statuses'          => array(
 				'max_media_attachments' => Mastodon_API::get_max_media_attachments(),
 			),
-			'media_attachment' => array(
-				'supported_mime_types' => array_values( get_allowed_mime_types() ),
-				'image_size_limit'     => \wp_max_upload_size(),
-				'video_size_limit'     => \wp_max_upload_size(),
-			),
-			'translation'      => array(
+			'media_attachments' => $media_attachments,
+			'media_attachment'  => $media_attachments,
+			'translation'       => array(
 				'enabled' => false,
 			),
 		);
@@ -129,6 +125,21 @@ class Instance extends Handler {
 		);
 
 		return $instance;
+	}
+
+	/**
+	 * Get the media attachment configuration for instance responses.
+	 *
+	 * @return array
+	 */
+	private function media_attachment_configuration(): array {
+		$upload_size_limit = \wp_max_upload_size();
+
+		return array(
+			'supported_mime_types' => array_values( get_allowed_mime_types() ),
+			'image_size_limit'     => $upload_size_limit,
+			'video_size_limit'     => $upload_size_limit,
+		);
 	}
 
 	/**

--- a/includes/handler/class-instance.php
+++ b/includes/handler/class-instance.php
@@ -65,6 +65,9 @@ class Instance extends Handler {
 		$instance->invites_enabled   = false;
 		$instance->languages         = empty( get_available_languages() ) ? array( 'en' ) : get_available_languages();
 		$instance->configuration     = array(
+			'statuses'         => array(
+				'max_media_attachments' => Mastodon_API::get_max_media_attachments(),
+			),
 			'media_attachment' => array(
 				'supported_mime_types' => array_values( get_allowed_mime_types() ),
 				'image_size_limit'     => \wp_max_upload_size(),
@@ -103,6 +106,9 @@ class Instance extends Handler {
 		$instance->thumbnail     = array( 'url' => \get_site_icon_url() );
 		$instance->languages     = empty( get_available_languages() ) ? array( 'en' ) : get_available_languages();
 		$instance->configuration = array(
+			'statuses'         => array(
+				'max_media_attachments' => Mastodon_API::get_max_media_attachments(),
+			),
 			'media_attachment' => array(
 				'supported_mime_types' => array_values( get_allowed_mime_types() ),
 				'image_size_limit'     => \wp_max_upload_size(),

--- a/includes/handler/class-instance.php
+++ b/includes/handler/class-instance.php
@@ -70,7 +70,6 @@ class Instance extends Handler {
 				'max_media_attachments' => Mastodon_API::get_max_media_attachments(),
 			),
 			'media_attachments' => $media_attachments,
-			'media_attachment'  => $media_attachments,
 			'translation'       => array(
 				'enabled' => false,
 			),
@@ -109,7 +108,6 @@ class Instance extends Handler {
 				'max_media_attachments' => Mastodon_API::get_max_media_attachments(),
 			),
 			'media_attachments' => $media_attachments,
-			'media_attachment'  => $media_attachments,
 			'translation'       => array(
 				'enabled' => false,
 			),

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -29,7 +29,7 @@
 					</td>
 				</tr>
 				<tr>
-					<th scope="row" rowspan="2"><?php esc_html_e( 'Posting', 'enable-mastodon-apps' ); ?></th>
+					<th scope="row" rowspan="3"><?php esc_html_e( 'Posting', 'enable-mastodon-apps' ); ?></th>
 					<td>
 						<fieldset>
 							<label for="mastodon_api_no_posting_cpt">
@@ -90,6 +90,27 @@
 							</select>
 							<p class="description">
 								<?php esc_html_e( 'If no post format is selected, posts in all post formats will be displayed.', 'enable-mastodon-apps' ); ?>
+							</p>
+						</fieldset>
+					</td>
+				</tr>
+				<tr>
+					<td>
+						<fieldset>
+							<label for="mastodon_api_max_media_attachments">
+								<?php esc_html_e( 'Maximum media attachments per post:', 'enable-mastodon-apps' ); ?>
+							</label>
+							<input
+								name="mastodon_api_max_media_attachments"
+								type="number"
+								id="mastodon_api_max_media_attachments"
+								value="<?php echo esc_attr( \Enable_Mastodon_Apps\Mastodon_API::get_max_media_attachments() ); ?>"
+								min="1"
+								step="1"
+								class="small-text"
+							/>
+							<p class="description">
+								<?php esc_html_e( 'This limit is advertised to Mastodon apps and enforced when posting or editing statuses.', 'enable-mastodon-apps' ); ?>
 							</p>
 						</fieldset>
 					</td>

--- a/tests/test-instance-endpoint.php
+++ b/tests/test-instance-endpoint.php
@@ -49,6 +49,28 @@ class InstanceEndpoint_Test extends Mastodon_API_TestCase {
 		$this->assertFalse( $data->registrations, false );
 
 		$this->assertFalse( $data->approval_required, false );
+
+		$this->assertEquals( 4, $data->configuration['statuses']['max_media_attachments'] );
+	}
+
+	public function test_apps_instance_v2_includes_status_limits() {
+		$request = $this->api_request( 'GET', '/api/v2/instance' );
+		$response = $this->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertEquals( 4, $data->configuration['statuses']['max_media_attachments'] );
+	}
+
+	public function test_apps_instance_uses_configured_media_attachment_limit() {
+		update_option( 'mastodon_api_max_media_attachments', 8 );
+
+		$request = $this->api_request( 'GET', '/api/v1/instance' );
+		$response = $this->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertEquals( 8, $data->configuration['statuses']['max_media_attachments'] );
 	}
 
 	public function test_extended_description() {

--- a/tests/test-instance-endpoint.php
+++ b/tests/test-instance-endpoint.php
@@ -51,6 +51,9 @@ class InstanceEndpoint_Test extends Mastodon_API_TestCase {
 		$this->assertFalse( $data->approval_required, false );
 
 		$this->assertEquals( 4, $data->configuration['statuses']['max_media_attachments'] );
+		$this->assertArrayHasKey( 'media_attachments', $data->configuration );
+		$this->assertEquals( wp_max_upload_size(), $data->configuration['media_attachments']['image_size_limit'] );
+		$this->assertEquals( wp_max_upload_size(), $data->configuration['media_attachments']['video_size_limit'] );
 	}
 
 	public function test_apps_instance_v2_includes_status_limits() {
@@ -60,6 +63,9 @@ class InstanceEndpoint_Test extends Mastodon_API_TestCase {
 
 		$data = $response->get_data();
 		$this->assertEquals( 4, $data->configuration['statuses']['max_media_attachments'] );
+		$this->assertArrayHasKey( 'media_attachments', $data->configuration );
+		$this->assertEquals( wp_max_upload_size(), $data->configuration['media_attachments']['image_size_limit'] );
+		$this->assertEquals( wp_max_upload_size(), $data->configuration['media_attachments']['video_size_limit'] );
 	}
 
 	public function test_apps_instance_uses_configured_media_attachment_limit() {

--- a/tests/test-instance-endpoint.php
+++ b/tests/test-instance-endpoint.php
@@ -52,6 +52,7 @@ class InstanceEndpoint_Test extends Mastodon_API_TestCase {
 
 		$this->assertEquals( 4, $data->configuration['statuses']['max_media_attachments'] );
 		$this->assertArrayHasKey( 'media_attachments', $data->configuration );
+		$this->assertArrayNotHasKey( 'media_attachment', $data->configuration );
 		$this->assertEquals( wp_max_upload_size(), $data->configuration['media_attachments']['image_size_limit'] );
 		$this->assertEquals( wp_max_upload_size(), $data->configuration['media_attachments']['video_size_limit'] );
 	}
@@ -64,6 +65,7 @@ class InstanceEndpoint_Test extends Mastodon_API_TestCase {
 		$data = $response->get_data();
 		$this->assertEquals( 4, $data->configuration['statuses']['max_media_attachments'] );
 		$this->assertArrayHasKey( 'media_attachments', $data->configuration );
+		$this->assertArrayNotHasKey( 'media_attachment', $data->configuration );
 		$this->assertEquals( wp_max_upload_size(), $data->configuration['media_attachments']['image_size_limit'] );
 		$this->assertEquals( wp_max_upload_size(), $data->configuration['media_attachments']['video_size_limit'] );
 	}

--- a/tests/test-statuses-endpoint.php
+++ b/tests/test-statuses-endpoint.php
@@ -274,6 +274,26 @@ class StatusesEndpoint_Test extends Mastodon_API_TestCase {
 		$this->assertEquals( 422, $response->get_status() );
 	}
 
+	public function test_submit_status_rejects_too_many_media_attachments() {
+		$request = $this->api_request( 'POST', '/api/v1/statuses' );
+		$request->set_param( 'status', 'too many attachments' );
+		$request->set_param( 'media_ids', array_fill( 0, 5, (string) $this->friend_attachment_id ) );
+
+		$response = $this->dispatch_authenticated( $request );
+		$this->assertEquals( 422, $response->get_status() );
+	}
+
+	public function test_submit_status_allows_configured_media_attachment_limit() {
+		update_option( 'mastodon_api_max_media_attachments', 5 );
+
+		$request = $this->api_request( 'POST', '/api/v1/statuses' );
+		$request->set_param( 'status', 'configured attachments' );
+		$request->set_param( 'media_ids', array_fill( 0, 5, (string) $this->friend_attachment_id ) );
+
+		$response = $this->dispatch_authenticated( $request );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
 	public function submit_status_data_provider() {
 		return array(
 			'basic_status'                    => array(


### PR DESCRIPTION
## Summary
- Add a WordPress setting for the maximum number of media attachments allowed per post, defaulting to Mastodon's 4 attachment behavior.
- Advertise the effective EMA-owned attachment-count limit through the Mastodon instance configuration so clients such as Tusky can adjust their compose UI.
- Advertise WordPress' upload size limit through the standard Mastodon `configuration.media_attachments` block.
- Enforce the same configured attachment-count limit when statuses are created or edited, keeping WordPress/EMA authoritative even if a client sends more media IDs than advertised.

## Ownership boundary
EMA owns the compatibility contract it exposes through the Mastodon API and the WordPress option used to configure the attachment-count limit. WordPress remains responsible for accepting, sizing, and storing uploaded attachments; EMA relays WordPress' upload-size limit to clients as instance metadata and returns WordPress upload failures from the media endpoint. Mastodon clients only receive the advertised limits and may choose to enforce them client-side. The server-side media-count validation is scoped to EMA status creation/editing so integrations cannot bypass the configured posting limit by sending a larger `media_ids` payload.

## Validation
- `php -l includes/class-mastodon-api.php`
- `php -l includes/class-mastodon-admin.php`
- `php -l includes/handler/class-instance.php`
- `php -l templates/settings.php`
- `php -l tests/test-instance-endpoint.php`
- `php -l tests/test-statuses-endpoint.php`
- `composer check-cs -- includes/class-mastodon-api.php includes/class-mastodon-admin.php includes/handler/class-instance.php templates/settings.php tests/test-instance-endpoint.php tests/test-statuses-endpoint.php`
- `composer check-cs -- includes/handler/class-instance.php tests/test-instance-endpoint.php`

PHPUnit was not run locally because `/tmp/wordpress-tests-lib/includes/functions.php` is missing in this environment.
