### PR TITLE
Match Mastodon's app registration, token and account responses

### DIFF
--- a/includes/class-mastodon-api.php
+++ b/includes/class-mastodon-api.php
@@ -2273,14 +2273,24 @@ class Mastodon_API {
 			return $app;
 		}
 
-		return array(
-			'id'            => $app->get_client_id(),
-			'name'          => $app->get_client_name(),
-			'website'       => $app->get_website(),
-			'redirect_uri'  => implode( ',', is_array( $redirect_uris ) ? $redirect_uris : array( $redirect_uris ) ),
-			'client_id'     => $app->get_client_id(),
-			'client_secret' => $app->get_client_secret(),
+		// The stored URIs are the validated ones, which is what the app is going to be held to.
+		$redirect_uris = $app->get_redirect_uris();
+		if ( ! is_array( $redirect_uris ) ) {
+			$redirect_uris = array( $redirect_uris );
+		}
+		$scopes = $app->get_scopes();
 
+		return array(
+			'id'                       => $app->get_client_id(),
+			'name'                     => $app->get_client_name(),
+			'website'                  => $app->get_website(),
+			// Mastodon's deprecated singular field separates multiple URIs with newlines.
+			'redirect_uri'             => implode( "\n", $redirect_uris ),
+			'redirect_uris'            => array_values( $redirect_uris ),
+			'scopes'                   => $scopes ? explode( ' ', $scopes ) : array(),
+			'client_id'                => $app->get_client_id(),
+			'client_secret'            => $app->get_client_secret(),
+			'client_secret_expires_at' => '0',
 		);
 	}
 

