### PR TITLE
Implement conversation read and delete handlers

### DIFF
--- a/includes/handler/class-conversation.php
+++ b/includes/handler/class-conversation.php
@@ -140,6 +140,103 @@ class Conversation extends Status {
 		return array_values( $accounts );
 	}
 
+	/**
+	 * Mark a conversation and its replies as read.
+	 *
+	 * @param int $id The conversation id, which is the id of the first message.
+	 */
+	public function api_conversation_mark_read( $id ) {
+		$message = $this->get_own_conversation( $id );
+		if ( ! $message ) {
+			return;
+		}
+
+		foreach ( $this->get_conversation_posts( $message ) as $post ) {
+			$read_status = $this->get_read_status( $post->post_status );
+			if ( ! $read_status ) {
+				continue;
+			}
+
+			wp_update_post(
+				array(
+					'ID'          => $post->ID,
+					'post_status' => $read_status,
+				)
+			);
+		}
+	}
+
+	/**
+	 * Delete a conversation and its replies.
+	 *
+	 * @param int $id The conversation id, which is the id of the first message.
+	 */
+	public function delete_conversation( $id ) {
+		$message = $this->get_own_conversation( $id );
+		if ( ! $message ) {
+			return;
+		}
+
+		foreach ( $this->get_conversation_posts( $message ) as $post ) {
+			wp_trash_post( $post->ID );
+		}
+	}
+
+	/**
+	 * Get a conversation that belongs to the current user.
+	 *
+	 * Direct messages are stored in a post type that is specific to the recipient,
+	 * so requiring the post to live in the current user's post type is what limits
+	 * this to their own conversations.
+	 *
+	 * @param int $id The conversation id.
+	 * @return \WP_Post|null The first message of the conversation, or null.
+	 */
+	private function get_own_conversation( $id ) {
+		$message = get_post( $id );
+		if ( ! $message || Mastodon_API::get_dm_cpt() !== $message->post_type ) {
+			return null;
+		}
+
+		return $message;
+	}
+
+	/**
+	 * Get all messages of a conversation, starting with the first one.
+	 *
+	 * @param \WP_Post $message The first message of the conversation.
+	 * @return \WP_Post[] The messages of the conversation.
+	 */
+	private function get_conversation_posts( \WP_Post $message ) {
+		return array_merge(
+			array( $message ),
+			get_children(
+				array(
+					'post_parent' => $message->ID,
+					'post_type'   => Mastodon_API::get_dm_cpt(),
+					'post_status' => $this->get_post_statuses(),
+				)
+			)
+		);
+	}
+
+	/**
+	 * Get the read post status that corresponds to an unread one.
+	 *
+	 * READ_STATUSES and UNREAD_STATUSES hold the same sources in the same order.
+	 *
+	 * @param string $post_status The current post status.
+	 * @return string|null The matching read status, or null if already read.
+	 */
+	private function get_read_status( $post_status ) {
+		$index = array_search( $post_status, self::UNREAD_STATUSES, true );
+		if ( false === $index ) {
+			return null;
+		}
+
+		return self::READ_STATUSES[ $index ];
+	}
+
 	public function conversation_post_type( $post_types, $context_post_id ) {
 		$post_type = get_post_type( $context_post_id );
 		if ( ! $post_type ) {

--- a/tests/test-conversations-endpoint.php
+++ b/tests/test-conversations-endpoint.php
@@ -95,4 +95,81 @@ class ConversationsEndpoint_Test extends Mastodon_API_TestCase {
 		$this->assertEquals( strval( $reply ), $data[0]->last_status->id );
 		$this->assertEquals( strval( $this->administrator ), $data[0]->last_status->account->id );
 	}
+
+	/**
+	 * Create a conversation owned by the given user.
+	 *
+	 * @param int    $user_id     The owner of the direct message post type.
+	 * @param string $post_status The post status for both messages.
+	 * @return array The root and reply post ids.
+	 */
+	private function create_conversation( $user_id, $post_status = 'ema_unread' ) {
+		$root = wp_insert_post(
+			array(
+				'post_author'  => 0,
+				'post_content' => 'First message',
+				'post_status'  => $post_status,
+				'post_type'    => Mastodon_API::get_dm_cpt( $user_id ),
+				'post_date'    => '2026-06-10 10:55:05',
+			)
+		);
+
+		$reply = wp_insert_post(
+			array(
+				'post_author'  => 0,
+				'post_content' => 'Second message',
+				'post_parent'  => $root,
+				'post_status'  => $post_status,
+				'post_type'    => Mastodon_API::get_dm_cpt( $user_id ),
+				'post_date'    => '2026-06-10 11:24:50',
+			)
+		);
+
+		return array( $root, $reply );
+	}
+
+	public function test_mark_conversation_read() {
+		list( $root, $reply ) = $this->create_conversation( $this->administrator );
+
+		$request = $this->api_request( 'POST', '/api/v1/conversations/' . $root . '/read' );
+		$response = $this->dispatch_authenticated( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'ema_read', get_post_status( $root ) );
+		$this->assertEquals( 'ema_read', get_post_status( $reply ) );
+		$this->assertFalse( $response->get_data()->unread );
+	}
+
+	public function test_mark_conversation_read_leaves_other_users_conversation_alone() {
+		$other_user = $this->factory->user->create( array( 'role' => 'author' ) );
+		list( $root, $reply ) = $this->create_conversation( $other_user );
+
+		$request = $this->api_request( 'POST', '/api/v1/conversations/' . $root . '/read' );
+		$this->dispatch_authenticated( $request );
+
+		$this->assertEquals( 'ema_unread', get_post_status( $root ) );
+		$this->assertEquals( 'ema_unread', get_post_status( $reply ) );
+	}
+
+	public function test_delete_conversation() {
+		list( $root, $reply ) = $this->create_conversation( $this->administrator );
+
+		$request = $this->api_request( 'DELETE', '/api/v1/conversations/' . $root );
+		$response = $this->dispatch_authenticated( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'trash', get_post_status( $root ) );
+		$this->assertEquals( 'trash', get_post_status( $reply ) );
+	}
+
+	public function test_delete_conversation_leaves_other_users_conversation_alone() {
+		$other_user = $this->factory->user->create( array( 'role' => 'author' ) );
+		list( $root, $reply ) = $this->create_conversation( $other_user );
+
+		$request = $this->api_request( 'DELETE', '/api/v1/conversations/' . $root );
+		$this->dispatch_authenticated( $request );
+
+		$this->assertEquals( 'ema_unread', get_post_status( $root ) );
+		$this->assertEquals( 'ema_unread', get_post_status( $reply ) );
+	}
 }


### PR DESCRIPTION
`Conversation::register_hooks()` has registered `api_conversation_mark_read()` and `delete_conversation()` as callbacks since #253, but neither method was ever written. Since there is no `__call()` fallback, hitting either endpoint dies with a call to an undefined method:

- `POST /api/v1/conversations/{id}/read`
- `DELETE /api/v1/conversations/{id}`

Nothing else in the plugin transitioned a DM out of `ema_unread` either, so once a conversation was unread it stayed unread forever.

This implements both handlers.

Direct messages live in a post type that is specific to the recipient (`ema-dm-<user_id>`), so requiring the post to be in the current user's DM post type is what keeps a request to its own conversations — a conversation id belonging to somebody else simply does not match and is left alone.

Marking read walks the first message and its replies and maps each unread status to its read counterpart (`ema_unread` → `ema_read`, `friends_unread` → `friends_read`). Deleting trashes the same set.

Four tests cover both endpoints, each with a counterpart asserting another user's conversation is untouched.