### PR TITLE
Add optional Videopack video thumbnail integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### 1.6.1
+- Add optional Videopack integration for generated video thumbnails.
 - Ensure account headers are always serialized ([#308])
 - Allow lower-privilege users to use Mastodon apps ([#307])
 - Keep EMA unread status out of public searches ([#306])

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ You'll then see just the posts on your blog which can already be useful in a mul
 
 Even without the ActivityPub or Friends plugins, Mastodon apps can be used as a local client for your WordPress posts. Favourites (likes) and bookmarks are stored locally so they can be shown again in the app and in the favourites and bookmarks views.
 
+For generated video thumbnails, install [Videopack](https://wordpress.org/plugins/video-embed-thumbnail-generator/) and configure it with FFMPEG. Enable Mastodon Apps will ask Videopack to generate a thumbnail for videos uploaded through Mastodon clients, then use the video's WordPress featured image as the Mastodon media `preview_url`.
+
 When used in combination with the [ActivityPub](https://wordpress.org/plugins/activitypub/) (for being followed via Mastodon) and [Friends](https://wordpress.org/plugins/friends/) (for following people on Mastodon or via RSS) plugins, the Enable Mastodon Apps plugin will show you your feed of people you follow and you can follow and unfollow people from within the app.
 
 Be aware that an app will have a post format associated (see the settings page). The plugin will check for the existance of the Friends plugin to find a resonable default (status with Friends plugin, standard otherwise). When you create a post with your Mastodon app, the post format that you selected for the app will be used.

--- a/includes/class-mastodon-api.php
+++ b/includes/class-mastodon-api.php
@@ -2517,6 +2517,10 @@ class Mastodon_API {
 		}
 
 		$attachment_id = $this->handle_upload( $media['file'] );
+		if ( is_wp_error( $attachment_id ) ) {
+			return $attachment_id;
+		}
+
 		$request->set_param( 'post_id', $attachment_id );
 
 		$description = $request->get_param( 'description' );
@@ -2528,6 +2532,14 @@ class Mastodon_API {
 				)
 			);
 		}
+
+		/**
+		 * Fires after a media attachment was uploaded through the Mastodon API.
+		 *
+		 * @param int             $attachment_id The uploaded attachment ID.
+		 * @param WP_REST_Request $request       The REST request.
+		 */
+		do_action( 'mastodon_api_media_uploaded', $attachment_id, $request );
 
 		return rest_ensure_response( $this->api_get_media( $request ) );
 	}

--- a/includes/handler/class-media-attachment.php
+++ b/includes/handler/class-media-attachment.php
@@ -26,6 +26,45 @@ class Media_Attachment extends Handler {
 		add_filter( 'mastodon_api_media_attachment', array( $this, 'video_attachment' ), 10, 2 );
 		add_filter( 'mastodon_api_status', array( $this, 'add_generic_image_attachments' ), 20 );
 		add_filter( 'mastodon_api_status', array( $this, 'add_generic_video_attachments' ), 20 );
+		add_action( 'mastodon_api_media_uploaded', array( $this, 'schedule_video_thumbnail_generation' ) );
+	}
+
+	/**
+	 * Schedule a Videopack thumbnail for video uploads when that plugin is available.
+	 *
+	 * @param int $attachment_id The uploaded attachment ID.
+	 */
+	public function schedule_video_thumbnail_generation( int $attachment_id ): void {
+		if ( ! \wp_attachment_is( 'video', $attachment_id ) || \has_post_thumbnail( $attachment_id ) ) {
+			return;
+		}
+
+		/**
+		 * Filters the callable used to schedule thumbnail generation for video uploads.
+		 *
+		 * Return null to use the built-in Videopack integration.
+		 *
+		 * @param callable|null $scheduler     Thumbnail scheduler callback.
+		 * @param int           $attachment_id The uploaded attachment ID.
+		 */
+		$scheduler = \apply_filters( 'mastodon_api_video_thumbnail_scheduler', null, $attachment_id );
+		if ( \is_callable( $scheduler ) ) {
+			$scheduler( $attachment_id );
+			return;
+		}
+
+		if ( ! \function_exists( 'kgvid_schedule_attachment_processing' ) ) {
+			return;
+		}
+
+		if ( \function_exists( 'kgvid_get_options' ) ) {
+			$options = \kgvid_get_options();
+			if ( isset( $options['auto_thumb'] ) && 'on' === $options['auto_thumb'] ) {
+				return;
+			}
+		}
+
+		\kgvid_schedule_attachment_processing( $attachment_id, 'thumbs' );
 	}
 
 	/**

--- a/tests/test-video-thumbnail-integration.php
+++ b/tests/test-video-thumbnail-integration.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Tests for video thumbnail integration.
+ *
+ * @package Enable_Mastodon_Apps
+ */
+
+namespace Enable_Mastodon_Apps;
+
+/**
+ * Test video thumbnail scheduling.
+ */
+class VideoThumbnailIntegration_Test extends Mastodon_API_TestCase {
+	public function tearDown(): void {
+		remove_all_filters( 'mastodon_api_video_thumbnail_scheduler' );
+
+		parent::tearDown();
+	}
+
+	public function test_video_upload_schedules_thumbnail_generation() {
+		$attachment_id = $this->create_video_attachment();
+		$scheduled     = array();
+		add_filter(
+			'mastodon_api_video_thumbnail_scheduler',
+			function () use ( &$scheduled ) {
+				return function ( $scheduled_attachment_id ) use ( &$scheduled ) {
+					$scheduled[] = $scheduled_attachment_id;
+				};
+			}
+		);
+		$handler = new Handler\Media_Attachment();
+
+		$handler->schedule_video_thumbnail_generation( $attachment_id );
+
+		$this->assertSame( array( $attachment_id ), $scheduled );
+	}
+
+	public function test_image_upload_does_not_schedule_thumbnail_generation() {
+		$attachment_id = wp_insert_attachment(
+			array(
+				'post_title'     => 'Test image',
+				'post_mime_type' => 'image/jpeg',
+				'post_status'    => 'inherit',
+			),
+			'test-image.jpg'
+		);
+		$scheduled     = false;
+		add_filter(
+			'mastodon_api_video_thumbnail_scheduler',
+			function () use ( &$scheduled ) {
+				$scheduled = true;
+				return null;
+			}
+		);
+		$handler = new Handler\Media_Attachment();
+
+		$handler->schedule_video_thumbnail_generation( $attachment_id );
+
+		$this->assertFalse( $scheduled );
+	}
+
+	/**
+	 * Create a video attachment post.
+	 *
+	 * @return int
+	 */
+	private function create_video_attachment(): int {
+		return wp_insert_attachment(
+			array(
+				'post_title'     => 'Test video',
+				'post_mime_type' => 'video/mp4',
+				'post_status'    => 'inherit',
+			),
+			'test-video.mp4'
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- Fire a `mastodon_api_media_uploaded` action after successful Mastodon media uploads so upload-side integrations can react to new media.
- Add an optional Videopack bridge that asks Videopack to generate thumbnails for newly uploaded videos without making Videopack a required dependency.
- Keep WordPress authoritative for the exposed preview: EMA still reads the video attachment featured image as the Mastodon media `preview_url`.
- Document Videopack as the supported way to generate video thumbnails and add focused coverage for thumbnail scheduling.

## Ownership boundary
EMA owns the Mastodon API mapping and exposes whatever WordPress has stored as the video attachment thumbnail. Videopack remains responsible for FFMPEG thumbnail generation and persistence. The fallback only runs when Videopack functions are available, and `mastodon_api_video_thumbnail_scheduler` lets another integration provide a different scheduler.

## Validation
- `php -l includes/class-mastodon-api.php`
- `php -l includes/handler/class-media-attachment.php`
- `php -l tests/test-video-thumbnail-integration.php`
- `composer check-cs -- includes/class-mastodon-api.php includes/handler/class-media-attachment.php tests/test-video-thumbnail-integration.php`
- `git diff --check`

Could not run PHPUnit locally because `/tmp/wordpress-tests-lib/includes/functions.php` is missing; `composer test -- --filter 'MediaEndpoint_Test|VideoThumbnailIntegration_Test'` fails before tests start with that missing WordPress test library error.

Manual site check on `ella-und-oskar.kirk.at`: found Videopack active with FFMPEG available and confirmed a generated thumbnail can be set as the video attachment featured image/poster metadata. Also queued missing existing video thumbnails through Videopack WP-Cron jobs.