--- a/includes/class-mastodon-app.php
+++ b/includes/class-mastodon-app.php
@@ -251,14 +251,26 @@ class Mastodon_App {
 	}
 
 	public function check_redirect_uri( $redirect_uri ) {
+		if ( ! $redirect_uri ) {
+			return false;
+		}
+
 		$redirect_uris = $this->get_redirect_uris();
 		if ( ! is_array( $redirect_uris ) ) {
 			$redirect_uris = array( $redirect_uris );
 		}
 
 		foreach ( $redirect_uris as $uri ) {
-			if ( $uri === $redirect_uri ) {
-				return true;
+			// Apps registered before newline-separated URIs were split still have them in one string.
+			foreach ( preg_split( '/\s+/', trim( $uri ) ) as $uri ) {
+				if ( $uri === $redirect_uri ) {
+					return true;
+				}
+
+				// The OAuth server matches by prefix, so this needs to agree with it.
+				if ( $uri && 0 === strcasecmp( substr( $redirect_uri, 0, strlen( $uri ) ), $uri ) ) {
+					return true;
+				}
 			}
 		}
 
@@ -575,11 +587,14 @@ class Mastodon_App {
 					}
 					$urls = array();
 					foreach ( $value as $url ) {
-						if ( Mastodon_OAuth::OOB_REDIRECT_URI === $url ) {
-							$urls[] = $url;
-						} elseif ( preg_match( '#^[a-z0-9.-]+://?[a-z0-9.%-]*#i', $url ) ) {
-							// custom protocols are ok.
-							$urls[] = $url;
+						// Mastodon lets apps register multiple redirect URIs separated by newlines.
+						foreach ( preg_split( '/\s+/', trim( $url ) ) as $url ) {
+							if ( Mastodon_OAuth::OOB_REDIRECT_URI === $url ) {
+								$urls[] = $url;
+							} elseif ( preg_match( '#^[a-z0-9.-]+://?[a-z0-9.%-]*#i', $url ) ) {
+								// custom protocols are ok.
+								$urls[] = $url;
+							}
 						}
 					}
 

--- a/includes/class-mastodon-oauth.php
+++ b/includes/class-mastodon-oauth.php
@@ -213,7 +213,12 @@ class Mastodon_OAuth {
 		$response = new Response();
 
 		$authenticate_handler = new OAuth2\Authenticate_Handler();
-		$authenticate_handler->handle( $request, $response );
+		$response             = $authenticate_handler->handle( $request, $response );
+
+		// The consent screen renders itself; anything else has an error to report.
+		if ( $response instanceof Response && 200 !== $response->getStatusCode() ) {
+			$response->send();
+		}
 		exit;
 	}
 

--- a/includes/entity/class-account.php
+++ b/includes/entity/class-account.php
@@ -18,37 +18,41 @@ namespace Enable_Mastodon_Apps\Entity;
  */
 class Account extends Entity {
 	protected $types = array(
-		'id'              => 'string',
-		'username'        => 'string',
-		'acct'            => 'string',
-		'url'             => 'string',
-		'display_name'    => 'string',
-		'note'            => 'string',
-		'avatar'          => 'string',
-		'avatar_static'   => 'string',
-		'header'          => 'string',
-		'header_static'   => 'string',
+		'id'               => 'string',
+		'username'         => 'string',
+		'acct'             => 'string',
+		'url'              => 'string',
+		'uri'              => 'string?',
+		'display_name'     => 'string',
+		'note'             => 'string',
+		'avatar'           => 'string',
+		'avatar_static'    => 'string',
+		'header'           => 'string',
+		'header_static'    => 'string',
 
-		'locked'          => 'bool',
-		'bot'             => 'bool',
-		'group'           => 'bool',
-		'discoverable'    => 'bool?',
-		'noindex'         => 'bool?',
-		'suspended'       => 'bool?',
-		'limited'         => 'bool?',
+		'locked'           => 'bool',
+		'bot'              => 'bool',
+		'group'            => 'bool',
+		'discoverable'     => 'bool?',
+		'noindex'          => 'bool?',
+		'indexable'        => 'bool?',
+		'hide_collections' => 'bool?',
+		'suspended'        => 'bool?',
+		'limited'          => 'bool?',
 
-		'statuses_count'  => 'int',
-		'followers_count' => 'int',
-		'following_count' => 'int',
+		'statuses_count'   => 'int',
+		'followers_count'  => 'int',
+		'following_count'  => 'int',
 
-		'source'          => 'array',
-		'fields'          => 'array',
-		'emojis'          => 'array',
+		'source'           => 'array',
+		'fields'           => 'array',
+		'emojis'           => 'array',
+		'roles'            => 'array',
 
-		'moved'           => 'Account?',
+		'moved'            => 'Account?',
 
-		'created_at'      => 'DateTime',
-		'last_status_at'  => 'Date?',
+		'created_at'       => 'DateTime',
+		'last_status_at'   => 'Date?',
 	);
 	/**
 	 * The account id.
@@ -77,6 +81,13 @@ class Account extends Entity {
 	 * @var string
 	 */
 	public $url;
+
+	/**
+	 * The user’s ActivityPub actor identifier.
+	 *
+	 * @var string|null
+	 */
+	public $uri;
 
 	/**
 	 * The profile’s display name.
@@ -170,6 +181,27 @@ class Account extends Entity {
 	public $noindex = false;
 
 	/**
+	 * Whether public posts of this account are available for search.
+	 *
+	 * @var bool
+	 */
+	public $indexable = true;
+
+	/**
+	 * Whether the account hides the contents of its follows and followers collections.
+	 *
+	 * @var bool
+	 */
+	public $hide_collections = false;
+
+	/**
+	 * The roles assigned to the currently authorized user.
+	 *
+	 * @var array
+	 */
+	public $roles = array();
+
+	/**
 	 * Indicates that the profile is currently inactive and that its user has moved to a new account.
 	 *
 	 * @var Account|null
@@ -232,11 +264,12 @@ class Account extends Entity {
 	 * @var array
 	 */
 	public $source = array(
-		'privacy'   => 'public',
-		'sensitive' => false,
-		'language'  => 'en',
-		'note'      => '',
-		'fields'    => array(),
+		'privacy'               => 'public',
+		'sensitive'             => false,
+		'language'              => 'en',
+		'note'                  => '',
+		'fields'                => array(),
+		'follow_requests_count' => 0,
 	);
 
 	public function __get( $k ) {

--- a/includes/handler/class-account.php
+++ b/includes/handler/class-account.php
@@ -30,6 +30,7 @@ class Account extends Handler {
 		add_filter( 'mastodon_api_account', array( $this, 'api_account_ema' ), 10, 4 );
 		add_filter( 'mastodon_api_account', array( $this, 'api_account_media_overrides' ), 20, 2 );
 		add_filter( 'mastodon_api_account', array( get_called_class(), 'api_account_ensure_numeric_id' ), 100, 2 );
+		add_filter( 'mastodon_api_account', array( get_called_class(), 'api_account_mastodon_defaults' ), 110, 2 );
 	}
 
 	public function api_account_ema( $account, $user_id, $request = null, $post = null ) {
@@ -85,13 +86,16 @@ class Account extends Handler {
 		$account->statuses_count = count_user_posts( $user->ID, 'post', true );
 		$account->last_status_at = new \DateTime( $user->user_registered );
 		$account->url            = get_author_posts_url( $user->ID );
+		// The author archive is also what the ActivityPub plugin serves the actor from.
+		$account->uri = $account->url;
 
 		$account->source = array(
-			'privacy'   => 'public',
-			'sensitive' => false,
-			'language'  => get_user_locale( $user->ID ),
-			'note'      => $note,
-			'fields'    => array(),
+			'privacy'               => 'public',
+			'sensitive'             => false,
+			'language'              => get_user_locale( $user->ID ),
+			'note'                  => $note,
+			'fields'                => array(),
+			'follow_requests_count' => 0,
 		);
 
 		return $account;
@@ -135,6 +139,59 @@ class Account extends Handler {
 		}
 
 		return $user_data;
+	}
+
+	/**
+	 * Fill in the parts of the account entity that Mastodon always sends.
+	 *
+	 * Accounts can come from integrations through the `mastodon_api_account` filter, so
+	 * this runs last and only supplies what is missing. Clients deserialize these into
+	 * typed models, and a missing key is not the same as an empty one for them.
+	 *
+	 * @param mixed $user_data The account.
+	 * @param int   $user_id   The user id.
+	 * @return mixed The account.
+	 */
+	public static function api_account_mastodon_defaults( $user_data, $user_id ) {
+		if ( ! is_object( $user_data ) ) {
+			return $user_data;
+		}
+
+		if ( empty( $user_data->uri ) && ! empty( $user_data->url ) ) {
+			$user_data->uri = $user_data->url;
+		}
+
+		if ( is_array( $user_data->source ) && ! isset( $user_data->source['follow_requests_count'] ) ) {
+			$user_data->source['follow_requests_count'] = 0;
+		}
+
+		// Mastodon always states whether a profile field has been verified.
+		$user_data->fields = self::add_field_verification( $user_data->fields );
+		if ( is_array( $user_data->source ) && isset( $user_data->source['fields'] ) ) {
+			$user_data->source['fields'] = self::add_field_verification( $user_data->source['fields'] );
+		}
+
+		return $user_data;
+	}
+
+	/**
+	 * Add the `verified_at` key to profile fields that don't have it.
+	 *
+	 * @param mixed $fields The profile fields.
+	 * @return mixed The profile fields.
+	 */
+	private static function add_field_verification( $fields ) {
+		if ( ! is_array( $fields ) ) {
+			return $fields;
+		}
+
+		foreach ( $fields as $i => $field ) {
+			if ( is_array( $field ) && ! array_key_exists( 'verified_at', $field ) ) {
+				$fields[ $i ]['verified_at'] = null;
+			}
+		}
+
+		return $fields;
 	}
 
 	public static function api_account_id( $user_id, $post_id ) {

--- a/includes/integration/class-pixelfed.php
+++ b/includes/integration/class-pixelfed.php
@@ -27,7 +27,7 @@ class Pixelfed {
 		add_action( 'mastodon_api_new_app', array( $this, 'set_pixelfed_app_options' ) );
 	}
 
-	private function is_pixelfed_client() {
+	public static function is_pixelfed_client() {
 		if ( ! isset( $_SERVER['HTTP_USER_AGENT'] ) ) {
 			return false;
 		}
@@ -44,7 +44,7 @@ class Pixelfed {
 	}
 
 	public function mastodon_api_pixelfed_nodeinfo_software_root( $ret ) {
-		if ( ! $this->is_pixelfed_client() ) {
+		if ( ! self::is_pixelfed_client() ) {
 			return $ret;
 		}
 		$ret['software'] = $this->mastodon_api_pixelfed_nodeinfo_software( array() );
@@ -53,7 +53,7 @@ class Pixelfed {
 	}
 
 	public function mastodon_api_pixelfed_nodeinfo_software( $software ) {
-		$pixelfed = $this->is_pixelfed_client();
+		$pixelfed = self::is_pixelfed_client();
 		if ( ! $pixelfed ) {
 			return $software;
 		}

--- a/includes/oauth2/class-authenticate-handler.php
+++ b/includes/oauth2/class-authenticate-handler.php
@@ -32,9 +32,11 @@ class Authenticate_Handler {
 		$client_name = $app->get_client_name();
 
 		$redirect_uri = isset( $_GET['redirect_uri'] ) ? sanitize_text_field( wp_unslash( $_GET['redirect_uri'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$redirect_uri = $app->check_redirect_uri( $redirect_uri );
-		if ( is_wp_error( $redirect_uri ) ) {
-			return $redirect_uri;
+		// Omitting it is allowed: the OAuth server then falls back to the registered URI.
+		if ( $redirect_uri && ! $app->check_redirect_uri( $redirect_uri ) ) {
+			$response->setError( 400, 'invalid_redirect_uri', 'The redirect URI is not registered for this app.' );
+
+			return $response;
 		}
 
 		$scopes = array();

--- a/includes/oauth2/class-response.php
+++ b/includes/oauth2/class-response.php
@@ -58,8 +58,9 @@ class Response extends \OAuth2\Response {
 			if ( ! $this->getParameter( 'created_at' ) ) {
 				$this->setParameter( 'created_at', time() );
 			}
-			if ( ! $this->getParameter( 'refresh_token' ) ) {
-				// Provide a placeholder to prevent apps from crashing when storing undefined.
+			if ( ! $this->getParameter( 'refresh_token' ) && \Enable_Mastodon_Apps\Integration\Pixelfed::is_pixelfed_client() ) {
+				// Pixelfed crashes when storing an undefined refresh token. An empty string is
+				// not a usable token, so it only goes to the clients that need the key present.
 				$this->setParameter( 'refresh_token', '' );
 			}
 		}


### PR DESCRIPTION
Found while investigating #323. None of this turned out to be the cause of that
report — Surf's OAuth flow completes and it fails afterwards in its own signup
step — but bisecting it surfaced a set of real deviations from what Mastodon
sends. Clients deserialize these responses into typed models, so a key Mastodon
always sends but we omit is not the same to them as an empty one.

## App registration

Mastodon lets an app register several redirect URIs by separating them with
newlines. We only ever split on commas, so such a registration was stored as one
string containing all of them. Nothing rejected it, because the OAuth server
splits the registered value on whitespace itself — but `check_redirect_uri()`
compared the whole blob and could never match a single URI.

The URIs are now split and validated individually, and the response gained
`redirect_uris`, `scopes` and `client_secret_expires_at`. `redirect_uri` keeps
Mastodon's deprecated semantics (all URIs, newline-separated) and is now derived
from the stored, validated list rather than the raw request.

No `vapid_key`: EMA implements no Web Push, and a key clients cannot use is
worse than an absent one.

## Token response

`refresh_token: ""` was added in #284 because Pixelfed crashes when it stores an
undefined value. An empty string is not a usable token, and an OAuth client that
validates the response rejects one that carries it. It now goes only to Pixelfed
clients, so #284 keeps working and everyone else gets what Mastodon sends.

## Account entity

Added `uri`, `indexable`, `hide_collections`, `roles`,
`source.follow_requests_count` and `verified_at` on profile fields.

Accounts can also arrive through the `mastodon_api_account` filter from
integrations such as ActivityPub or Friends. Those remain authoritative for
everything they set; a late filter only fills in keys that are still missing.
`uri` falls back to the author archive URL, which is where the ActivityPub
plugin serves the actor from.

`url` deliberately keeps pointing at the author archive. Mastodon's `/@user`
shape would 404 on a WordPress site that isn't serving it, so WordPress core's
permalink structure stays authoritative here.

## Redirect URI checks

`check_redirect_uri()` now splits legacy newline blobs, so apps registered before
this change keep working, and matches by prefix so it agrees with the OAuth
server's `require_exact_redirect_uri => false` rather than being stricter than
the thing that actually issues the code.

The consent screen passed that check's boolean result to `is_wp_error()`, so it
never rejected anything; it now does. An omitted `redirect_uri` stays allowed,
because the OAuth server then falls back to the registered one.
`authenticate_handler()` also discarded its response object, which rendered a
blank page for every error path including the existing unknown-client 404.

## Validation

- `php -l` and `phpcs --standard=phpcs.xml.dist` clean on all eight files.
- Against a live site: registering an app with a newline-separated list of four
  redirect URIs stores them as four separate entries and returns the full
  Mastodon shape.
- `check_redirect_uri()` matches a registered URI for both a newly registered app
  and one stored as a legacy blob, and rejects an unregistered URI for both.
- The serialized account carries every added key, including for fields
  contributed by an integration.
- The token response omits `refresh_token` for a generic client and still
  includes it for a Pixelfed user agent.
- PHPUnit was not runnable locally (no `/tmp/wordpress-tests-lib`, no Docker
  access). CI has since run it: the full matrix passes on PHP 7.4, 8.0, 8.1,
  8.2, 8.3 and 8.4 against WordPress trunk, alongside lint and CS.
- The consent screen's new rejection path was not exercised end to end, as it
  needs a logged-in session.

https://claude.ai/code/session_01FSUZiZzPd3A2S11QN9XbRg

