### PR TITLE
Query every notification source separately

### DIFF
--- a/includes/class-comment-cpt.php
+++ b/includes/class-comment-cpt.php
@@ -50,7 +50,7 @@ class Comment_CPT {
 		add_filter( 'mastodon_api_account', array( $this, 'api_account' ), 10, 4 );
 		add_filter( 'mastodon_api_in_reply_to_id', array( $this, 'mastodon_api_in_reply_to_id' ), 15 );
 		add_filter( 'mastodon_api_notification_type', array( $this, 'mastodon_api_notification_type' ), 10, 2 );
-		add_filter( 'mastodon_api_get_notifications_query_args', array( $this, 'mastodon_api_get_notifications_query_args' ), 10, 2 );
+		add_filter( 'mastodon_api_get_notifications_queries', array( $this, 'mastodon_api_get_notifications_queries' ), 10, 2 );
 	}
 
 	public function register_custom_post_type() {
@@ -363,16 +363,14 @@ class Comment_CPT {
 		return $type;
 	}
 
-	public function mastodon_api_get_notifications_query_args( $args, $type ) {
+	public function mastodon_api_get_notifications_queries( $queries, $type ) {
 		if ( 'mention' === $type ) {
-			if ( ! isset( $args['post_type'] ) ) {
-				$args['post_type'] = array();
-			} elseif ( ! is_array( $args['post_type'] ) ) {
-				$args['post_type'] = array( $args['post_type'] );
-			}
-			$args['post_type'][] = self::CPT;
+			$queries[] = array(
+				'post_type'   => self::CPT,
+				'post_status' => 'publish',
+			);
 		}
 
-		return $args;
+		return $queries;
 	}
 }

--- a/includes/handler/class-conversation.php
+++ b/includes/handler/class-conversation.php
@@ -38,7 +38,7 @@ class Conversation extends Status {
 		add_filter( 'mastodon_api_conversation_delete', array( $this, 'delete_conversation' ), 10 );
 		add_filter( 'mastodon_api_status_context_post_types', array( $this, 'conversation_post_type' ), 10, 2 );
 		add_filter( 'mastodon_api_status_context_post_statuses', array( $this, 'conversation_post_status' ), 10, 2 );
-		add_filter( 'mastodon_api_get_notifications_query_args', array( $this, 'conversation_query_args' ), 20, 2 );
+		add_filter( 'mastodon_api_get_notifications_queries', array( $this, 'conversation_queries' ), 20, 2 );
 		add_filter( 'the_title', array( $this, 'show_dm_text' ), 10, 2 );
 		add_filter( 'post_row_actions', array( $this, 'dm_row_actions' ), 10, 2 );
 	}
@@ -166,29 +166,17 @@ class Conversation extends Status {
 		return $post_types;
 	}
 
-	public function conversation_query_args( $args, $type ) {
+	public function conversation_queries( $queries, $type ) {
 		if ( 'mention' !== $type ) {
-			return $args;
-		}
-		if ( ! isset( $args['post_type'] ) ) {
-			$args['post_type'] = array();
-		} elseif ( ! is_array( $args['post_type'] ) ) {
-			$args['post_type'] = array( $args['post_type'] );
-		}
-		$args['post_type'][] = Mastodon_Api::get_dm_cpt();
-
-		if ( ! isset( $args['post_status'] ) ) {
-			$args['post_status'] = array();
-		} elseif ( ! is_array( $args['post_status'] ) ) {
-			$args['post_status'] = array( $args['post_status'] );
-		}
-		foreach ( $this->get_post_statuses() as $post_status ) {
-			if ( ! in_array( $post_status, $args['post_status'], true ) ) {
-				$args['post_status'][] = $post_status;
-			}
+			return $queries;
 		}
 
-		return $args;
+		$queries[] = array(
+			'post_type'   => Mastodon_Api::get_dm_cpt(),
+			'post_status' => $this->get_post_statuses(),
+		);
+
+		return $queries;
 	}
 
 	public function show_dm_text( $title, $post_id ) {

--- a/includes/handler/class-notification.php
+++ b/includes/handler/class-notification.php
@@ -119,13 +119,22 @@ class Notification extends Handler {
 		$limit         = $request->get_param( 'limit' ) ? $request->get_param( 'limit' ) : 15;
 		$notifications = array();
 		$types         = $request->get_param( 'types' );
-		$args          = array(
-			'posts_per_page' => $limit + 2,
-		);
 		$exclude_types = $request->get_param( 'exclude_types' );
 		if ( ( ! is_array( $types ) || in_array( 'mention', $types, true ) ) && ( ! is_array( $exclude_types ) || ! in_array( 'mention', $exclude_types, true ) ) ) {
+			$base_args = array(
+				'author__not_in' => array( get_current_user_id() ),
+			);
+
+			$queries = array();
+
 			/**
 			 * Get the WP_Query arguments for fetching notifications.
+			 *
+			 * This filter provides a single query that all its callers need to share. Since
+			 * WP_Query applies post statuses and taxonomy queries to every post type in it,
+			 * one caller can filter out another caller's posts. Prefer the
+			 * mastodon_api_get_notifications_queries filter, which queries each source
+			 * separately.
 			 *
 			 * @param array $args WP_Query arguments.
 			 * @param string $type Type of notifications.
@@ -144,55 +153,95 @@ class Notification extends Handler {
 			 */
 			$args = apply_filters(
 				'mastodon_api_get_notifications_query_args',
-				array(
-					'author__not_in' => array( get_current_user_id() ),
-				),
+				$base_args,
 				'mention',
 				$request
 			);
-			if ( ! isset( $args['post_type'] ) ) {
-				return array();
+			if ( isset( $args['post_type'] ) ) {
+				$queries[] = $args;
 			}
-			$args['posts_per_page'] = $limit + 2;
+
+			/**
+			 * Get the queries for fetching notifications.
+			 *
+			 * Every entry is a set of WP_Query arguments that is queried on its own, so that
+			 * the post statuses or taxonomy queries a notification source needs don't apply
+			 * to the posts of the other sources. The posts the current user authored are
+			 * excluded from each of them.
+			 *
+			 * @param array $queries The queries, each of them WP_Query arguments.
+			 * @param string $type Type of notifications.
+			 * @param object $request Request object from WP.
+			 * @return array The modified queries.
+			 *
+			* Example:
+			* ```php
+			* add_filter( 'mastodon_api_get_notifications_queries', function( $queries, $type ) {
+			*     if ( $type === 'mention' ) {
+			*         $queries[] = array(
+			*             'post_type'   => 'my_message',
+			*             'post_status' => 'my_unread',
+			*         );
+			*     }
+			*     return $queries;
+			* } );
+			* ```
+			 */
+			$queries = apply_filters( 'mastodon_api_get_notifications_queries', $queries, 'mention', $request );
 
 			$notification_dismissed_tag = get_term_by( 'slug', apply_filters( 'mastodon_api_notification_dismissed_tag', 'notification-dismissed' ), 'post_tag' );
-			if ( $notification_dismissed_tag ) {
-				$args['tag__not_in'] = array( $notification_dismissed_tag->term_id );
-			}
-			foreach ( get_posts( $args ) as $post ) {
-				$type = apply_filters( 'mastodon_api_notification_type', 'mention', $post );
-				switch ( $type ) {
-					case 'like':
-						$type = 'favourite';
-						$status  = apply_filters( 'mastodon_api_status', null, $post->post_parent, array() );
-						break;
-					case 'repost':
-						$type = 'reblog';
-						$status  = apply_filters( 'mastodon_api_status', null, $post->post_parent, array() );
-						break;
-					default:
-						$type = 'mention';
-						$status  = apply_filters( 'mastodon_api_status', null, $post->ID, array() );
-				}
 
-				if ( is_array( $types ) && ! in_array( $type, $types, true ) ) {
+			$seen_post_ids = array();
+			foreach ( $queries as $args ) {
+				if ( empty( $args['post_type'] ) ) {
 					continue;
 				}
-				if ( is_array( $exclude_types ) && in_array( $type, $exclude_types, true ) ) {
-					continue;
-				}
+				$args                   = array_merge( $base_args, $args );
+				$args['posts_per_page'] = $limit + 2;
 
-				$account = apply_filters( 'mastodon_api_account', null, $post->post_author, null, $post );
-				if ( $status ) {
-					$status->account = $account;
+				if ( $notification_dismissed_tag ) {
+					$args['tag__not_in'] = array( $notification_dismissed_tag->term_id );
 				}
+				foreach ( get_posts( $args ) as $post ) {
+					if ( isset( $seen_post_ids[ $post->ID ] ) ) {
+						continue;
+					}
+					$seen_post_ids[ $post->ID ] = true;
 
-				$notifications[] = $this->get_notification_array(
-					$type,
-					mysql2date( 'Y-m-d\TH:i:s.000P', $post->post_date, false ),
-					$account,
-					$status
-				);
+					$type = apply_filters( 'mastodon_api_notification_type', 'mention', $post );
+					switch ( $type ) {
+						case 'like':
+							$type = 'favourite';
+							$status  = apply_filters( 'mastodon_api_status', null, $post->post_parent, array() );
+							break;
+						case 'repost':
+							$type = 'reblog';
+							$status  = apply_filters( 'mastodon_api_status', null, $post->post_parent, array() );
+							break;
+						default:
+							$type = 'mention';
+							$status  = apply_filters( 'mastodon_api_status', null, $post->ID, array() );
+					}
+
+					if ( is_array( $types ) && ! in_array( $type, $types, true ) ) {
+						continue;
+					}
+					if ( is_array( $exclude_types ) && in_array( $type, $exclude_types, true ) ) {
+						continue;
+					}
+
+					$account = apply_filters( 'mastodon_api_account', null, $post->post_author, null, $post );
+					if ( $status ) {
+						$status->account = $account;
+					}
+
+					$notifications[] = $this->get_notification_array(
+						$type,
+						mysql2date( 'Y-m-d\TH:i:s.000P', $post->post_date, false ),
+						$account,
+						$status
+					);
+				}
 			}
 		}
 

--- a/tests/test-notifications-endpoint.php
+++ b/tests/test-notifications-endpoint.php
@@ -69,6 +69,116 @@ class NotificationsEndpoint_Test extends Mastodon_API_TestCase {
 		$this->assertArrayHasKey( '/' . Mastodon_API::PREFIX . '/api/v1/notifications', $routes );
 	}
 
+	/**
+	 * Collect the status IDs of the notifications in a response.
+	 *
+	 * @param array $data The decoded response data.
+	 * @return array The status IDs.
+	 */
+	private function notification_status_ids( array $data ): array {
+		$ids = array();
+		foreach ( $data as $notification ) {
+			if ( ! empty( $notification['status']['id'] ) ) {
+				$ids[] = $notification['status']['id'];
+			}
+		}
+		return $ids;
+	}
+
+	public function test_direct_message_creates_a_notification() {
+		$dm = wp_insert_post(
+			array(
+				'post_author'  => $this->friend,
+				'post_content' => 'A direct message for you',
+				'post_status'  => 'ema_unread',
+				'post_type'    => Mastodon_API::get_dm_cpt( $this->administrator ),
+			)
+		);
+
+		$request  = $this->api_request( 'GET', '/api/v1/notifications' );
+		$response = $this->dispatch_authenticated( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = json_decode( wp_json_encode( $response->get_data() ), true );
+		$this->assertContains( strval( $dm ), $this->notification_status_ids( $data ) );
+	}
+
+	public function test_comment_creates_a_notification() {
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $this->post,
+				'comment_content'  => 'A comment on your post',
+				'user_id'          => $this->friend,
+				'comment_approved' => 1,
+			)
+		);
+		$comment_post_id = Comment_CPT::comment_id_to_post_id( $comment_id );
+		$this->assertNotEmpty( $comment_post_id );
+
+		$request  = $this->api_request( 'GET', '/api/v1/notifications' );
+		$response = $this->dispatch_authenticated( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = json_decode( wp_json_encode( $response->get_data() ), true );
+		$this->assertContains( strval( $comment_post_id ), $this->notification_status_ids( $data ) );
+	}
+
+	/**
+	 * A notification source that needs its own post statuses or taxonomy terms must not
+	 * filter out the posts of the other sources.
+	 */
+	public function test_third_party_query_does_not_hide_other_notifications() {
+		$dm = wp_insert_post(
+			array(
+				'post_author'  => $this->friend,
+				'post_content' => 'A direct message for you',
+				'post_status'  => 'ema_unread',
+				'post_type'    => Mastodon_API::get_dm_cpt( $this->administrator ),
+			)
+		);
+
+		add_filter(
+			'mastodon_api_get_notifications_query_args',
+			function ( $args, $type ) {
+				if ( 'mention' !== $type ) {
+					return $args;
+				}
+				$args['post_type'] = 'post';
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+				$args['tax_query'] = array(
+					array(
+						'taxonomy' => 'post_tag',
+						'field'    => 'name',
+						'terms'    => 'mentions-of-someone-else',
+					),
+				);
+				return $args;
+			},
+			10,
+			2
+		);
+
+		$request  = $this->api_request( 'GET', '/api/v1/notifications' );
+		$response = $this->dispatch_authenticated( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = json_decode( wp_json_encode( $response->get_data() ), true );
+		$this->assertContains( strval( $dm ), $this->notification_status_ids( $data ) );
+	}
+
+	public function test_notification_sources_are_queried_separately() {
+		$queries = apply_filters( 'mastodon_api_get_notifications_queries', array(), 'mention', $this->api_request( 'GET', '/api/v1/notifications' ) );
+
+		$post_types = array();
+		foreach ( $queries as $query ) {
+			$this->assertArrayHasKey( 'post_type', $query );
+			$post_types[] = $query['post_type'];
+		}
+
+		$this->assertContains( Comment_CPT::CPT, $post_types );
+		$this->assertContains( Mastodon_API::get_dm_cpt( get_current_user_id() ), $post_types );
+	}
+
 	public function test_notifications_sorted_newest_first() {
 		$this->inject_test_notifications(
 			array(


### PR DESCRIPTION
Refs #320.

Notifications are collected from several sources — the comment CPT, direct messages, and whatever plugins add — but they all had to share **one** `WP_Query`, built through `mastodon_api_get_notifications_query_args`. WP_Query applies post statuses and taxonomy queries to every post type in the query, so each source's constraints were silently applied to the other sources' posts:

* The Friends plugin adds its cached posts plus a `tax_query` for the current user's mention tag. Comments and DMs don't carry that term, so **with Friends active no comment or DM notification could ever be returned** — the query came out as `... AND ( 0 = 1 )` when the term didn't exist yet, and excluded them all when it did.
* The conversation handler appended the DM post statuses to the shared query without `publish`, which dropped comment notifications even with Friends inactive.

This adds a `mastodon_api_get_notifications_queries` filter: each source contributes its own set of query arguments and each set is queried on its own, with `author__not_in` and the dismissed-notification tag applied to all of them and results de-duplicated by post ID. The comment CPT and the DM handler use it now.

The old filter keeps working — its result is queried as one more source — so a plugin using it now only constrains its own posts. It's documented as superseded.

### Verification

The unit tests can't run locally (no test database), so this was exercised in a disposable WordPress with EMA + Friends + ActivityPub, creating a comment on the user's post, a DM in the EMA DM post type, a Friends-cached public mention carrying the mention tag, and a DM received through Friends:

```
=== BEFORE ===
notifications: 1
  mention  post_type=friend_post_cache

=== AFTER ===
notifications: 3
  mention  post_type=friend_post_cache
  mention  post_type=ema-dm-1
  mention  post_type=comment
```

Without Friends installed, comment mentions go from 0 to 1 and DMs from 0 to 1 as well.

The fourth post — a DM received through the Friends plugin (`friend_message`) — still produces no notification: Friends doesn't register its messages as a notification source. That needs the matching one-liner on the Friends side, which is what remains of #320 for people who receive their DMs through Friends.

Four tests are included (DM notification, comment notification, a third-party query with an unmatched `tax_query` not hiding the others, and both built-in sources registering their own query); `phpcs` is clean on the changed files.

https://claude.ai/code/session_01CUVxR8uyLTg2roNVWgp91y