### PR TITLE
Search by year, month or day

### DIFF
--- a/includes/handler/class-media-attachment.php
+++ b/includes/handler/class-media-attachment.php
@@ -83,13 +83,32 @@ class Media_Attachment extends Handler {
 		if ( ! $thumb ) {
 			return $data;
 		}
+		$url  = \wp_get_attachment_url( $attachment_id );
 		$meta = \wp_get_attachment_metadata( $attachment_id );
+		if ( ! is_array( $meta ) || empty( $meta['width'] ) || empty( $meta['height'] ) ) {
+			// The metadata was never generated, e.g. for an import; fall back to the file itself.
+			$meta = array(
+				'width'  => 0,
+				'height' => 0,
+			);
+			$file = \get_attached_file( $attachment_id );
+			if ( $file && file_exists( $file ) ) {
+				$size = \wp_getimagesize( $file );
+				if ( $size ) {
+					$meta['width']  = $size[0];
+					$meta['height'] = $size[1];
+				}
+			}
+		}
+		$thumb = false;
 		if ( isset( $meta['sizes']['medium_large'] ) ) {
 			$thumb = \wp_get_attachment_image_src( $attachment_id, 'medium_large' );
 		} elseif ( isset( $meta['sizes']['medium'] ) ) {
 			$thumb = \wp_get_attachment_image_src( $attachment_id, 'medium' );
 		}
-		$url = \wp_get_attachment_url( $attachment_id );
+		if ( ! $thumb ) {
+			$thumb = array( $url, $meta['width'], $meta['height'] );
+		}
 
 		$media_attachment              = new Media_Attachment_Entity();
 		$media_attachment->id          = strval( $attachment_id );
@@ -102,13 +121,13 @@ class Media_Attachment extends Handler {
 				'width'  => $meta['width'],
 				'height' => $meta['height'],
 				'size'   => $meta['width'] . 'x' . $meta['height'],
-				'aspect' => $meta['width'] / $meta['height'],
+				'aspect' => $meta['height'] ? $meta['width'] / $meta['height'] : 0,
 			),
 			'small'    => array(
 				'width'  => $thumb[1],
 				'height' => $thumb[2],
 				'size'   => $thumb[1] . 'x' . $thumb[2],
-				'aspect' => $thumb[1] / $thumb[2],
+				'aspect' => $thumb[2] ? $thumb[1] / $thumb[2] : 0,
 			),
 		);
 
@@ -161,13 +180,13 @@ class Media_Attachment extends Handler {
 				'width'  => $meta['width'],
 				'height' => $meta['height'],
 				'size'   => $meta['width'] . 'x' . $meta['height'],
-				'aspect' => $meta['width'] / $meta['height'],
+				'aspect' => $meta['height'] ? $meta['width'] / $meta['height'] : 0,
 			),
 			'small'    => array(
 				'width'  => $thumb[1],
 				'height' => $thumb[2],
 				'size'   => $thumb[1] . 'x' . $thumb[2],
-				'aspect' => $thumb[1] / $thumb[2],
+				'aspect' => $thumb[2] ? $thumb[1] / $thumb[2] : 0,
 			),
 		);
 

