### PR TITLE
Update GitHub Actions for Node 24

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
@@ -32,7 +32,7 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies
-        uses: "ramsey/composer-install@v2"
+        uses: "ramsey/composer-install@v4"
         with:
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")

--- a/.github/workflows/extract-wp-hooks.yml
+++ b/.github/workflows/extract-wp-hooks.yml
@@ -12,5 +12,5 @@ jobs:
     permissions:
       contents: write # Required to push to wiki repository
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: akirk/extract-wp-hooks@1.1.0

--- a/.github/workflows/extract-wp-hooks.yml
+++ b/.github/workflows/extract-wp-hooks.yml
@@ -12,5 +12,5 @@ jobs:
     permissions:
       contents: write # Required to push to wiki repository
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: akirk/extract-wp-hooks@1.1.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
@@ -44,14 +44,14 @@ jobs:
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies - normal
         if: matrix.php != '8.3'
-        uses: "ramsey/composer-install@v2"
+        uses: "ramsey/composer-install@v4"
         with:
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Install Composer dependencies - ignore PHP restrictions
         if: matrix.php == '8.3'
-        uses: "ramsey/composer-install@v2"
+        uses: "ramsey/composer-install@v4"
         with:
           composer-options: --ignore-platform-req=php+
           # Bust the cache at least once a month - output format: YYYY-MM.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,11 +41,11 @@ jobs:
     name: "Tests: PHP ${{ matrix.php }} - PHPUnit: ${{matrix.phpunit}} - WordPress: ${{matrix.wordpress}}"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Checkout ActivityPub plugin
         if: ${{ matrix.php >= 8.1 }}
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           repository: Automattic/wordpress-activitypub
           ref: ${{ matrix.activitypub-ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,11 +41,11 @@ jobs:
     name: "Tests: PHP ${{ matrix.php }} - PHPUnit: ${{matrix.phpunit}} - WordPress: ${{matrix.wordpress}}"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Checkout ActivityPub plugin
         if: ${{ matrix.php >= 8.1 }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           repository: Automattic/wordpress-activitypub
           ref: ${{ matrix.activitypub-ref }}
@@ -84,12 +84,12 @@ jobs:
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies for PHP < 8.2
         if: ${{ matrix.php < 8.2 }}
-        uses: "ramsey/composer-install@v2"
+        uses: "ramsey/composer-install@v4"
 
       # For PHP 8.2 and above, we need to install with ignore platform reqs as not all dependencies allow it yet.
       - name: Install Composer dependencies for PHP >= 8.2
         if: ${{ matrix.php >= 8.2 }}
-        uses: "ramsey/composer-install@v2"
+        uses: "ramsey/composer-install@v4"
         with:
           composer-options: --ignore-platform-reqs
 


### PR DESCRIPTION
Updates CI workflow actions to Node 24-compatible major versions to avoid Node module deprecation warnings.

- actions/checkout to v6
- actions/github-script to v9 where used
- ramsey/composer-install to v4 where used