### PR TITLE
Populate status URL fields

### DIFF
--- a/includes/class-comment-cpt.php
+++ b/includes/class-comment-cpt.php
@@ -263,6 +263,7 @@ class Comment_CPT {
 		$status->created_at = new \DateTime( $comment->comment_date_gmt, new \DateTimeZone( 'UTC' ) );
 		$status->visibility = 'public';
 		$status->uri        = get_comment_link( $comment );
+		$status->url        = $status->uri;
 		$status->content    = $comment->comment_content;
 		$status->account    = $account;
 		if ( $comment->comment_parent ) {

--- a/includes/handler/class-status.php
+++ b/includes/handler/class-status.php
@@ -268,6 +268,7 @@ class Status extends Handler {
 				$status->visibility = 'direct';
 			}
 			$status->uri        = get_the_guid( $post->ID );
+			$status->url        = get_permalink( $post );
 			$status->content    = $post->post_content;
 			if ( ! empty( $post->post_title ) && trim( $post->post_title ) ) {
 				$status->content = '<strong>' . esc_html( $post->post_title ) . '</strong>' . PHP_EOL . $status->content;

--- a/tests/test-statuses-endpoint.php
+++ b/tests/test-statuses-endpoint.php
@@ -37,6 +37,7 @@ class StatusesEndpoint_Test extends Mastodon_API_TestCase {
 
 		$this->assertInstanceOf( '\Enable_Mastodon_Apps\Entity\Account', $data->account );
 		$this->assertIsString( $data->uri );
+		$this->assertEquals( get_permalink( $this->friend_post ), $data->url );
 		$this->assertIsString( $data->content );
 		if ( ! empty( $data->in_reply_to_id ) ) {
 			$this->assertIsInt( $data->in_reply_to_id );


### PR DESCRIPTION
## Summary
- Populate the Mastodon status `url` field for WordPress post-backed statuses with the canonical permalink while leaving `uri` as the GUID identifier.
- Populate comment-backed statuses with their comment link for both `uri` and `url`, preserving the existing comment status ownership in EMA.
- Add endpoint coverage asserting returned post statuses expose the permalink URL expected by Mastodon clients.

## Ownership boundary
WordPress remains authoritative for public permalink generation via `get_permalink()` and comment links via `get_comment_link()`. EMA only maps those canonical WordPress URLs onto the Mastodon API entity field so clients can display or navigate to the local status URL without changing how WordPress owns routing or identifiers.

## Validation
- `php -l includes/handler/class-status.php`
- `php -l includes/class-comment-cpt.php`
- `php -l tests/test-statuses-endpoint.php`
- `composer test` attempted, but local test bootstrap is unavailable: `/tmp/wordpress-tests-lib/includes/functions.php` is missing.