--- a/includes/handler/class-search.php
+++ b/includes/handler/class-search.php
@@ -90,7 +90,12 @@ class Search extends Handler {
 					// TODO allow lookup by URL.
 				}
 			} elseif ( is_user_logged_in() ) {
-				$args['s']              = $q;
+				$date_args = self::get_date_query_args( $q );
+				if ( $date_args ) {
+					$args = array_merge( $args, $date_args );
+				} else {
+					$args['s'] = $q;
+				}
 				$args['offset']         = $request->get_param( 'offset' );
 				$args['posts_per_page'] = $request->get_param( 'limit' );
 				$ret['statuses']        = array_merge( $ret['statuses'], $this->get_posts( $args )->get_data() );
@@ -132,6 +137,44 @@ class Search extends Handler {
 		return $ret;
 	}
 
+
+	/**
+	 * Turn a date-like query into WP_Query date arguments.
+	 *
+	 * Searching for "2016", "2016-05" or "2016-05-17" returns the posts from that
+	 * year, month or day instead of the posts mentioning that string.
+	 *
+	 * @param string $q The search query.
+	 *
+	 * @return array WP_Query arguments, or an empty array if the query is not a date.
+	 */
+	public static function get_date_query_args( $q ) {
+		if ( ! preg_match( '/^(\d{4})(?:-(\d{1,2})(?:-(\d{1,2}))?)?$/', trim( $q ), $m ) ) {
+			return array();
+		}
+		$year  = intval( $m[1] );
+		$month = isset( $m[2] ) ? intval( $m[2] ) : 0;
+		$day   = isset( $m[3] ) ? intval( $m[3] ) : 0;
+
+		if ( $year < 1970 || $year > intval( gmdate( 'Y' ) ) + 1 ) {
+			return array();
+		}
+		if ( $month && ( $month < 1 || $month > 12 ) ) {
+			return array();
+		}
+		if ( $day && ! checkdate( $month, $day, $year ) ) {
+			return array();
+		}
+
+		$date_args = array( 'year' => $year );
+		if ( $month ) {
+			$date_args['monthnum'] = $month;
+		}
+		if ( $day ) {
+			$date_args['day'] = $day;
+		}
+		return $date_args;
+	}
 
 	public function api_search_status_ensure_numeric_id( $ret ) {
 		if ( ! empty( $ret['statuses'] ) && is_array( $ret['statuses'] ) ) {

--- a/tests/test-search-endpoint.php
+++ b/tests/test-search-endpoint.php
@@ -290,6 +290,9 @@ class Test_Search_Endpoint extends Mastodon_API_TestCase {
 		);
 		set_post_format( $mentions_2016, 'status' );
 
+		// Statuses are only searched for logged-in users; in production the token resolves the user.
+		wp_set_current_user( $this->administrator );
+
 		$request = $this->api_request( 'GET', '/api/v2/search' );
 		$request->set_param( 'q', '2016' );
 		$request->set_param( 'type', 'statuses' );

--- a/tests/test-search-endpoint.php
+++ b/tests/test-search-endpoint.php
@@ -240,4 +240,69 @@ class Test_Search_Endpoint extends Mastodon_API_TestCase {
 		$reply_to_id = apply_filters( 'mastodon_api_in_reply_to_id', $processed_status->id );
 		$this->assertEquals( $original_status_url, $reply_to_id, 'Numeric ID from search should be correctly reversed for reply' );
 	}
+
+	public function test_date_query_args() {
+		$this->assertSame( array( 'year' => 2016 ), Handler\Search::get_date_query_args( '2016' ) );
+		$this->assertSame(
+			array(
+				'year'     => 2016,
+				'monthnum' => 5,
+			),
+			Handler\Search::get_date_query_args( '2016-05' )
+		);
+		$this->assertSame(
+			array(
+				'year'     => 2016,
+				'monthnum' => 5,
+				'day'      => 17,
+			),
+			Handler\Search::get_date_query_args( '2016-5-17' )
+		);
+		$this->assertSame( array(), Handler\Search::get_date_query_args( '2016-13' ) );
+		$this->assertSame( array(), Handler\Search::get_date_query_args( '2016-02-30' ) );
+		$this->assertSame( array(), Handler\Search::get_date_query_args( '1234' ) );
+		$this->assertSame( array(), Handler\Search::get_date_query_args( '20160' ) );
+		$this->assertSame( array(), Handler\Search::get_date_query_args( 'Hello 2016' ) );
+	}
+
+	/**
+	 * Searching for a year returns the posts from that year rather than the posts mentioning it.
+	 */
+	public function test_search_by_year() {
+		$in_2016 = wp_insert_post(
+			array(
+				'post_author'  => $this->administrator,
+				'post_content' => 'Nothing about the year here',
+				'post_status'  => 'publish',
+				'post_type'    => 'post',
+				'post_date'    => '2016-06-01 12:00:00',
+			)
+		);
+		$mentions_2016 = wp_insert_post(
+			array(
+				'post_author'  => $this->administrator,
+				'post_content' => 'Remembering 2016',
+				'post_status'  => 'publish',
+				'post_type'    => 'post',
+				'post_date'    => '2017-06-01 12:00:00',
+			)
+		);
+
+		$request = $this->api_request( 'GET', '/api/v2/search' );
+		$request->set_param( 'q', '2016' );
+		$request->set_param( 'type', 'statuses' );
+		$response = $this->dispatch_authenticated( $request );
+		$data     = json_decode( wp_json_encode( $response->get_data() ), true );
+
+		$ids = wp_list_pluck( $data['statuses'], 'id' );
+		$this->assertContains( strval( $in_2016 ), $ids );
+		$this->assertNotContains( strval( $mentions_2016 ), $ids );
+
+		$request = $this->api_request( 'GET', '/api/v2/search' );
+		$request->set_param( 'q', '2016-07' );
+		$request->set_param( 'type', 'statuses' );
+		$response = $this->dispatch_authenticated( $request );
+		$data     = json_decode( wp_json_encode( $response->get_data() ), true );
+		$this->assertEmpty( $data['statuses'] );
+	}
 }

--- a/tests/test-search-endpoint.php
+++ b/tests/test-search-endpoint.php
@@ -278,6 +278,7 @@ class Test_Search_Endpoint extends Mastodon_API_TestCase {
 				'post_date'    => '2016-06-01 12:00:00',
 			)
 		);
+		set_post_format( $in_2016, 'status' );
 		$mentions_2016 = wp_insert_post(
 			array(
 				'post_author'  => $this->administrator,
@@ -287,6 +288,7 @@ class Test_Search_Endpoint extends Mastodon_API_TestCase {
 				'post_date'    => '2017-06-01 12:00:00',
 			)
 		);
+		set_post_format( $mentions_2016, 'status' );
 
 		$request = $this->api_request( 'GET', '/api/v2/search' );
 		$request->set_param( 'q', '2016' );


### PR DESCRIPTION
## Intent

In a Mastodon client, searching for a year like `2016` is a natural way to ask for "everything from 2016". Until now the search endpoint handed every query to WordPress as a text search (`s=2016`), so it only returned posts that literally mention the year. This makes a query that consists of just a date (`YYYY`, `YYYY-MM` or `YYYY-MM-DD`) a date query instead.

## Ownership boundary

- EMA only decides *which* `WP_Query` arguments to build: a valid date becomes `year` / `monthnum` / `day`; anything else keeps going through `s`. Ordering, pagination (`limit`/`offset`), post types and the `mastodon_api_timelines_args` / `mastodon_api_get_posts_query_args` filters are unchanged, so integrations that reshape the query keep working.
- WordPress core remains authoritative for date matching (`WP_Query`'s date vars). Invalid dates (`2016-13`, `2016-02-30`, out-of-range years) are not treated as dates and fall back to the existing text search rather than erroring.
- Only the statuses branch is affected; accounts and hashtags are searched as before.

## Fallback for attachments without metadata

While verifying on a real site, the `2016` search kept returning 500 because one matching post had an image attachment whose metadata had never been generated (an import), and `Media_Attachment::image_attachment()` divided by the missing height. That attachment broke *every* timeline or search that included the post, not just this feature, so the second commit reads the dimensions from the file when the metadata is missing and falls back to the original URL as the preview, with the aspect ratio guarded against zero. WordPress' `wp_get_attachment_metadata()` stays the primary source; the file is only consulted when it has nothing.

## Validation

- `php -l` and `phpcs --standard=phpcs.xml.dist` on the changed files: clean.
- Against a live site with 138 posts in 2016 (logged-in user, `rest_do_request` on `/api/v2/search?type=statuses`):
  - `q=2016` → 200, 40 statuses (the limit), all dated 2016 (before: 500).
  - `q=2016-08` → 200, 12 statuses, all from August 2016.
  - `q=2016-13`, `q=2016-02-30` → 200, empty (text search fallback).
  - a plain word → unchanged text search results.
- New PHPUnit tests in `tests/test-search-endpoint.php` for the date parser and for the endpoint (a post *dated* 2016 is returned, a 2017 post *mentioning* 2016 is not). CI: PHPUnit passes on PHP 7.4–8.4 (128 tests), lint and CS pass. (Two fixture fixes were needed first: the test app filters by the `status` post format, and the statuses branch only runs for a logged-in user, which the token resolves in production but not in the test bootstrap.)
