### PR TITLE
Only validate Authorization headers on Mastodon API requests

### DIFF
--- a/includes/class-mastodon-api.php
+++ b/includes/class-mastodon-api.php
@@ -58,6 +58,98 @@ class Mastodon_API {
 	}
 
 	/**
+	 * Get the REST route the current request is aimed at.
+	 *
+	 * This deliberately does not rely on the parsed query vars alone:
+	 * `determine_current_user` can run before `parse_request` has filled them in,
+	 * and the answer needs to be the same in both cases.
+	 *
+	 * @return string The route without a leading slash, or an empty string if this is not a REST request.
+	 */
+	public static function get_current_rest_route() {
+		if ( ! empty( $GLOBALS['wp']->query_vars['rest_route'] ) ) {
+			return ltrim( $GLOBALS['wp']->query_vars['rest_route'], '/' );
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( ! empty( $_GET['rest_route'] ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return ltrim( sanitize_text_field( wp_unslash( $_GET['rest_route'] ) ), '/' );
+		}
+
+		if ( empty( $_SERVER['REQUEST_URI'] ) ) {
+			return '';
+		}
+
+		$rest_path = wp_parse_url( get_rest_url( null, '/' ), PHP_URL_PATH );
+		if ( ! $rest_path || false === strpos( $rest_path, '/' . rest_get_url_prefix() . '/' ) ) {
+			// Plain permalinks, in which case only the rest_route parameter above applies.
+			return '';
+		}
+
+		$path = wp_parse_url( sanitize_url( wp_unslash( $_SERVER['REQUEST_URI'] ) ), PHP_URL_PATH );
+		if ( ! $path || 0 !== strpos( $path, $rest_path ) ) {
+			return '';
+		}
+
+		return ltrim( substr( $path, strlen( $rest_path ) ), '/' );
+	}
+
+	/**
+	 * Determine whether the current request is aimed at this plugin.
+	 *
+	 * Used to keep the plugin from acting on requests it does not own, most
+	 * importantly to avoid validating Authorization headers that belong to
+	 * WordPress core or to another plugin.
+	 *
+	 * @return bool Whether the request is a Mastodon API request.
+	 */
+	public static function is_mastodon_api_request() {
+		$route = self::get_current_rest_route();
+		if ( $route ) {
+			$is_api_request = 0 === strpos( $route, self::PREFIX );
+		} else {
+			// The short paths (/api/v1/...) are rewritten to REST routes, but the
+			// rewrite has not necessarily been applied yet at this point.
+			$is_api_request = (bool) preg_match( '#^api/(v[0-9]+|nodeinfo)(/|$)#', self::get_current_home_path() );
+		}
+
+		/**
+		 * Filter whether the current request is a Mastodon API request.
+		 *
+		 * Requests that are not are left alone: in particular, their Authorization
+		 * header is not validated against the plugin's OAuth tokens.
+		 *
+		 * @param bool $is_api_request Whether the request is a Mastodon API request.
+		 * @return bool Whether the request is a Mastodon API request.
+		 */
+		return apply_filters( 'mastodon_api_is_api_request', $is_api_request );
+	}
+
+	/**
+	 * Get the path of the current request, relative to the site home.
+	 *
+	 * @return string The path without a leading slash.
+	 */
+	private static function get_current_home_path() {
+		if ( empty( $_SERVER['REQUEST_URI'] ) ) {
+			return '';
+		}
+
+		$path = wp_parse_url( sanitize_url( wp_unslash( $_SERVER['REQUEST_URI'] ) ), PHP_URL_PATH );
+		if ( ! $path ) {
+			return '';
+		}
+
+		$home_path = wp_parse_url( home_url( '/' ), PHP_URL_PATH );
+		if ( $home_path && 0 === strpos( $path, $home_path ) ) {
+			$path = substr( $path, strlen( $home_path ) );
+		}
+
+		return ltrim( $path, '/' );
+	}
+
+	/**
 	 * Constructor
 	 */
 	public function __construct() {
@@ -2269,12 +2361,8 @@ class Mastodon_API {
 	 * @return WP_Error WP_Error object.
 	 */
 	public function rest_authentication_errors( $errors ) {
-		if ( empty( $GLOBALS['wp']->query_vars['rest_route'] ) ) {
-			return $errors;
-		}
-
-		$route = ltrim( $GLOBALS['wp']->query_vars['rest_route'], '/' );
-		if ( 0 !== strpos( $route, self::PREFIX ) ) {
+		$route = self::get_current_rest_route();
+		if ( ! $route || 0 !== strpos( $route, self::PREFIX ) ) {
 			return $errors;
 		}
 

--- a/includes/class-mastodon-oauth.php
+++ b/includes/class-mastodon-oauth.php
@@ -180,7 +180,27 @@ class Mastodon_OAuth {
 		return $this->server->getAccessTokenData( $request, $response );
 	}
 
+	/**
+	 * Authenticate a request through an OAuth access token.
+	 *
+	 * `determine_current_user` runs for every WordPress request, so this only
+	 * looks at the Authorization header when the request is aimed at this
+	 * plugin. Otherwise a Bearer token that belongs to WordPress core or to
+	 * another plugin would be run through this plugin's token validation.
+	 *
+	 * @param int|false $user_id The user id determined so far.
+	 * @return int|false The user id.
+	 */
 	public function authenticate( $user_id ) {
+		if ( ! Mastodon_API::is_mastodon_api_request() ) {
+			return $user_id;
+		}
+
+		if ( Mastodon_API::PREFIX . '/' . WP_Admin\Health_Check::AUTH_HEADER_ROUTE === Mastodon_API::get_current_rest_route() ) {
+			// The Site Health diagnostic sends a synthetic Authorization header that is not meant to authenticate.
+			return $user_id;
+		}
+
 		$token = $this->get_token();
 		if ( is_array( $token ) && isset( $token['user_id'] ) ) {
 			return intval( $token['user_id'] );

--- a/includes/wp-admin/class-health-check.php
+++ b/includes/wp-admin/class-health-check.php
@@ -16,8 +16,8 @@ use WP_REST_Request;
  */
 class Health_Check {
 	const AUTH_HEADER_ROUTE       = 'diagnostics/authorization-header';
-	const AUTH_HEADER_TRANSIENT   = 'ema_health_check_auth_header_';
 	const AUTH_HEADER_TEST_VALUE  = 'Bearer ema-health-check';
+	const CHECK_LIFETIME_SECONDS  = 300;
 	const REQUEST_TIMEOUT_SECONDS = 10;
 
 	/**
@@ -58,8 +58,7 @@ class Health_Check {
 	 * @return true|WP_Error True if allowed, WP_Error otherwise.
 	 */
 	public static function diagnostic_permission( WP_REST_Request $request ) {
-		$check = $request->get_param( 'check' );
-		if ( $check && get_transient( self::AUTH_HEADER_TRANSIENT . $check ) ) {
+		if ( self::verify_check_token( $request->get_param( 'check' ) ) ) {
 			return true;
 		}
 
@@ -68,6 +67,46 @@ class Health_Check {
 			__( 'The diagnostic token is invalid or expired.', 'enable-mastodon-apps' ),
 			array( 'status' => 403 )
 		);
+	}
+
+	/**
+	 * Create a short-lived token for the diagnostic route.
+	 *
+	 * This is signed rather than stored so that the diagnostic does not depend on
+	 * a working object cache or on the loopback request landing in the same
+	 * transient scope: a failure to store the token would otherwise look like a
+	 * failure to forward the Authorization header.
+	 *
+	 * @return string The token.
+	 */
+	private static function create_check_token() {
+		$payload = ( time() + self::CHECK_LIFETIME_SECONDS ) . ':' . wp_generate_password( 12, false, false );
+
+		return $payload . ':' . hash_hmac( 'sha256', $payload, wp_salt( 'nonce' ) );
+	}
+
+	/**
+	 * Verify a token created by create_check_token().
+	 *
+	 * @param string $token The token.
+	 * @return bool Whether the token is valid and unexpired.
+	 */
+	private static function verify_check_token( $token ) {
+		if ( ! is_string( $token ) ) {
+			return false;
+		}
+
+		$parts = explode( ':', $token );
+		if ( 3 !== count( $parts ) ) {
+			return false;
+		}
+
+		list( $expires, $nonce, $signature ) = $parts;
+		if ( ! ctype_digit( $expires ) || intval( $expires ) < time() ) {
+			return false;
+		}
+
+		return hash_equals( hash_hmac( 'sha256', $expires . ':' . $nonce, wp_salt( 'nonce' ) ), $signature );
 	}
 
 	/**
@@ -308,6 +347,22 @@ class Health_Check {
 			return $result;
 		}
 
+		if ( 'authorization_header_missing' !== $check->get_error_code() ) {
+			// The diagnostic never got a usable answer, so it cannot say anything about the Authorization header.
+			$result['status']         = 'recommended';
+			$result['label']          = __( 'The Authorization header test could not be completed', 'enable-mastodon-apps' );
+			$result['badge']['color'] = 'orange';
+			$result['description']    = self::paragraphs(
+				__( 'The diagnostic request did not reach the diagnostic route, so this test could not determine whether Authorization headers are forwarded. This is not in itself a sign that the header is being stripped.', 'enable-mastodon-apps' ),
+				$check->get_error_message()
+			);
+			$result['actions']        = self::paragraphs(
+				__( 'Check whether WordPress can make loopback requests to itself, and whether a security plugin, firewall, or host-level rule blocks the plugin REST API routes.', 'enable-mastodon-apps' )
+			);
+
+			return $result;
+		}
+
 		$result['status']         = 'critical';
 		$result['label']          = __( 'Authorization headers do not reach WordPress', 'enable-mastodon-apps' );
 		$result['badge']['color'] = 'red';
@@ -512,12 +567,9 @@ class Health_Check {
 	 * @return true|WP_Error True on success, WP_Error otherwise.
 	 */
 	private static function is_authorization_header_forwarded() {
-		$check = wp_generate_password( 32, false, false );
-		set_transient( self::AUTH_HEADER_TRANSIENT . $check, 1, 5 * MINUTE_IN_SECONDS );
-
 		$url = add_query_arg(
 			'check',
-			rawurlencode( $check ),
+			rawurlencode( self::create_check_token() ),
 			self::get_rest_route_url( self::AUTH_HEADER_ROUTE )
 		);
 
@@ -532,8 +584,6 @@ class Health_Check {
 			)
 		);
 
-		delete_transient( self::AUTH_HEADER_TRANSIENT . $check );
-
 		if ( is_wp_error( $response ) ) {
 			return new WP_Error(
 				'authorization_header_request_failed',
@@ -545,23 +595,41 @@ class Health_Check {
 			);
 		}
 
+		$body = json_decode( wp_remote_retrieve_body( $response ), true );
+
 		$code = wp_remote_retrieve_response_code( $response );
 		if ( 200 !== $code ) {
+			$detail = '';
+			if ( is_array( $body ) && ! empty( $body['code'] ) ) {
+				$detail = sprintf(
+					// translators: %s: an error code returned by the REST API.
+					__( ' The response reported the error code %s.', 'enable-mastodon-apps' ),
+					'<code>' . esc_html( $body['code'] ) . '</code>'
+				);
+			}
+
 			return new WP_Error(
 				'authorization_header_unexpected_status',
 				sprintf(
-					// translators: %d: HTTP status code.
-					__( 'The Authorization header diagnostic route returned HTTP %d.', 'enable-mastodon-apps' ),
-					$code
+					// translators: %1$d: HTTP status code, %2$s: an optional sentence with further detail.
+					__( 'The Authorization header diagnostic route returned HTTP %1$d instead of 200.%2$s', 'enable-mastodon-apps' ),
+					$code,
+					$detail
 				)
 			);
 		}
 
-		$body = json_decode( wp_remote_retrieve_body( $response ), true );
 		if ( ! is_array( $body ) ) {
 			return new WP_Error(
 				'authorization_header_invalid_response',
 				__( 'The Authorization header diagnostic route did not return JSON.', 'enable-mastodon-apps' )
+			);
+		}
+
+		if ( ! array_key_exists( 'authorization_header_present', $body ) ) {
+			return new WP_Error(
+				'authorization_header_invalid_response',
+				__( 'The Authorization header diagnostic route returned JSON from somewhere other than the diagnostic itself.', 'enable-mastodon-apps' )
 			);
 		}
 

--- a/tests/test-health-check.php
+++ b/tests/test-health-check.php
@@ -14,6 +14,12 @@ use Enable_Mastodon_Apps\WP_Admin\Health_Check;
  */
 class Health_Check_Test extends \WP_UnitTestCase {
 	private $http_callback;
+	private $http_requests = array();
+
+	public function set_up() {
+		parent::set_up();
+		$this->http_requests = array();
+	}
 
 	public function tear_down() {
 		if ( $this->http_callback ) {
@@ -157,6 +163,90 @@ class Health_Check_Test extends \WP_UnitTestCase {
 		$this->assertStringContainsString( 'HTTP_AUTHORIZATION', $result['actions'] );
 	}
 
+	public function test_authorization_header_check_recommended_when_route_is_unreachable() {
+		$this->mock_http_response(
+			$this->http_response(
+				403,
+				array(
+					'code'    => 'rest_forbidden',
+					'message' => 'Sorry, you are not allowed to do that.',
+				),
+				array( 'content-type' => 'application/json' )
+			)
+		);
+
+		$result = Health_Check::test_authorization_header();
+
+		// A test that could not run must not be reported as a stripped Authorization header.
+		$this->assertSame( 'recommended', $result['status'] );
+		$this->assertStringContainsString( 'HTTP 403', $result['description'] );
+		$this->assertStringContainsString( 'rest_forbidden', $result['description'] );
+		$this->assertStringNotContainsString( 'was missing', $result['description'] );
+		$this->assertStringNotContainsString( 'HTTP_AUTHORIZATION', $result['actions'] );
+	}
+
+	public function test_authorization_header_check_recommended_when_response_is_not_the_diagnostic() {
+		$this->mock_http_response(
+			$this->http_response(
+				200,
+				array( 'hello' => 'world' ),
+				array( 'content-type' => 'application/json' )
+			)
+		);
+
+		$result = Health_Check::test_authorization_header();
+
+		$this->assertSame( 'recommended', $result['status'] );
+		$this->assertStringNotContainsString( 'HTTP_AUTHORIZATION', $result['actions'] );
+	}
+
+	public function test_authorization_header_check_sends_an_authorization_header() {
+		$this->mock_http_response(
+			$this->http_response(
+				200,
+				array( 'authorization_header_present' => true ),
+				array( 'content-type' => 'application/json' )
+			)
+		);
+
+		Health_Check::test_authorization_header();
+
+		$this->assertCount( 1, $this->http_requests );
+		$this->assertSame( Health_Check::AUTH_HEADER_TEST_VALUE, $this->http_requests[0]['args']['headers']['Authorization'] );
+	}
+
+	public function test_diagnostic_permission_accepts_the_token_the_test_sends() {
+		$this->mock_http_response(
+			$this->http_response(
+				200,
+				array( 'authorization_header_present' => true ),
+				array( 'content-type' => 'application/json' )
+			)
+		);
+
+		Health_Check::test_authorization_header();
+
+		$this->assertCount( 1, $this->http_requests );
+		$query = array();
+		parse_str( (string) wp_parse_url( $this->http_requests[0]['url'], PHP_URL_QUERY ), $query );
+		$this->assertArrayHasKey( 'check', $query );
+
+		$this->assertTrue( Health_Check::diagnostic_permission( $this->diagnostic_request( $query['check'] ) ) );
+	}
+
+	public function test_diagnostic_permission_rejects_an_invalid_token() {
+		$this->assertWPError( Health_Check::diagnostic_permission( $this->diagnostic_request( '' ) ) );
+		$this->assertWPError( Health_Check::diagnostic_permission( $this->diagnostic_request( 'not-a-token' ) ) );
+		$this->assertWPError( Health_Check::diagnostic_permission( $this->diagnostic_request( ( time() + 300 ) . ':nonce:signature' ) ) );
+	}
+
+	private function diagnostic_request( $check ) {
+		$request = new \WP_REST_Request( 'GET', '/' . Mastodon_API::PREFIX . '/' . Health_Check::AUTH_HEADER_ROUTE );
+		$request->set_param( 'check', $check );
+
+		return $request;
+	}
+
 	public function test_cors_preflight_check_good() {
 		$this->mock_http_response(
 			$this->http_response(
@@ -197,11 +287,15 @@ class Health_Check_Test extends \WP_UnitTestCase {
 			remove_filter( 'pre_http_request', $this->http_callback, 5 );
 		}
 
-		$this->http_callback = function () use ( $response ) {
+		$this->http_callback = function ( $preempt, $args, $url ) use ( $response ) {
+			$this->http_requests[] = array(
+				'url'  => $url,
+				'args' => $args,
+			);
 			return $response;
 		};
 
-		add_filter( 'pre_http_request', $this->http_callback, 5 );
+		add_filter( 'pre_http_request', $this->http_callback, 5, 3 );
 	}
 
 	private function http_response( $code, $body, $headers = array() ) {

--- a/tests/test-request-scope.php
+++ b/tests/test-request-scope.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Class Request_Scope_Test
+ *
+ * @package Enable_Mastodon_Apps
+ */
+
+namespace Enable_Mastodon_Apps;
+
+/**
+ * Tests that the plugin only acts on requests that are aimed at it.
+ */
+class Request_Scope_Test extends \WP_UnitTestCase {
+	private $original_request_uri;
+	private $original_authorization;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->original_request_uri    = isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : null;
+		$this->original_authorization  = isset( $_SERVER['HTTP_AUTHORIZATION'] ) ? $_SERVER['HTTP_AUTHORIZATION'] : null;
+
+		$this->reset_request();
+		$this->set_permalink_structure( '/%postname%/' );
+	}
+
+	public function tear_down() {
+		$this->reset_request();
+		$this->set_permalink_structure( '' );
+
+		if ( null === $this->original_request_uri ) {
+			unset( $_SERVER['REQUEST_URI'] );
+		} else {
+			$_SERVER['REQUEST_URI'] = $this->original_request_uri;
+		}
+
+		if ( null === $this->original_authorization ) {
+			unset( $_SERVER['HTTP_AUTHORIZATION'] );
+		} else {
+			$_SERVER['HTTP_AUTHORIZATION'] = $this->original_authorization;
+		}
+
+		parent::tear_down();
+	}
+
+	private function reset_request() {
+		unset( $_GET['rest_route'] );
+		unset( $_SERVER['HTTP_AUTHORIZATION'] );
+		if ( isset( $GLOBALS['wp'] ) ) {
+			unset( $GLOBALS['wp']->query_vars['rest_route'] );
+		}
+		$_SERVER['REQUEST_URI'] = '/';
+	}
+
+	/**
+	 * Test which request URIs are recognized as plugin requests.
+	 *
+	 * @dataProvider data_request_uris
+	 *
+	 * @param string $request_uri    The request URI.
+	 * @param bool   $is_api_request Whether it should be treated as a plugin request.
+	 */
+	public function test_is_mastodon_api_request_by_uri( $request_uri, $is_api_request ) {
+		$_SERVER['REQUEST_URI'] = $request_uri;
+
+		$this->assertSame( $is_api_request, Mastodon_API::is_mastodon_api_request(), $request_uri );
+	}
+
+	public function data_request_uris() {
+		return array(
+			'plugin rest route'        => array( '/wp-json/enable-mastodon-apps/api/v1/instance', true ),
+			'plugin short path'        => array( '/api/v1/timelines/home', true ),
+			'plugin short path v2'     => array( '/api/v2/search?q=test', true ),
+			'plugin nodeinfo path'     => array( '/api/nodeinfo/2.0', true ),
+			'core rest route'          => array( '/wp-json/wp/v2/posts', false ),
+			'other plugin rest route'  => array( '/wp-json/activitypub/1.0/actors/1', false ),
+			'admin'                    => array( '/wp-admin/index.php', false ),
+			'front page'               => array( '/', false ),
+			'a post'                   => array( '/hello-world/', false ),
+			'a page starting with api' => array( '/apidocs/', false ),
+		);
+	}
+
+	public function test_is_mastodon_api_request_by_query_var() {
+		$GLOBALS['wp']->query_vars['rest_route'] = '/' . Mastodon_API::PREFIX . '/api/v1/instance';
+		$this->assertTrue( Mastodon_API::is_mastodon_api_request() );
+
+		$GLOBALS['wp']->query_vars['rest_route'] = '/wp/v2/posts';
+		$this->assertFalse( Mastodon_API::is_mastodon_api_request() );
+	}
+
+	public function test_is_mastodon_api_request_with_plain_permalinks() {
+		$this->set_permalink_structure( '' );
+
+		$_SERVER['REQUEST_URI'] = '/index.php?rest_route=/' . Mastodon_API::PREFIX . '/api/v1/instance';
+		$_GET['rest_route']     = '/' . Mastodon_API::PREFIX . '/api/v1/instance';
+		$this->assertTrue( Mastodon_API::is_mastodon_api_request() );
+
+		$_GET['rest_route'] = '/wp/v2/posts';
+		$this->assertFalse( Mastodon_API::is_mastodon_api_request() );
+	}
+
+	public function test_is_mastodon_api_request_can_be_filtered() {
+		$_SERVER['REQUEST_URI'] = '/wp-json/wp/v2/posts';
+		$this->assertFalse( Mastodon_API::is_mastodon_api_request() );
+
+		add_filter( 'mastodon_api_is_api_request', '__return_true' );
+		$this->assertTrue( Mastodon_API::is_mastodon_api_request() );
+		remove_filter( 'mastodon_api_is_api_request', '__return_true' );
+	}
+
+	public function test_get_current_rest_route() {
+		$_SERVER['REQUEST_URI'] = '/wp-json/' . Mastodon_API::PREFIX . '/api/v1/instance';
+		$this->assertSame( Mastodon_API::PREFIX . '/api/v1/instance', Mastodon_API::get_current_rest_route() );
+
+		$_SERVER['REQUEST_URI'] = '/hello-world/';
+		$this->assertSame( '', Mastodon_API::get_current_rest_route() );
+	}
+
+	public function test_access_token_only_authenticates_plugin_requests() {
+		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		$token   = 'ema-test-' . wp_generate_password( 12, false, false );
+
+		$storage = new OAuth2\Access_Token_Storage();
+		$storage->setAccessToken( $token, 'test-client', $user_id, time() + HOUR_IN_SECONDS, 'read write' );
+
+		$_SERVER['HTTP_AUTHORIZATION'] = 'Bearer ' . $token;
+		$oauth                         = new Mastodon_OAuth();
+
+		$_SERVER['REQUEST_URI'] = '/wp-json/' . Mastodon_API::PREFIX . '/api/v1/accounts/verify_credentials';
+		$this->assertSame( $user_id, $oauth->authenticate( false ) );
+
+		// The same token must not log the user in on a request that is not ours.
+		$_SERVER['REQUEST_URI'] = '/wp-json/wp/v2/posts';
+		$this->assertFalse( $oauth->authenticate( false ) );
+
+		$_SERVER['REQUEST_URI'] = '/wp-admin/index.php';
+		$this->assertFalse( $oauth->authenticate( false ) );
+
+		$storage->unsetAccessToken( $token );
+	}
+
+	public function test_the_health_check_diagnostic_route_is_not_authenticated() {
+		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		$token   = 'ema-test-' . wp_generate_password( 12, false, false );
+
+		$storage = new OAuth2\Access_Token_Storage();
+		$storage->setAccessToken( $token, 'test-client', $user_id, time() + HOUR_IN_SECONDS, 'read write' );
+
+		$_SERVER['HTTP_AUTHORIZATION'] = 'Bearer ' . $token;
+		$_SERVER['REQUEST_URI']        = '/wp-json/' . Mastodon_API::PREFIX . '/' . WP_Admin\Health_Check::AUTH_HEADER_ROUTE;
+
+		$oauth = new Mastodon_OAuth();
+		$this->assertFalse( $oauth->authenticate( false ) );
+
+		$storage->unsetAccessToken( $token );
+	}
+}


### PR DESCRIPTION
Fixes #324.

## What was wrong

`Mastodon_OAuth::__construct()` hooks `determine_current_user` unscoped, so it fires on **every** WordPress request. Any `Authorization: Bearer …` header — one that belongs to WordPress core, to another plugin, or to nothing at all — was run through this plugin's OAuth2 token validation, along with the taxonomy lookup that comes with it. EMA is not the authoritative authentication layer for requests it does not own, and it should not behave as if it were.

The second half is the Site Health test the issue reports. `test_authorization_header()` labelled *every* failure "Authorization headers do not reach WordPress" and offered the Apache/LiteSpeed and Nginx rewrite snippets as the fix. That framing is only correct for one of the failure modes. If the loopback request never reached the diagnostic route — a redirect, a 403, a security plugin, a blocked REST API — the test still told the admin their host was stripping the header, and sent them off to edit `.htaccess` and PHP-FPM configuration for a problem somewhere else.

## What changed

**Ownership boundary.** `Mastodon_API::is_mastodon_api_request()` decides whether a request belongs to this plugin, recognising the prefixed REST route, the `rest_route` parameter, and the short `/api/v1/…` paths. It answers the same way before and after `parse_request` has filled in the query vars, because `determine_current_user` can run at either point and a wrong answer there would be cached for the rest of the request. `Mastodon_OAuth::authenticate()` returns the incoming user id untouched for everything else, leaving core and other plugins to authenticate their own requests. `rest_authentication_errors()` now shares the same route lookup instead of duplicating it. The decision is filterable through `mastodon_api_is_api_request` for anyone who does want an EMA token honoured elsewhere.

**Honest diagnostics.** The Site Health test now separates "the header did not arrive" (critical, with the rewrite-rule advice) from "this test could not get an answer" (recommended, reporting the HTTP status and REST error code it actually saw, and pointing at loopback requests and REST API blocking instead). Only the first case gets the header-forwarding advice.

**Fewer moving parts in the diagnostic.** The Site Health route is excluded from OAuth authentication, since its `Bearer ema-health-check` value is synthetic and never meant to authenticate. Its short-lived token is now signed with `wp_salt()` rather than stored in a transient, so a diagnostic answer no longer depends on a working object cache — a failure to store the token used to surface as a failure to forward the header.

## Validation

`php -l` and `phpcs --standard=phpcs.xml.dist` clean on all changed files (same as the branch point: zero warnings before and after).

Exercised against a live site with `wp eval-file`:

- All ten request shapes classify as expected: prefixed REST route, short `/api/v1/…` and `/api/v2/…` paths, and `/api/nodeinfo/…` are ours; core REST routes, another plugin's REST routes, wp-admin, the front page, a permalink, and a page whose slug merely starts with `api` are not. Same for the `rest_route` query var and the `?rest_route=` parameter.
- A real, unexpired access token still authenticates on both `/wp-json/enable-mastodon-apps/api/v1/accounts/verify_credentials` and the short `/api/v1/accounts/verify_credentials`, and no longer authenticates on `/wp-json/wp/v2/posts`, `/wp-admin/index.php`, or the diagnostic route.
- Over real HTTP: both paths return HTTP 200 with the account object when the token is sent, and HTTP 401 when it is not.
- All five Site Health tests report `good`, including the reworked Authorization header test end to end — signed token, loopback request, diagnostic route.

New unit tests cover the request classification, the filter, the token round-trip, and the new "could not be completed" reporting path. PHPUnit could not run locally (no database available in this environment), so it ran on CI: all checks green — PHPUnit on PHP 7.4, 8.0, 8.1, 8.2 and 8.4 against WordPress trunk, lint on PHP 7.4 through 8.3, and the CS/QA job.

https://claude.ai/code/session_01JdhdibwuQmo6uEiEptVgRU
