### PR TITLE
Add captions for media descriptions

### DIFF
--- a/includes/handler/class-status.php
+++ b/includes/handler/class-status.php
@@ -478,6 +478,23 @@ class Status extends Handler {
 		return trim( wp_strip_all_tags( $post_content_parts[0] ) );
 	}
 
+	private static function get_attachment_description( int $media_id ): string {
+		return trim( wp_strip_all_tags( get_post_field( 'post_excerpt', $media_id ) ) );
+	}
+
+	private static function render_image_figure( int $media_id, string $image_attributes = '' ): string {
+		$description = self::get_attachment_description( $media_id );
+		$html        = '<figure class="wp-block-image"><img src="' . esc_url( wp_get_attachment_url( $media_id ) ) . '" alt="' . esc_attr( $description ) . '" class="wp-image-' . esc_attr( $media_id ) . '"' . $image_attributes . '/>';
+
+		if ( '' !== $description ) {
+			$html .= '<figcaption class="wp-element-caption">' . esc_html( $description ) . '</figcaption>';
+		}
+
+		$html .= '</figure>';
+
+		return $html;
+	}
+
 	public function prepare_post_data( $post_id, $status_text, $in_reply_to_id, $media_ids, $post_format, $visibility, $scheduled_at ) {
 		$post_data = array();
 
@@ -565,7 +582,7 @@ class Status extends Handler {
 						'sizeSlug' => 'large',
 					);
 					$post_data['post_content'] .= '<!-- wp:image ' . wp_json_encode( $meta_json ) . ' -->' . PHP_EOL;
-					$post_data['post_content'] .= '<figure class="wp-block-image"><img src="' . esc_url( wp_get_attachment_url( $media_id ) ) . '" alt="" class="wp-image-' . esc_attr( $media_id ) . '"/></figure>' . PHP_EOL;
+					$post_data['post_content'] .= self::render_image_figure( (int) $media_id ) . PHP_EOL;
 					$post_data['post_content'] .= '<!-- /wp:image -->' . PHP_EOL;
 				} elseif ( \wp_attachment_is( 'video', $media_id ) ) {
 					$post_data['post_content'] .= PHP_EOL;
@@ -791,7 +808,7 @@ class Status extends Handler {
 				$attachment                       = \wp_get_attachment_metadata( $media_id );
 				$comment_data['comment_content'] .= PHP_EOL;
 				$comment_data['comment_content'] .= '<!-- wp:image -->';
-				$comment_data['comment_content'] .= '<p><img src="' . esc_url( wp_get_attachment_url( $media_id ) ) . '" width="' . esc_attr( $attachment['width'] ) . '"  height="' . esc_attr( $attachment['height'] ) . '" class="size-full" /></p>';
+				$comment_data['comment_content'] .= self::render_image_figure( (int) $media_id, ' width="' . esc_attr( $attachment['width'] ) . '" height="' . esc_attr( $attachment['height'] ) . '"' );
 				$comment_data['comment_content'] .= '<!-- /wp:image -->';
 			}
 		}
@@ -854,7 +871,7 @@ class Status extends Handler {
 				$attachment                       = \wp_get_attachment_metadata( $media_id );
 				$comment_data['comment_content'] .= PHP_EOL;
 				$comment_data['comment_content'] .= '<!-- wp:image -->';
-				$comment_data['comment_content'] .= '<p><img src="' . esc_url( wp_get_attachment_url( $media_id ) ) . '" width="' . esc_attr( $attachment['width'] ) . '"  height="' . esc_attr( $attachment['height'] ) . '" class="size-full" /></p>';
+				$comment_data['comment_content'] .= self::render_image_figure( (int) $media_id, ' width="' . esc_attr( $attachment['width'] ) . '" height="' . esc_attr( $attachment['height'] ) . '"' );
 				$comment_data['comment_content'] .= '<!-- /wp:image -->';
 			}
 		}

--- a/tests/test-statuses-endpoint.php
+++ b/tests/test-statuses-endpoint.php
@@ -437,6 +437,30 @@ class StatusesEndpoint_Test extends Mastodon_API_TestCase {
 		$this->assertStringContainsString( 'wp:image', $p->post_content );
 	}
 
+	public function test_submit_status_adds_media_description_as_alt_text_and_caption() {
+		$this->app->set_post_formats( 'standard' );
+		$this->app->set_create_post_format( 'standard' );
+		$this->app->set_create_post_type( 'post' );
+		$this->app->set_disable_blocks( true );
+
+		wp_update_post(
+			array(
+				'ID'           => $this->friend_attachment_id,
+				'post_excerpt' => 'A fox sitting near the fence',
+			)
+		);
+
+		$request = $this->api_request( 'POST', '/api/v1/statuses' );
+		$request->set_param( 'status', 'caption text' );
+		$request->set_param( 'media_ids', array( (string) $this->friend_attachment_id ) );
+		$response = $this->dispatch_authenticated( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$p = get_post( $response->get_data()->id );
+		$this->assertStringContainsString( 'alt="A fox sitting near the fence"', $p->post_content );
+		$this->assertStringContainsString( '<figcaption class="wp-element-caption">A fox sitting near the fence</figcaption>', $p->post_content );
+	}
+
 	public function test_submit_single_line_standard_without_media() {
 		$this->app->set_post_formats( 'standard' );
 		$this->app->set_create_post_format( 'standard' );


### PR DESCRIPTION
## Summary
- Use the Mastodon media description stored on the attachment excerpt when EMA generates image markup for submitted statuses and comments.
- Write that description into both the image alt attribute and a WordPress image figcaption, so the client-provided accessibility text is also visible as a proper caption.
- Keep WordPress authoritative for rendering the generated core image block; EMA only supplies the attachment URL, alt text, and caption fallback from the existing media description field.

## Validation
- php -l includes/handler/class-status.php
- php -l tests/test-statuses-endpoint.php
- composer check-cs -- includes/handler/class-status.php tests/test-statuses-endpoint.php
- composer test -- --filter StatusesEndpoint_Test could not run locally because /tmp/wordpress-tests-lib/includes/functions.php is missing.