### PR TITLE
Include the featured image as a media attachment

### DIFF
--- a/includes/handler/class-status.php
+++ b/includes/handler/class-status.php
@@ -62,7 +62,12 @@ class Status extends Handler {
 		$media_ids = array();
 
 		if ( \function_exists( 'has_post_thumbnail' ) && \has_post_thumbnail( $post->ID ) ) {
-			$media_ids[] = \get_post_thumbnail_id( $post->ID );
+			$thumbnail_id = \get_post_thumbnail_id( $post->ID );
+			if ( $thumbnail_id ) {
+				// The array is keyed by attachment ID, the value is the HTML to be removed from the content.
+				// A featured image is not part of the content, so there is nothing to remove.
+				$media_ids[ $thumbnail_id ] = '';
+			}
 		}
 
 		$blocks = \parse_blocks( $post->post_content );
@@ -278,8 +283,10 @@ class Status extends Handler {
 			foreach ( $media_attachments as $media_id => $html ) {
 				$media_attachment = apply_filters( 'mastodon_api_media_attachment', null, $media_id );
 				if ( $media_attachment ) {
-					// We don't want to show the media in the content as they are attachments.
-					$status->content             = str_replace( $html, '', $status->content );
+					if ( $html ) {
+						// We don't want to show the media in the content as they are attachments.
+						$status->content = str_replace( $html, '', $status->content );
+					}
 					$status->media_attachments[] = $media_attachment;
 				}
 			}

--- a/tests/test-statuses-endpoint.php
+++ b/tests/test-statuses-endpoint.php
@@ -77,6 +77,55 @@ class StatusesEndpoint_Test extends Mastodon_API_TestCase {
 		$this->assertEmpty( $data->media_attachments );
 	}
 
+	public function test_status_uses_featured_image_as_media_attachment() {
+		$post_id = wp_insert_post(
+			array(
+				'post_author'  => $this->friend,
+				'post_content' => '<!-- wp:paragraph --><p>A post whose image is only the featured image.</p><!-- /wp:paragraph -->',
+				'post_title'   => 'Featured image only',
+				'post_status'  => 'publish',
+				'post_type'    => 'post',
+			)
+		);
+		set_post_thumbnail( $post_id, $this->friend_attachment_id );
+
+		$request  = $this->api_request( 'GET', '/api/v1/statuses/' . $post_id );
+		$response = $this->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertCount( 1, $data->media_attachments );
+		$this->assertEquals( strval( $this->friend_attachment_id ), $data->media_attachments[0]->id );
+		$this->assertStringContainsString( 'A post whose image is only the featured image.', $data->content );
+	}
+
+	public function test_status_does_not_duplicate_featured_image_used_in_content() {
+		$post_content = sprintf(
+			'<!-- wp:image {"id":%1$d} -->
+<figure class="wp-block-image"><img src="https://example.org/image.png" alt="" class="wp-image-%1$d" /></figure>
+<!-- /wp:image -->',
+			$this->friend_attachment_id
+		);
+		$post_id      = wp_insert_post(
+			array(
+				'post_author'  => $this->friend,
+				'post_content' => $post_content,
+				'post_title'   => 'Featured image also in content',
+				'post_status'  => 'publish',
+				'post_type'    => 'post',
+			)
+		);
+		set_post_thumbnail( $post_id, $this->friend_attachment_id );
+
+		$request  = $this->api_request( 'GET', '/api/v1/statuses/' . $post_id );
+		$response = $this->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertCount( 1, $data->media_attachments );
+		$this->assertStringNotContainsString( '<img', $data->content );
+	}
+
 	public function test_statuses_private_id() {
 		$request = $this->api_request( 'GET', '/api/v1/statuses/' . $this->private_post );
 		$response = $this->dispatch( $request );


### PR DESCRIPTION
Posts whose only image is the featured image were returned with `"media_attachments": []` by the Mastodon Client API, so no image showed up in Mastodon/Pixelfed apps, even though the same post federates its `attachment` correctly via ActivityPub.

`get_block_attachments()` builds a map of attachment ID => block HTML (the HTML is used to strip the media from the status content), but the featured image was appended as a *value*:

```php
$media_ids[] = \get_post_thumbnail_id( $post->ID );
```

`api_status()` iterates that array by key, so for a featured image it called `apply_filters( 'mastodon_api_media_attachment', null, 0 )`, which returns null, and the attachment was silently dropped. The generic `<img>` scanner does not compensate, because a featured image is not part of `post_content`.

The featured image is now keyed by its attachment ID with an empty HTML value (there is nothing to remove from the content), and the `str_replace` is skipped in that case. Keying it also collapses the duplicate that occurred when the featured image was additionally present as an image block: previously that produced two entries, one broken and one working.

### Verification

The unit tests could not be run locally (no test database available), so the code path was exercised in a disposable WordPress with the plugin mounted, running the same script with and without the change:

```
=== BEFORE ===
featured image only          attachments=0 []          content_has_img=0
image block only             attachments=1 [4(image)]  content_has_img=0
featured image + same block  attachments=1 [4(image)]  content_has_img=0

=== AFTER ===
featured image only          attachments=1 [4(image)]  content_has_img=0
image block only             attachments=1 [4(image)]  content_has_img=0
featured image + same block  attachments=1 [4(image)]  content_has_img=0
```

Two tests covering both cases are included; `phpcs` is clean on the changed files.

Fixes #329

https://claude.ai/code/session_01CUVxR8uyLTg2roNVWgp91y