### PR TITLE
Perform follows through the ActivityPub plugin

### DIFF
--- a/enable-mastodon-apps.php
+++ b/enable-mastodon-apps.php
@@ -68,6 +68,7 @@ add_action(
 		new Mastodon_API();
 		WP_Admin\Health_Check::init();
 		new Integration\Pixelfed();
+		new Integration\Activitypub();
 		new Comment_CPT();
 	}
 );

--- a/includes/class-mastodon-api.php
+++ b/includes/class-mastodon-api.php
@@ -3388,11 +3388,20 @@ class Mastodon_API {
 		 *
 		 * @param string          $user_id The user ID.
 		 * @param WP_REST_Request $request The request object.
-		 * @return string The user ID.
+		 * @return string|\WP_Error The user ID, or a WP_Error if the follow could not be performed.
 		 */
-		$user_id = apply_filters( 'mastodon_api_account_follow', $user_id, $request );
+		$followed_user_id = apply_filters( 'mastodon_api_account_follow', $user_id, $request );
 
-		return rest_ensure_response( $this->get_relationship( $user_id, $request ) );
+		if ( is_wp_error( $followed_user_id ) ) {
+			return $followed_user_id;
+		}
+
+		// A handler that returns nothing must not take the account id down with it.
+		if ( ! is_string( $followed_user_id ) && ! is_numeric( $followed_user_id ) ) {
+			$followed_user_id = $user_id;
+		}
+
+		return rest_ensure_response( $this->get_relationship( strval( $followed_user_id ), $request ) );
 	}
 
 	/**

--- a/includes/integration/class-activitypub.php
+++ b/includes/integration/class-activitypub.php
@@ -1,0 +1,427 @@
+<?php
+/**
+ * ActivityPub Integration
+ *
+ * Perform follows through the ActivityPub plugin so that Mastodon apps can
+ * follow remote accounts even when no other plugin owns following behavior.
+ *
+ * @package Enable_Mastodon_Apps
+ */
+
+namespace Enable_Mastodon_Apps\Integration;
+
+use Enable_Mastodon_Apps\Entity\Account as Account_Entity;
+use Enable_Mastodon_Apps\Entity\Relationship as Relationship_Entity;
+
+/**
+ * This is the class that implements the ActivityPub adaptations.
+ *
+ * The ActivityPub plugin owns the follow relationships of a WordPress site, so
+ * EMA only translates between Mastodon account ids and remote actor posts.
+ *
+ * @since 1.6.2
+ *
+ * @package Enable_Mastodon_Apps
+ */
+class Activitypub {
+	/**
+	 * The post type the ActivityPub plugin uses for remote actors.
+	 *
+	 * @var string
+	 */
+	const ACTOR_POST_TYPE = 'ap_actor';
+
+	public function __construct() {
+		if ( ! self::is_available() ) {
+			return;
+		}
+
+		// Run before other integrations so that the account id is still the one the app was given.
+		add_filter( 'mastodon_api_account_follow', array( $this, 'account_follow' ), 9 );
+		add_action( 'mastodon_api_account_unfollow', array( $this, 'account_unfollow' ), 9 );
+		add_filter( 'mastodon_entity_relationship', array( $this, 'entity_relationship' ), 20, 2 );
+		add_filter( 'mastodon_api_account', array( $this, 'account_counts' ), 16, 2 );
+		add_filter( 'mastodon_api_account_following', array( $this, 'account_following' ), 20, 3 );
+	}
+
+	/**
+	 * Whether the ActivityPub plugin provides the API we rely on.
+	 *
+	 * @return bool True if follows can be handed to the ActivityPub plugin.
+	 */
+	public static function is_available() {
+		return function_exists( '\Activitypub\follow' )
+			&& function_exists( '\Activitypub\unfollow' )
+			&& class_exists( '\Activitypub\Collection\Following' )
+			&& class_exists( '\Activitypub\Collection\Remote_Actors' );
+	}
+
+	/**
+	 * Get the local actor id to act as.
+	 *
+	 * In blog-only mode the individual user has no actor of their own, so the
+	 * blog actor is used instead, mirroring what the ActivityPub plugin does.
+	 *
+	 * @return int|null The local actor id, or null if the site cannot federate.
+	 */
+	private function get_local_actor_id() {
+		if ( ! function_exists( '\Activitypub\user_can_activitypub' ) ) {
+			return null;
+		}
+
+		$user_id = get_current_user_id();
+		if ( $user_id && \Activitypub\user_can_activitypub( $user_id ) ) {
+			return $user_id;
+		}
+
+		$blog_user_id = \Activitypub\Collection\Actors::BLOG_USER_ID;
+		if ( \Activitypub\user_can_activitypub( $blog_user_id ) ) {
+			return $blog_user_id;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Resolve a Mastodon account id to a remote actor post id.
+	 *
+	 * @param string|int $user_id     The account id as it was handed out to the app.
+	 * @param bool       $allow_fetch Whether the actor may be fetched from the remote server.
+	 * @return int The remote actor post id, or 0 if this is not a remote actor.
+	 */
+	private function resolve_remote_actor( $user_id, $allow_fetch = false ) {
+		if ( is_numeric( $user_id ) ) {
+			// The ActivityPub plugin hands out remote actor post ids as account ids.
+			$post = get_post( intval( $user_id ) );
+			if ( $post && self::ACTOR_POST_TYPE === $post->post_type ) {
+				return $post->ID;
+			}
+
+			return 0;
+		}
+
+		$identifier = $this->normalize_identifier( $user_id );
+		if ( ! $identifier ) {
+			return 0;
+		}
+
+		if ( filter_var( $identifier, FILTER_VALIDATE_URL ) ) {
+			$post = \Activitypub\Collection\Remote_Actors::get_by_uri( $identifier );
+			if ( ! is_wp_error( $post ) ) {
+				return $post->ID;
+			}
+		} else {
+			$post_id = $this->get_actor_post_id_by_acct( $identifier );
+			if ( $post_id ) {
+				return $post_id;
+			}
+		}
+
+		if ( ! $allow_fetch ) {
+			return 0;
+		}
+
+		$post = \Activitypub\Collection\Remote_Actors::fetch_by_various( $identifier );
+		if ( is_wp_error( $post ) ) {
+			return 0;
+		}
+
+		return $post->ID;
+	}
+
+	/**
+	 * Turn an account id into a webfinger address or actor URL.
+	 *
+	 * @param string|int $user_id The account id.
+	 * @return string The identifier, or an empty string if it cannot be used.
+	 */
+	private function normalize_identifier( $user_id ) {
+		if ( ! is_string( $user_id ) ) {
+			return '';
+		}
+
+		$identifier = trim( str_replace( 'acct:', '', $user_id ) );
+		$identifier = trim( $identifier, '@' );
+
+		if ( ! $identifier || ! preg_match( '/^[^\s@]+(@[^\s@]+)?$|^https?:\/\//i', $identifier ) ) {
+			return '';
+		}
+
+		return $identifier;
+	}
+
+	/**
+	 * Look up a locally known remote actor by its webfinger address.
+	 *
+	 * @param string $acct The webfinger address, without a leading `@`.
+	 * @return int The remote actor post id, or 0 if it is not known locally.
+	 */
+	private function get_actor_post_id_by_acct( $acct ) {
+		$posts = get_posts(
+			array(
+				'post_type'        => self::ACTOR_POST_TYPE,
+				'post_status'      => 'any',
+				'posts_per_page'   => 1,
+				'no_found_rows'    => true,
+				'fields'           => 'ids',
+				'suppress_filters' => false,
+				'meta_key'         => '_activitypub_acct', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value'       => $acct, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+			)
+		);
+
+		if ( empty( $posts ) ) {
+			return 0;
+		}
+
+		return intval( $posts[0] );
+	}
+
+	/**
+	 * Follow a remote account through the ActivityPub plugin.
+	 *
+	 * @param string|int $user_id The account id to follow.
+	 * @return string|int|\WP_Error The unmodified account id, or an error if the follow failed.
+	 */
+	public function account_follow( $user_id ) {
+		if ( is_wp_error( $user_id ) ) {
+			return $user_id;
+		}
+
+		$actor_post_id = $this->resolve_remote_actor( $user_id, true );
+		if ( ! $actor_post_id ) {
+			// A numeric id that is not a remote actor belongs to a local or plugin-owned account.
+			if ( is_numeric( $user_id ) ) {
+				return $user_id;
+			}
+
+			return $this->fail(
+				$user_id,
+				'mastodon_api_account_not_found',
+				__( 'The account could not be found on the fediverse.', 'enable-mastodon-apps' ),
+				404
+			);
+		}
+
+		$local_actor_id = $this->get_local_actor_id();
+		if ( null === $local_actor_id ) {
+			return $this->fail(
+				$user_id,
+				'mastodon_api_follow_failed',
+				__( 'This site cannot follow accounts on the fediverse.', 'enable-mastodon-apps' ),
+				400
+			);
+		}
+
+		// Another integration may have performed the follow already.
+		if ( \Activitypub\Collection\Following::check_status( $local_actor_id, $actor_post_id ) ) {
+			return $user_id;
+		}
+
+		$result = \Activitypub\follow( $actor_post_id, $local_actor_id );
+		if ( is_wp_error( $result ) ) {
+			return $this->fail( $user_id, $result->get_error_code(), $result->get_error_message(), 500 );
+		}
+
+		return $user_id;
+	}
+
+	/**
+	 * Unfollow a remote account through the ActivityPub plugin.
+	 *
+	 * @param string|int $user_id The account id to unfollow.
+	 */
+	public function account_unfollow( $user_id ) {
+		$actor_post_id = $this->resolve_remote_actor( $user_id );
+		if ( ! $actor_post_id ) {
+			return;
+		}
+
+		$local_actor_id = $this->get_local_actor_id();
+		if ( null === $local_actor_id ) {
+			return;
+		}
+
+		if ( ! \Activitypub\Collection\Following::check_status( $local_actor_id, $actor_post_id ) ) {
+			return;
+		}
+
+		\Activitypub\unfollow( $actor_post_id, $local_actor_id );
+	}
+
+	/**
+	 * Report a follow that could not be performed.
+	 *
+	 * Only reported when no other plugin handles follows: when one does, it gets
+	 * to run with the account id it expects and decide the outcome itself.
+	 *
+	 * @param string|int $user_id The account id.
+	 * @param string     $code    The error code.
+	 * @param string     $message The error message.
+	 * @param int        $status  The HTTP status to report.
+	 * @return string|int|\WP_Error The account id, or an error.
+	 */
+	private function fail( $user_id, $code, $message, $status ) {
+		if ( $this->another_integration_follows() ) {
+			return $user_id;
+		}
+
+		return new \WP_Error( $code, $message, array( 'status' => $status ) );
+	}
+
+	/**
+	 * Whether another plugin also handles follows.
+	 *
+	 * @return bool True if something other than this integration is hooked into following.
+	 */
+	private function another_integration_follows() {
+		global $wp_filter;
+
+		if ( empty( $wp_filter['mastodon_api_account_follow'] ) ) {
+			return false;
+		}
+
+		foreach ( $wp_filter['mastodon_api_account_follow']->callbacks as $callbacks ) {
+			foreach ( $callbacks as $callback ) {
+				if ( is_array( $callback['function'] ) && isset( $callback['function'][0] ) && $this === $callback['function'][0] ) {
+					continue;
+				}
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Report the ActivityPub follow state in the relationship.
+	 *
+	 * @param Relationship_Entity $relationship The relationship.
+	 * @param string|int          $user_id      The account id.
+	 * @return Relationship_Entity The relationship.
+	 */
+	public function entity_relationship( $relationship, $user_id ) {
+		if ( ! $relationship instanceof Relationship_Entity ) {
+			return $relationship;
+		}
+
+		$actor_post_id = $this->resolve_remote_actor( $user_id );
+		if ( ! $actor_post_id ) {
+			return $relationship;
+		}
+
+		$local_actor_id = $this->get_local_actor_id();
+		if ( null === $local_actor_id ) {
+			return $relationship;
+		}
+
+		$status = \Activitypub\Collection\Following::check_status( $local_actor_id, $actor_post_id );
+		if ( \Activitypub\Collection\Following::ACCEPTED === $status ) {
+			$relationship->following = true;
+		} elseif ( \Activitypub\Collection\Following::PENDING === $status ) {
+			$relationship->requested = true;
+		}
+
+		if ( class_exists( '\Activitypub\Collection\Followers' ) && \Activitypub\Collection\Followers::follows( $actor_post_id, $local_actor_id ) ) {
+			$relationship->followed_by = true;
+		}
+
+		return $relationship;
+	}
+
+	/**
+	 * Report how many accounts a local user follows.
+	 *
+	 * @param mixed      $account The account.
+	 * @param string|int $user_id The account id.
+	 * @return mixed The account.
+	 */
+	public function account_counts( $account, $user_id ) {
+		if ( ! $account instanceof Account_Entity || ! $this->is_local_actor( $user_id ) ) {
+			return $account;
+		}
+
+		if ( ! $account->following_count ) {
+			$account->following_count = \Activitypub\Collection\Following::count( $user_id );
+		}
+
+		return $account;
+	}
+
+	/**
+	 * List the remote accounts a local user follows.
+	 *
+	 * @param Account_Entity[] $following Accounts another handler already found.
+	 * @param string|int       $user_id   The account id.
+	 * @param \WP_REST_Request $request   The request.
+	 * @return Account_Entity[] The accounts.
+	 */
+	public function account_following( $following, $user_id, $request ) {
+		if ( ! empty( $following ) || ! $this->is_local_actor( $user_id ) ) {
+			return $following;
+		}
+
+		return $this->accounts_from_actors(
+			\Activitypub\Collection\Following::get_many( $user_id, $this->get_limit( $request ) ),
+			$request
+		);
+	}
+
+	/**
+	 * Turn remote actor posts into accounts.
+	 *
+	 * @param mixed            $actor_posts The remote actor posts.
+	 * @param \WP_REST_Request $request     The request.
+	 * @return Account_Entity[] The accounts.
+	 */
+	private function accounts_from_actors( $actor_posts, $request ) {
+		if ( ! is_array( $actor_posts ) ) {
+			return array();
+		}
+
+		$accounts = array();
+		foreach ( $actor_posts as $actor_post ) {
+			$account = apply_filters( 'mastodon_api_account', null, $actor_post->ID, $request, null );
+			if ( $account instanceof Account_Entity ) {
+				$accounts[] = $account;
+			}
+		}
+
+		return $accounts;
+	}
+
+	/**
+	 * Whether the account id belongs to a local actor of this site.
+	 *
+	 * @param string|int $user_id The account id.
+	 * @return bool True if this is a local actor that can federate.
+	 */
+	private function is_local_actor( $user_id ) {
+		if ( ! is_numeric( $user_id ) || ! function_exists( '\Activitypub\user_can_activitypub' ) ) {
+			return false;
+		}
+
+		$user_id = intval( $user_id );
+		if ( $user_id <= 0 || ! get_user_by( 'ID', $user_id ) ) {
+			return false;
+		}
+
+		return (bool) \Activitypub\user_can_activitypub( $user_id );
+	}
+
+	/**
+	 * Get the requested number of results.
+	 *
+	 * @param \WP_REST_Request|null $request The request.
+	 * @return int The limit.
+	 */
+	private function get_limit( $request ) {
+		$limit = 40;
+		if ( $request instanceof \WP_REST_Request && $request->get_param( 'limit' ) ) {
+			$limit = intval( $request->get_param( 'limit' ) );
+		}
+
+		return max( 1, min( 80, $limit ) );
+	}
+}

--- a/includes/integration/class-activitypub.php
+++ b/includes/integration/class-activitypub.php
@@ -31,14 +31,27 @@ class Activitypub {
 	 */
 	const ACTOR_POST_TYPE = 'ap_actor';
 
+	/**
+	 * The account id the app asked to follow, before any handler rewrote it.
+	 *
+	 * @var string|int|null
+	 */
+	private $requested_account_id = null;
+
 	public function __construct() {
 		if ( ! self::is_available() ) {
 			return;
 		}
 
-		// Run before other integrations so that the account id is still the one the app was given.
-		add_filter( 'mastodon_api_account_follow', array( $this, 'account_follow' ), 9 );
-		add_action( 'mastodon_api_account_unfollow', array( $this, 'account_unfollow' ), 9 );
+		/*
+		 * Following is handled last, so that a plugin that owns following - Friends,
+		 * say - gets first refusal and this is only the fallback. The account id is
+		 * remembered first because such a handler may return something else entirely.
+		 */
+		add_filter( 'mastodon_api_account_follow', array( $this, 'remember_account_id' ), 1 );
+		add_filter( 'mastodon_api_account_follow', array( $this, 'account_follow' ), 20 );
+		add_action( 'mastodon_api_account_unfollow', array( $this, 'remember_account_id' ), 1 );
+		add_action( 'mastodon_api_account_unfollow', array( $this, 'account_unfollow' ), 20 );
 		add_filter( 'mastodon_entity_relationship', array( $this, 'entity_relationship' ), 20, 2 );
 		add_filter( 'mastodon_api_account', array( $this, 'account_counts' ), 16, 2 );
 		add_filter( 'mastodon_api_account_following', array( $this, 'account_following' ), 20, 3 );
@@ -178,15 +191,42 @@ class Activitypub {
 	}
 
 	/**
+	 * Remember the account id the app asked about.
+	 *
+	 * @param string|int $user_id The account id.
+	 * @return string|int The unmodified account id.
+	 */
+	public function remember_account_id( $user_id ) {
+		$this->requested_account_id = $user_id;
+
+		return $user_id;
+	}
+
+	/**
+	 * Get the account id to act on.
+	 *
+	 * A handler that ran before us may have returned something we cannot use, in
+	 * which case we fall back to what the app asked for.
+	 *
+	 * @param string|int $user_id The account id as the filter chain has it.
+	 * @return string|int The account id to act on.
+	 */
+	private function requested_account_id( $user_id ) {
+		if ( is_string( $user_id ) || is_numeric( $user_id ) ) {
+			return $user_id;
+		}
+
+		return $this->requested_account_id;
+	}
+
+	/**
 	 * Follow a remote account through the ActivityPub plugin.
 	 *
 	 * @param string|int $user_id The account id to follow.
 	 * @return string|int|\WP_Error The unmodified account id, or an error if the follow failed.
 	 */
 	public function account_follow( $user_id ) {
-		if ( is_wp_error( $user_id ) ) {
-			return $user_id;
-		}
+		$user_id = $this->requested_account_id( $user_id );
 
 		$actor_post_id = $this->resolve_remote_actor( $user_id, true );
 		if ( ! $actor_post_id ) {
@@ -213,7 +253,7 @@ class Activitypub {
 			);
 		}
 
-		// Another integration may have performed the follow already.
+		// A plugin that owns following has already done it, or it was already followed.
 		if ( \Activitypub\Collection\Following::check_status( $local_actor_id, $actor_post_id ) ) {
 			return $user_id;
 		}
@@ -232,6 +272,8 @@ class Activitypub {
 	 * @param string|int $user_id The account id to unfollow.
 	 */
 	public function account_unfollow( $user_id ) {
+		$user_id = $this->requested_account_id( $user_id );
+
 		$actor_post_id = $this->resolve_remote_actor( $user_id );
 		if ( ! $actor_post_id ) {
 			return;

--- a/tests/test-follow-endpoint.php
+++ b/tests/test-follow-endpoint.php
@@ -142,6 +142,10 @@ class Follow_Endpoint_Test extends Mastodon_API_TestCase {
 	 * A follow that cannot be performed must not be reported as a success.
 	 */
 	public function test_follow_unknown_account_errors() {
+		if ( $this->another_integration_follows() ) {
+			$this->markTestSkipped( 'Another plugin owns following and decides the outcome.' );
+		}
+
 		$user_id = Mastodon_API::remap_user_id( 'nobody@mastodon.local' );
 
 		$request  = $this->api_request( 'POST', '/api/v1/accounts/' . $user_id . '/follow' );
@@ -152,7 +156,32 @@ class Follow_Endpoint_Test extends Mastodon_API_TestCase {
 	}
 
 	/**
-	 * Another plugin that handles follows keeps the last word.
+	 * Whether a plugin other than this one handles follows.
+	 *
+	 * @return bool True if another plugin is hooked into following.
+	 */
+	private function another_integration_follows() {
+		global $wp_filter;
+
+		if ( empty( $wp_filter['mastodon_api_account_follow'] ) ) {
+			return false;
+		}
+
+		foreach ( $wp_filter['mastodon_api_account_follow']->callbacks as $callbacks ) {
+			foreach ( $callbacks as $callback ) {
+				if ( is_array( $callback['function'] ) && $callback['function'][0] instanceof Integration\Activitypub ) {
+					continue;
+				}
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * A plugin that owns following gets first refusal and decides the outcome.
 	 */
 	public function test_follow_defers_to_another_integration() {
 		$handled = false;
@@ -170,6 +199,46 @@ class Follow_Endpoint_Test extends Mastodon_API_TestCase {
 
 		$this->assertTrue( $handled );
 		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	/**
+	 * A follow another plugin already performed is not performed a second time.
+	 */
+	public function test_follow_performed_by_another_integration_is_not_repeated() {
+		$actor_post_id = $this->actor_post_id;
+		$handler       = function ( $user_id ) use ( $actor_post_id ) {
+			// Stand in for a plugin that follows through the ActivityPub plugin itself.
+			\Activitypub\Collection\Following::follow( $actor_post_id, get_current_user_id() );
+			return $user_id;
+		};
+		add_filter( 'mastodon_api_account_follow', $handler );
+
+		$request  = $this->api_request( 'POST', '/api/v1/accounts/' . $this->actor_post_id . '/follow' );
+		$response = $this->dispatch_authenticated( $request );
+
+		remove_filter( 'mastodon_api_account_follow', $handler );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 1, $this->count_follow_activities() );
+	}
+
+	/**
+	 * A handler that returns nothing does not cost us the account id.
+	 */
+	public function test_follow_survives_a_handler_that_returns_nothing() {
+		$handler = function () {
+			return null;
+		};
+		add_filter( 'mastodon_api_account_follow', $handler, 15 );
+
+		$request  = $this->api_request( 'POST', '/api/v1/accounts/' . $this->actor_post_id . '/follow' );
+		$response = $this->dispatch_authenticated( $request );
+
+		remove_filter( 'mastodon_api_account_follow', $handler, 15 );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 1, $this->count_follow_activities() );
+		$this->assertEquals( strval( $this->actor_post_id ), $response->get_data()->id );
 	}
 
 	/**

--- a/tests/test-follow-endpoint.php
+++ b/tests/test-follow-endpoint.php
@@ -1,0 +1,205 @@
+<?php
+/**
+ * Class Follow_Endpoint_Test
+ *
+ * @package Enable_Mastodon_Apps
+ */
+
+namespace Enable_Mastodon_Apps;
+
+/**
+ * Testcase for following remote accounts through the ActivityPub plugin.
+ *
+ * @package
+ */
+class Follow_Endpoint_Test extends Mastodon_API_TestCase {
+	/**
+	 * The remote actor post id.
+	 *
+	 * @var int
+	 */
+	private $actor_post_id;
+
+	public function set_up() {
+		if ( ! Integration\Activitypub::is_available() ) {
+			return $this->markTestSkipped( 'The ActivityPub plugin is not loaded.' );
+		}
+		parent::set_up();
+
+		$this->actor_post_id = \Activitypub\Collection\Remote_Actors::upsert(
+			array(
+				'id'                => 'https://mastodon.local/users/remote',
+				'type'              => 'Person',
+				'name'              => 'Remote Person',
+				'preferredUsername' => 'remote',
+				'summary'           => 'A remote person',
+				'url'               => 'https://mastodon.local/@remote',
+				'inbox'             => 'https://mastodon.local/users/remote/inbox',
+				'outbox'            => 'https://mastodon.local/users/remote/outbox',
+			)
+		);
+		$this->assertIsInt( $this->actor_post_id );
+		update_post_meta( $this->actor_post_id, '_activitypub_acct', 'remote@mastodon.local' );
+	}
+
+	/**
+	 * Get the number of Follow activities in the outbox.
+	 *
+	 * @return int The number of Follow activities.
+	 */
+	private function count_follow_activities() {
+		return count(
+			get_posts(
+				array(
+					'post_type'      => \Activitypub\Collection\Outbox::POST_TYPE,
+					'post_status'    => 'any',
+					'posts_per_page' => -1,
+					'fields'         => 'ids',
+					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+					'meta_query'     => array(
+						array(
+							'key'   => '_activitypub_activity_type',
+							'value' => 'Follow',
+						),
+					),
+				)
+			)
+		);
+	}
+
+	/**
+	 * A follow of a remote actor reaches the ActivityPub plugin.
+	 */
+	public function test_follow_remote_actor() {
+		$this->assertFalse( \Activitypub\Collection\Following::check_status( $this->administrator, $this->actor_post_id ) );
+
+		$request  = $this->api_request( 'POST', '/api/v1/accounts/' . $this->actor_post_id . '/follow' );
+		$response = $this->dispatch_authenticated( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 1, $this->count_follow_activities() );
+		$this->assertEquals(
+			\Activitypub\Collection\Following::PENDING,
+			\Activitypub\Collection\Following::check_status( $this->administrator, $this->actor_post_id )
+		);
+
+		$data = $response->get_data();
+		$this->assertInstanceOf( Entity\Relationship::class, $data );
+		$this->assertEquals( strval( $this->actor_post_id ), $data->id );
+		$this->assertTrue( $data->requested );
+	}
+
+	/**
+	 * An accepted follow is reported as following in the relationship.
+	 */
+	public function test_relationship_reports_accepted_follow() {
+		\Activitypub\Collection\Following::follow( $this->actor_post_id, $this->administrator );
+		\Activitypub\Collection\Following::accept( $this->actor_post_id, $this->administrator );
+
+		$request = $this->api_request( 'GET', '/api/v1/accounts/relationships' );
+		$request->set_param( 'id', array( strval( $this->actor_post_id ) ) );
+		$response = $this->dispatch_authenticated( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertCount( 1, $data );
+		$this->assertTrue( $data[0]->following );
+		$this->assertFalse( $data[0]->requested );
+	}
+
+	/**
+	 * Unfollowing removes the follow from the ActivityPub plugin.
+	 */
+	public function test_unfollow_remote_actor() {
+		\Activitypub\Collection\Following::follow( $this->actor_post_id, $this->administrator );
+		\Activitypub\Collection\Following::accept( $this->actor_post_id, $this->administrator );
+
+		$request  = $this->api_request( 'POST', '/api/v1/accounts/' . $this->actor_post_id . '/unfollow' );
+		$response = $this->dispatch_authenticated( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertFalse( \Activitypub\Collection\Following::check_status( $this->administrator, $this->actor_post_id ) );
+		$this->assertFalse( $response->get_data()->following );
+	}
+
+	/**
+	 * Following a locally known handle resolves it without a remote lookup.
+	 */
+	public function test_follow_by_webfinger_handle() {
+		$user_id = Mastodon_API::remap_user_id( 'remote@mastodon.local' );
+
+		$request  = $this->api_request( 'POST', '/api/v1/accounts/' . $user_id . '/follow' );
+		$response = $this->dispatch_authenticated( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals(
+			\Activitypub\Collection\Following::PENDING,
+			\Activitypub\Collection\Following::check_status( $this->administrator, $this->actor_post_id )
+		);
+	}
+
+	/**
+	 * A follow that cannot be performed must not be reported as a success.
+	 */
+	public function test_follow_unknown_account_errors() {
+		$user_id = Mastodon_API::remap_user_id( 'nobody@mastodon.local' );
+
+		$request  = $this->api_request( 'POST', '/api/v1/accounts/' . $user_id . '/follow' );
+		$response = $this->dispatch_authenticated( $request );
+
+		$this->assertGreaterThanOrEqual( 400, $response->get_status() );
+		$this->assertEquals( 0, $this->count_follow_activities() );
+	}
+
+	/**
+	 * Another plugin that handles follows keeps the last word.
+	 */
+	public function test_follow_defers_to_another_integration() {
+		$handled = false;
+		$handler = function ( $user_id ) use ( &$handled ) {
+			$handled = true;
+			return $user_id;
+		};
+		add_filter( 'mastodon_api_account_follow', $handler );
+
+		$user_id  = Mastodon_API::remap_user_id( 'nobody@mastodon.local' );
+		$request  = $this->api_request( 'POST', '/api/v1/accounts/' . $user_id . '/follow' );
+		$response = $this->dispatch_authenticated( $request );
+
+		remove_filter( 'mastodon_api_account_follow', $handler );
+
+		$this->assertTrue( $handled );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	/**
+	 * The account of a local user reports the ActivityPub follow counts.
+	 */
+	public function test_account_reports_following_count() {
+		\Activitypub\Collection\Following::follow( $this->actor_post_id, $this->administrator );
+		\Activitypub\Collection\Following::accept( $this->actor_post_id, $this->administrator );
+
+		$request  = $this->api_request( 'GET', '/api/v1/accounts/verify_credentials' );
+		$response = $this->dispatch_authenticated( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 1, $response->get_data()->following_count );
+	}
+
+	/**
+	 * The following list contains the remote accounts followed via ActivityPub.
+	 */
+	public function test_account_following_list() {
+		\Activitypub\Collection\Following::follow( $this->actor_post_id, $this->administrator );
+		\Activitypub\Collection\Following::accept( $this->actor_post_id, $this->administrator );
+
+		$request  = $this->api_request( 'GET', '/api/v1/accounts/' . $this->administrator . '/following' );
+		$response = $this->dispatch_authenticated( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertCount( 1, $data );
+		$this->assertEquals( strval( $this->actor_post_id ), $data[0]->id );
+		$this->assertEquals( 'remote@mastodon.local', $data[0]->acct );
+	}
+}


### PR DESCRIPTION
Fixes #327: following a remote account from a Mastodon app returned 200 but no follow was ever created.

## What was happening

EMA does not own following behavior. `api_account_follow()` fires `mastodon_api_account_follow` and expects an integration to act on it. Neither plugin in the reported setup does so for the account ids involved:

- the ActivityPub plugin hands out **remote actor post ids** (`ap_actor`) as Mastodon account ids from its own `mastodon_api_account` integration, but hooks nothing into following;
- Friends resolves an account id via `User::get_user_by_id()`, which only knows its own users and subscription terms, and its `friends_create_and_follow` fallback is a stub.

So a follow of a remote actor fell through the whole filter chain, the endpoint returned the relationship anyway, and the app showed no error.

## Ownership boundary

The ActivityPub plugin stays authoritative for follows; EMA only translates between Mastodon account ids and remote actor posts and calls `\Activitypub\follow()` / `\Activitypub\unfollow()`. Concretely:

- following runs at **priority 20**, so Friends — or anything else hooked into `mastodon_api_account_follow` — gets first refusal and this integration is only the fallback. The account id the app asked about is remembered at priority 1, because a handler that declines may return `null` rather than the id it was given;
- it is a no-op when the actor is already followed or pending, so it never repeats a follow another integration performed;
- a follow it cannot perform is only turned into an error when nothing else is hooked into `mastodon_api_account_follow` — when a plugin owns following, that plugin decides the outcome and EMA stays out of it;
- followers lists and remote account rendering are **not** touched: the ActivityPub plugin's own EMA integration already provides those. Only the following list and following count fall back to the ActivityPub collections, and only when no other integration filled them in.

### Measured against Friends 4.2.1 + ActivityPub 9.3.1

Both plugins loaded alongside EMA, driving the real endpoint:

| account id the app was given | who follows | Follow activities in outbox |
| --- | --- | --- |
| Friends subscription (`1e10 + term`) | **Friends** — activates its ActivityPub feed and federates on its own schedule; EMA resolves no remote actor and does nothing | 0 added by EMA, feed active |
| remote actor post id (`ap_actor`) | **EMA** — Friends does not recognise the id, so EMA follows; Friends then picks it up via its own `post_activitypub_add_to_outbox` handler and creates the matching subscription | 1 |

A repeat follow adds none in either case. Both directions have regression tests that stand in for another integration with a filter, so they run without Friends installed.

Account ids are resolved from remote actor post ids, actor URLs and webfinger addresses. The follow acts as the current user's actor, falling back to the blog actor in blog-only mode, mirroring how the ActivityPub plugin picks an actor.

The relationship entity now reports `following` / `requested` / `followed_by` from `Following::check_status()` and `Followers::follows()`, so a client sees the follow take effect (a fresh follow is `requested` until the remote side accepts).

## Endpoint hardening

`api_account_follow()` no longer feeds a handler's return value straight into the relationship lookup. A handler that returns nothing (Friends' stub returns `null`) now falls back to the requested account id instead of taking it down with it, and a `WP_Error` from a handler is passed through to the client instead of being swallowed.

## Validation

- `vendor/bin/phpunit`: 159 tests, 709 assertions, all passing (WordPress 7.1, PHP 8.4, ActivityPub 9.3.1).
- 10 new tests in `tests/test-follow-endpoint.php`. The core ones fail when the integration is not registered — including the exact reported symptom: `POST /api/v1/accounts/<id>/follow` returns 200 while no Follow activity reaches the outbox.
- Also run with Friends 4.2.1 loaded alongside, to produce the table above.
- `vendor/bin/phpcs`: clean across the repo.
- `vendor/bin/parallel-lint`: clean.
- Every ActivityPub symbol used was checked to exist in 9.0.0, the version CI pins.
- Exercised read-only against a live site running EMA + Friends 4.2.1 + ActivityPub 9.3.1: the relationship for an already-followed remote actor now reports `following: true`, the follow filter is correctly a no-op for it (status stays `accepted`, no second activity), and the account reports non-zero follow counts. The write path was not exercised on the live site to avoid federating a real follow; it is covered by the tests.

## Not addressed here

- The issue also mentions that remote profiles show a post count but no statuses. That is rendered by the Friends/ActivityPub account handlers and is a separate concern.
- Running the suite with Friends loaded surfaced a **pre-existing fatal in Friends**, unrelated to this change and reproducible with this integration disabled: `Friends\Enable_Mastodon_Apps::mastodon_api_account_unfollow()` calls `$user->get_active_feeds()` without checking that `User::get_user_by_id()` returned `false`, so unfollowing any account id that is not a Friends user is a 500. It runs before EMA's unfollow handler, so it cannot be worked around from here — it needs a null check in Friends.

https://claude.ai/code/session_01T9Jg2jb91xQTbTJBd3pSvN
