### PR TITLE
Represent local blog follows in the API

### DIFF
--- a/includes/handler/class-relationship.php
+++ b/includes/handler/class-relationship.php
@@ -10,6 +10,7 @@
 namespace Enable_Mastodon_Apps\Handler;
 
 use Enable_Mastodon_Apps\Entity\Relationship as Relationship_Entity;
+use Enable_Mastodon_Apps\Entity\Account as Account_Entity;
 use Enable_Mastodon_Apps\Mastodon_API;
 use Enable_Mastodon_Apps\Handler\Handler;
 
@@ -31,7 +32,146 @@ class Relationship extends Handler {
 	 */
 	public function register_hooks() {
 		add_filter( 'mastodon_api_relationship', array( $this, 'api_relationship' ), 10, 3 );
+		add_filter( 'mastodon_api_account', array( $this, 'api_account_counts' ), 15, 2 );
+		add_filter( 'mastodon_api_account_following', array( $this, 'api_account_following' ), 10, 3 );
+		add_filter( 'mastodon_api_account_followers', array( $this, 'api_account_followers' ), 10, 3 );
 		add_filter( 'mastodon_entity_relationship', array( $this, 'entity_relationship_ensure_numeric_id' ), 100, 2 );
+	}
+
+	/**
+	 * Whether a follow integration is active.
+	 *
+	 * @return bool True if another plugin owns following behavior.
+	 */
+	private function has_following_integration(): bool {
+		$has_integration = class_exists( 'Friends\Friends' ) || class_exists( '\Activitypub\Activitypub' );
+
+		/**
+		 * Filters whether another plugin owns following behavior.
+		 *
+		 * @param bool $has_integration Whether another plugin owns following behavior.
+		 */
+		return (bool) apply_filters( 'mastodon_api_has_following_integration', $has_integration );
+	}
+
+	/**
+	 * Determine whether a user is a local member of the current blog.
+	 *
+	 * @param string|int $user_id User ID.
+	 * @return bool True if the user belongs to the current blog.
+	 */
+	private function is_local_blog_user( $user_id ): bool {
+		if ( ! is_numeric( $user_id ) ) {
+			return false;
+		}
+
+		$user_id = (int) $user_id;
+		if ( $user_id <= 0 || ! get_user_by( 'ID', $user_id ) ) {
+			return false;
+		}
+
+		if ( function_exists( 'is_user_member_of_blog' ) ) {
+			return is_user_member_of_blog( $user_id, get_current_blog_id() );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get local accounts automatically followed by a local blog user.
+	 *
+	 * @param string           $user_id User ID whose follows are requested.
+	 * @param \WP_REST_Request $request Request object.
+	 * @return Account_Entity[] Local account entities.
+	 */
+	private function get_local_blog_accounts( string $user_id, \WP_REST_Request $request ): array {
+		if ( $this->has_following_integration() || ! $this->is_local_blog_user( $user_id ) ) {
+			return array();
+		}
+
+		$accounts = array();
+		$user_ids = $this->get_local_blog_user_ids();
+
+		foreach ( $user_ids as $blog_user_id ) {
+			if ( (int) $blog_user_id === (int) $user_id ) {
+				continue;
+			}
+
+			$account = apply_filters( 'mastodon_api_account', null, $blog_user_id, $request, null );
+			if ( $account instanceof Account_Entity ) {
+				$accounts[] = $account;
+			}
+		}
+
+		return $accounts;
+	}
+
+	/**
+	 * Get local user IDs for the current blog.
+	 *
+	 * @return int[] Local blog user IDs.
+	 */
+	private function get_local_blog_user_ids(): array {
+		return array_map(
+			'intval',
+			get_users(
+				array(
+					'blog_id' => get_current_blog_id(),
+					'fields'  => 'ID',
+				)
+			)
+		);
+	}
+
+	/**
+	 * Set local follow counts when EMA owns local following behavior.
+	 *
+	 * @param mixed      $account Account entity.
+	 * @param string|int $user_id User ID.
+	 * @return mixed Account entity.
+	 */
+	public function api_account_counts( $account, $user_id ) {
+		if ( $this->has_following_integration() || ! $account instanceof Account_Entity || ! $this->is_local_blog_user( $user_id ) ) {
+			return $account;
+		}
+
+		$local_follow_count        = max( count( $this->get_local_blog_user_ids() ) - 1, 0 );
+		$account->followers_count = $local_follow_count;
+		$account->following_count = $local_follow_count;
+
+		return $account;
+	}
+
+	/**
+	 * Add automatically followed local blog accounts.
+	 *
+	 * @param Account_Entity[] $following Existing following accounts.
+	 * @param string           $user_id   User ID.
+	 * @param \WP_REST_Request $request   Request object.
+	 * @return Account_Entity[] Following accounts.
+	 */
+	public function api_account_following( $following, string $user_id, \WP_REST_Request $request ) {
+		if ( $this->has_following_integration() || ! empty( $following ) ) {
+			return $following;
+		}
+
+		return $this->get_local_blog_accounts( $user_id, $request );
+	}
+
+	/**
+	 * Add automatic local blog followers.
+	 *
+	 * @param Account_Entity[] $followers Existing follower accounts.
+	 * @param string           $user_id   User ID.
+	 * @param \WP_REST_Request $request   Request object.
+	 * @return Account_Entity[] Follower accounts.
+	 */
+	public function api_account_followers( $followers, string $user_id, \WP_REST_Request $request ) {
+		if ( $this->has_following_integration() || ! empty( $followers ) ) {
+			return $followers;
+		}
+
+		return $this->get_local_blog_accounts( $user_id, $request );
 	}
 
 	/**
@@ -46,6 +186,11 @@ class Relationship extends Handler {
 	public function api_relationship( $relationship_data, string $user_id, \WP_REST_Request $request ): Relationship_Entity {
 		$relationship     = new Relationship_Entity();
 		$relationship->id = $user_id;
+
+		if ( ! $this->has_following_integration() && $this->is_local_blog_user( $user_id ) && get_current_user_id() !== (int) $user_id ) {
+			$relationship->following   = true;
+			$relationship->followed_by = true;
+		}
 
 		return apply_filters( 'mastodon_entity_relationship', $relationship, $user_id, $request );
 	}

--- a/tests/test-accounts-endpoint.php
+++ b/tests/test-accounts-endpoint.php
@@ -203,6 +203,68 @@ class AccountsEndpoint_Test extends Mastodon_API_TestCase {
 		}
 	}
 
+	public function test_local_blog_users_are_following_without_following_integration() {
+		$disable_following_integration = '__return_false';
+		add_filter( 'mastodon_api_has_following_integration', $disable_following_integration );
+
+		$request  = $this->api_request( 'GET', '/api/v1/accounts/' . $this->administrator . '/following' );
+		$response = $this->dispatch_authenticated( $request );
+		$data     = json_decode( wp_json_encode( $response->get_data() ), true );
+
+		remove_filter( 'mastodon_api_has_following_integration', $disable_following_integration );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertCount( 1, $data );
+		$this->assertSame( strval( $this->friend ), $data[0]['id'] );
+	}
+
+	public function test_local_blog_users_are_followers_without_following_integration() {
+		$disable_following_integration = '__return_false';
+		add_filter( 'mastodon_api_has_following_integration', $disable_following_integration );
+
+		$request  = $this->api_request( 'GET', '/api/v1/accounts/' . $this->friend . '/followers' );
+		$response = $this->dispatch_authenticated( $request );
+		$data     = json_decode( wp_json_encode( $response->get_data() ), true );
+
+		remove_filter( 'mastodon_api_has_following_integration', $disable_following_integration );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertCount( 1, $data );
+		$this->assertSame( strval( $this->administrator ), $data[0]['id'] );
+	}
+
+	public function test_local_blog_user_relationship_is_following_without_following_integration() {
+		$disable_following_integration = '__return_false';
+		add_filter( 'mastodon_api_has_following_integration', $disable_following_integration );
+
+		$request = $this->api_request( 'GET', '/api/v1/accounts/relationships' );
+		$request->set_param( 'id', array( $this->friend ) );
+
+		$response = $this->dispatch_authenticated( $request );
+		$data     = json_decode( wp_json_encode( $response->get_data() ), true );
+
+		remove_filter( 'mastodon_api_has_following_integration', $disable_following_integration );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertTrue( $data[0]['following'] );
+		$this->assertTrue( $data[0]['followed_by'] );
+	}
+
+	public function test_local_blog_account_counts_include_automatic_follows_without_following_integration() {
+		$disable_following_integration = '__return_false';
+		add_filter( 'mastodon_api_has_following_integration', $disable_following_integration );
+
+		$request  = $this->api_request( 'GET', '/api/v1/accounts/verify_credentials' );
+		$response = $this->dispatch_authenticated( $request );
+		$data     = json_decode( wp_json_encode( $response->get_data() ), true );
+
+		remove_filter( 'mastodon_api_has_following_integration', $disable_following_integration );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 1, $data['followers_count'] );
+		$this->assertSame( 1, $data['following_count'] );
+	}
+
 	public function xtest_accounts_external() {
 		wp_cache_flush();
 		$request = $this->api_request( 'GET', '/api/v1/accounts/' . $this->external_account );

--- a/tests/test-accounts-endpoint.php
+++ b/tests/test-accounts-endpoint.php
@@ -214,8 +214,8 @@ class AccountsEndpoint_Test extends Mastodon_API_TestCase {
 		remove_filter( 'mastodon_api_has_following_integration', $disable_following_integration );
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertCount( 1, $data );
-		$this->assertSame( strval( $this->friend ), $data[0]['id'] );
+		$this->assertContains( strval( $this->friend ), wp_list_pluck( $data, 'id' ) );
+		$this->assertNotContains( strval( $this->administrator ), wp_list_pluck( $data, 'id' ) );
 	}
 
 	public function test_local_blog_users_are_followers_without_following_integration() {
@@ -229,8 +229,8 @@ class AccountsEndpoint_Test extends Mastodon_API_TestCase {
 		remove_filter( 'mastodon_api_has_following_integration', $disable_following_integration );
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertCount( 1, $data );
-		$this->assertSame( strval( $this->administrator ), $data[0]['id'] );
+		$this->assertContains( strval( $this->administrator ), wp_list_pluck( $data, 'id' ) );
+		$this->assertNotContains( strval( $this->friend ), wp_list_pluck( $data, 'id' ) );
 	}
 
 	public function test_local_blog_user_relationship_is_following_without_following_integration() {
@@ -238,7 +238,11 @@ class AccountsEndpoint_Test extends Mastodon_API_TestCase {
 		add_filter( 'mastodon_api_has_following_integration', $disable_following_integration );
 
 		$request = $this->api_request( 'GET', '/api/v1/accounts/relationships' );
-		$request->set_param( 'id', array( $this->friend ) );
+		$request->set_query_params(
+			array(
+				'id' => array( strval( $this->friend ) ),
+			)
+		);
 
 		$response = $this->dispatch_authenticated( $request );
 		$data     = json_decode( wp_json_encode( $response->get_data() ), true );
@@ -260,9 +264,21 @@ class AccountsEndpoint_Test extends Mastodon_API_TestCase {
 
 		remove_filter( 'mastodon_api_has_following_integration', $disable_following_integration );
 
+		$local_follow_count = max(
+			count(
+				get_users(
+					array(
+						'blog_id' => get_current_blog_id(),
+						'fields'  => 'ID',
+					)
+				)
+			) - 1,
+			0
+		);
+
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertSame( 1, $data['followers_count'] );
-		$this->assertSame( 1, $data['following_count'] );
+		$this->assertSame( $local_follow_count, $data['followers_count'] );
+		$this->assertSame( $local_follow_count, $data['following_count'] );
 	}
 
 	public function xtest_accounts_external() {


### PR DESCRIPTION
## Summary
- Adds an EMA-owned fallback for installs without Friends or ActivityPub: local blog users appear as automatically followed by each other through the Mastodon API.
- Populates `/api/v1/accounts/:id/following`, `/api/v1/accounts/:id/followers`, account follow counts, and relationship `following` / `followed_by` flags from current-blog users.
- Leaves Friends and ActivityPub authoritative when either integration is active, with a `mastodon_api_has_following_integration` filter for tests and explicit overrides.

## Validation
- `php -l includes/handler/class-relationship.php`
- `php -l tests/test-accounts-endpoint.php`
- `/home/kirk.at/www/public/wp-content/plugins/enable-mastodon-apps/vendor/bin/phpcs includes/handler/class-relationship.php tests/test-accounts-endpoint.php`
- `git diff --check`

Attempted but not completed:
- `/home/kirk.at/www/public/wp-content/plugins/enable-mastodon-apps/vendor/bin/phpunit --no-coverage tests/test-accounts-endpoint.php` failed because `/tmp/wordpress-tests-lib/includes/functions.php` is missing; the local WordPress test suite has not been installed in this worktree environment.
