### PR TITLE
Don't split off a title for post types that don't support one

### DIFF
--- a/includes/handler/class-status.php
+++ b/includes/handler/class-status.php
@@ -276,7 +276,13 @@ class Status extends Handler {
 			$status->url        = get_permalink( $post );
 			$status->content    = $post->post_content;
 			if ( ! empty( $post->post_title ) && trim( $post->post_title ) ) {
-				$status->content = '<strong>' . esc_html( $post->post_title ) . '</strong>' . PHP_EOL . $status->content;
+				if ( post_type_supports( $post->post_type, 'title' ) ) {
+					$status->content = '<strong>' . esc_html( $post->post_title ) . '</strong>' . PHP_EOL . $status->content;
+				} else {
+					// Posts created by an app before the title split was disabled still carry a
+					// title. Keep the text (it can be the entire status) but don't render it bold.
+					$status->content = esc_html( $post->post_title ) . PHP_EOL . $status->content;
+				}
 			}
 			$status->account    = $account;
 			$media_attachments  = $this->get_block_attachments( $post );
@@ -542,13 +548,18 @@ class Status extends Handler {
 		$post_data['post_title'] = '';
 
 		if ( ! $post_format || 'standard' === $post_format ) {
-			$post_content_parts = preg_split( self::get_line_split_pattern(), $status_text, 2 );
-			if ( count( $post_content_parts ) === 2 ) {
-				$post_data['post_title']   = wp_strip_all_tags( $post_content_parts[0] );
-				$post_data['post_content'] = trim( $post_content_parts[1] );
-			} elseif ( ! empty( $media_ids ) ) {
-				$post_data['post_title']   = wp_strip_all_tags( $status_text );
-				$post_data['post_content'] = '';
+			// Only split the first line off as a title if the post type actually supports one.
+			// The default ema-post CPT (and the DM CPT) don't, so the title would be invisible
+			// in WordPress and only come back to the app as a bold first line.
+			if ( post_type_supports( $post_data['post_type'], 'title' ) ) {
+				$post_content_parts = preg_split( self::get_line_split_pattern(), $status_text, 2 );
+				if ( count( $post_content_parts ) === 2 ) {
+					$post_data['post_title']   = wp_strip_all_tags( $post_content_parts[0] );
+					$post_data['post_content'] = trim( $post_content_parts[1] );
+				} elseif ( ! empty( $media_ids ) ) {
+					$post_data['post_title']   = wp_strip_all_tags( $status_text );
+					$post_data['post_content'] = '';
+				}
 			}
 
 			if ( $app->get_first_line_as_excerpt() && ! empty( $post_data['post_content'] ) ) {

--- a/tests/test-statuses-endpoint.php
+++ b/tests/test-statuses-endpoint.php
@@ -527,6 +527,69 @@ class StatusesEndpoint_Test extends Mastodon_API_TestCase {
 		$this->assertEquals( 'just a short toot', $p->post_content );
 	}
 
+	public function test_submit_multiline_standard_to_post_type_without_title_support() {
+		$this->app->set_post_formats( 'standard' );
+		$this->app->set_create_post_format( 'standard' );
+		$this->app->set_create_post_type( Mastodon_API::POST_CPT );
+		$this->app->set_disable_blocks( true );
+
+		$request = $this->api_request( 'POST', '/api/v1/statuses' );
+		$request->set_param( 'status', 'headline' . PHP_EOL . 'post_content' );
+		$response = $this->dispatch_authenticated( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$p = get_post( $response->get_data()->id );
+		$this->assertEquals( '', $p->post_title );
+		$this->assertEquals( 'headline' . PHP_EOL . 'post_content', $p->post_content );
+	}
+
+	public function test_submit_single_line_standard_with_media_to_post_type_without_title_support() {
+		$this->app->set_post_formats( 'standard' );
+		$this->app->set_create_post_format( 'standard' );
+		$this->app->set_create_post_type( Mastodon_API::POST_CPT );
+		$this->app->set_disable_blocks( true );
+
+		$request = $this->api_request( 'POST', '/api/v1/statuses' );
+		$request->set_param( 'status', 'caption text' );
+		$request->set_param( 'media_ids', array( (string) $this->friend_attachment_id ) );
+		$response = $this->dispatch_authenticated( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$p = get_post( $response->get_data()->id );
+		$this->assertEquals( '', $p->post_title );
+		$this->assertStringContainsString( 'caption text', $p->post_content );
+		$this->assertStringContainsString( 'wp:image', $p->post_content );
+	}
+
+	public function test_status_does_not_bold_title_of_post_type_without_title_support() {
+		$post_id = wp_insert_post(
+			array(
+				'post_author'  => $this->administrator,
+				'post_content' => 'post_content',
+				'post_title'   => 'headline',
+				'post_status'  => 'publish',
+				'post_type'    => Mastodon_API::POST_CPT,
+			)
+		);
+
+		$request = $this->api_request( 'GET', '/api/v1/statuses/' . $post_id );
+		$response = $this->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$content = $response->get_data()->content;
+		$this->assertStringNotContainsString( '<strong>', $content );
+		$this->assertStringContainsString( 'headline', $content );
+		$this->assertStringContainsString( 'post_content', $content );
+	}
+
+	public function test_status_bolds_title_of_post_type_with_title_support() {
+		$request = $this->api_request( 'GET', '/api/v1/statuses/' . $this->friend_post );
+		$response = $this->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$this->assertStringContainsString( '<strong>Friend title</strong>', $response->get_data()->content );
+	}
+
 	public function test_submit_standard_uses_first_content_line_as_excerpt() {
 		$this->app->set_post_formats( 'standard' );
 		$this->app->set_create_post_format( 'standard' );


### PR DESCRIPTION
Fixes #319.

## The problem

When a status is submitted with the standard post format, `Status::prepare_post_data()` moves the first line into `post_title` and keeps the rest as `post_content`. On the way back out, `api_status()` prepends that title as `<strong>`, so the first line of every toot shows up bold in the client.

In the default configuration this is pure loss: apps post to the `ema-post` CPT, which is registered without `title` support (as is the DM CPT), so the title is invisible everywhere in WordPress and its only observable effect is the bold line in the app.

## The fix

**Write side** — only split the first line off when the target post type actually supports a title. Apps configured to create regular `post`s are unaffected, which is the case where first-line-as-title is the point.

**Read side** — posts created before this still carry a title, so render it without `<strong>` when the post type has no title support. It can't simply be dropped: for a single-line status with media the entire text went into the title and `post_content` is empty.

`get_first_line_as_excerpt()` deliberately stayed outside the new guard, so it keeps working for `ema-post` (where ActivityPub may publish the excerpt).

## Verification

`composer test` can't run in this environment, so the change was exercised in a real WordPress via the Playground CLI, running the same script against the unmodified checkout and against this branch:

| case | before | after |
| --- | --- | --- |
| write `ema-post`, multiline | title=`headline`, content=`post_content` | title=`''`, content=`headline\npost_content` |
| write `post`, multiline | title=`headline`, content=`post_content` | unchanged |
| write `ema-post`, 1 line + image | title=`caption text`, text gone from content | title=`''`, text in content |
| write `post`, 1 line + image | title=`caption text` | unchanged |
| read `ema-post` with title | `<strong>headline</strong>\npost_content` | `headline\npost_content` |
| read `post` with title | `<strong>headline</strong>\npost_content` | unchanged |

Every `post` row is untouched; every `ema-post` row is fixed.

Four unit tests were added covering both submit branches and both read-back cases. They pass `php -l` and `phpcs` locally but have only been run by CI. The existing title assertions all use `set_create_post_type( 'post' )`, so they are unaffected.

https://claude.ai/code/session_017JXdALJE2HAAPXorRxQWUd
