### PR TITLE
Federate what Mastodon apps actually submit

### DIFF
--- a/includes/class-mastodon-api.php
+++ b/includes/class-mastodon-api.php
@@ -3901,8 +3901,8 @@ class Mastodon_API {
 	private function software_string() {
 		global $wp_version;
 		$software = 'WordPress/' . $wp_version;
-		if ( defined( 'ACTIVITYPUB_VERSION' ) ) {
-			$software .= ', ActivityPub/' . ACTIVITYPUB_VERSION;
+		if ( defined( 'ACTIVITYPUB_PLUGIN_VERSION' ) ) {
+			$software .= ', ActivityPub/' . ACTIVITYPUB_PLUGIN_VERSION;
 		}
 		$software .= ', EMA/' . self::VERSION;
 		return $software;

--- a/includes/handler/class-status.php
+++ b/includes/handler/class-status.php
@@ -492,6 +492,46 @@ class Status extends Handler {
 		return trim( wp_strip_all_tags( $post_content_parts[0] ) );
 	}
 
+	/**
+	 * The ActivityPub content visibility that corresponds to Mastodon's "unlisted".
+	 *
+	 * @return string The visibility value.
+	 */
+	private static function get_quiet_public_visibility(): string {
+		return defined( 'ACTIVITYPUB_CONTENT_VISIBILITY_QUIET_PUBLIC' ) ? ACTIVITYPUB_CONTENT_VISIBILITY_QUIET_PUBLIC : 'quiet_public';
+	}
+
+	/**
+	 * Whether a status mentions somebody on the Fediverse.
+	 *
+	 * @param string $text The status text as it was submitted by the app.
+	 * @return bool Whether the text contains an @user@domain mention.
+	 */
+	private static function contains_mention( string $text ): bool {
+		$username_pattern = defined( 'ACTIVITYPUB_USERNAME_REGEXP' ) ? ACTIVITYPUB_USERNAME_REGEXP : '(?:[A-Za-z0-9\._-]+@(?:[A-Za-z0-9_-]+\.)+[A-Za-z]+)';
+
+		return 1 === preg_match( '/@' . $username_pattern . '/i', $text );
+	}
+
+	/**
+	 * Render the ActivityPub reply block for a status on another server.
+	 *
+	 * @param string $url The URL of the status that is being replied to.
+	 * @return string The block markup, or an empty string without the ActivityPub plugin.
+	 */
+	private static function render_reply_block( string $url ): string {
+		if ( ! defined( 'ACTIVITYPUB_PLUGIN_VERSION' ) ) {
+			return '';
+		}
+
+		$attributes = array(
+			'url'       => $url,
+			'embedPost' => false,
+		);
+
+		return '<!-- wp:activitypub/reply ' . wp_json_encode( $attributes ) . ' /-->' . PHP_EOL . PHP_EOL;
+	}
+
 	private static function get_attachment_description( int $media_id ): string {
 		return trim( wp_strip_all_tags( get_post_field( 'post_excerpt', $media_id ) ) );
 	}
@@ -517,6 +557,10 @@ class Status extends Handler {
 		}
 		$app = Mastodon_App::get_current_app();
 
+		// Keep what the app actually submitted around: integrations rewrite mentions into
+		// links, so the filtered text is no longer a reliable place to look for them.
+		$submitted_status_text = $status_text;
+
 		/**
 		 * Allow modifying the status text before it gets posted.
 		 *
@@ -535,12 +579,22 @@ class Status extends Handler {
 				$post_data['post_status'] = 'publish';
 				break;
 
+			case 'unlisted':
+				// Unlisted is still federated, it is only kept out of the public timelines.
+				// WordPress has no post status for that, so the post is published and the
+				// ActivityPub plugin is asked to address it quietly.
+				$post_data['post_status'] = 'publish';
+				$post_data['meta_input']['activitypub_content_visibility'] = self::get_quiet_public_visibility();
+				break;
+
 			case 'direct':
 				$post_data['post_status'] = 'ema_unread';
 				$post_data['post_type'] = Mastodon_API::get_dm_cpt();
 				break;
 
 			default:
+				// Followers-only posts stay private: WordPress does not federate them and
+				// ActivityPub has no followers-only audience to map them onto.
 				$post_data['post_status'] = 'private';
 				break;
 		}
@@ -551,7 +605,11 @@ class Status extends Handler {
 			// Only split the first line off as a title if the post type actually supports one.
 			// The default ema-post CPT (and the DM CPT) don't, so the title would be invisible
 			// in WordPress and only come back to the app as a bold first line.
-			if ( post_type_supports( $post_data['post_type'], 'title' ) ) {
+			// A status that mentions somebody keeps all of its text in the content: the
+			// ActivityPub plugin reads the content and the excerpt to work out whom to
+			// address, never the title, so a mention that ends up in the title is never
+			// delivered to the person it names.
+			if ( post_type_supports( $post_data['post_type'], 'title' ) && ! self::contains_mention( $submitted_status_text ) ) {
 				$post_content_parts = preg_split( self::get_line_split_pattern(), $status_text, 2 );
 				if ( count( $post_content_parts ) === 2 ) {
 					$post_data['post_title']   = wp_strip_all_tags( $post_content_parts[0] );
@@ -575,7 +633,17 @@ class Status extends Handler {
 			if ( is_numeric( $in_reply_to_id ) ) {
 				$post_data['post_parent'] = $in_reply_to_id;
 			} else {
+				// Our own fallback, applied while the activity is being serialized. It sets
+				// inReplyTo, but by then the audience of the object has already been worked
+				// out, so the author of the post being replied to is not addressed.
 				$post_data['meta_input']['activitypub_in_reply_to'] = $in_reply_to_id;
+
+				// A reply block is what the ActivityPub plugin reads natively while it builds
+				// the object, so the author of the replied-to post ends up in the audience and
+				// is notified about the reply.
+				if ( ! $app->get_disable_blocks() ) {
+					$post_data['post_content'] = self::render_reply_block( $in_reply_to_id ) . $post_data['post_content'];
+				}
 			}
 		}
 

--- a/includes/handler/class-status.php
+++ b/includes/handler/class-status.php
@@ -605,11 +605,13 @@ class Status extends Handler {
 			// Only split the first line off as a title if the post type actually supports one.
 			// The default ema-post CPT (and the DM CPT) don't, so the title would be invisible
 			// in WordPress and only come back to the app as a bold first line.
-			// A status that mentions somebody keeps all of its text in the content: the
-			// ActivityPub plugin reads the content and the excerpt to work out whom to
-			// address, never the title, so a mention that ends up in the title is never
-			// delivered to the person it names.
-			if ( post_type_supports( $post_data['post_type'], 'title' ) && ! self::contains_mention( $submitted_status_text ) ) {
+			// Only the text that would become the title matters: the ActivityPub plugin reads
+			// the content and the excerpt to work out whom to address, never the title, so a
+			// mention that ends up there is never delivered to the person it names. A mention
+			// further down the status is in no danger and the post still gets its title. The
+			// submitted text is what gets checked, since integrations rewrite mentions above.
+			$submitted_parts = preg_split( self::get_line_split_pattern(), $submitted_status_text, 2 );
+			if ( post_type_supports( $post_data['post_type'], 'title' ) && ! self::contains_mention( $submitted_parts[0] ) ) {
 				$post_content_parts = preg_split( self::get_line_split_pattern(), $status_text, 2 );
 				if ( count( $post_content_parts ) === 2 ) {
 					$post_data['post_title']   = wp_strip_all_tags( $post_content_parts[0] );

--- a/tests/test-statuses-endpoint.php
+++ b/tests/test-statuses-endpoint.php
@@ -750,6 +750,22 @@ class StatusesEndpoint_Test extends Mastodon_API_TestCase {
 		$this->assertStringContainsString( 'What do you think?', $p->post_content );
 	}
 
+	public function test_submit_multiline_status_with_mention_below_the_first_line_keeps_its_title() {
+		$this->app->set_post_formats( 'standard' );
+		$this->app->set_create_post_format( 'standard' );
+		$this->app->set_create_post_type( 'post' );
+		$this->app->set_disable_blocks( true );
+
+		$request = $this->api_request( 'POST', '/api/v1/statuses' );
+		$request->set_param( 'status', 'My holiday photos' . PHP_EOL . 'Went with @doe@example.org' );
+		$response = $this->dispatch_authenticated( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$p = get_post( $response->get_data()->id );
+		$this->assertEquals( 'My holiday photos', $p->post_title, 'A mention below the first line does not cost the post its title' );
+		$this->assertStringContainsString( '@doe@example.org', $p->post_content );
+	}
+
 	public function test_submit_single_line_status_with_mention_and_media_keeps_the_mention_in_the_content() {
 		$this->app->set_post_formats( 'standard' );
 		$this->app->set_create_post_format( 'standard' );

--- a/tests/test-statuses-endpoint.php
+++ b/tests/test-statuses-endpoint.php
@@ -682,8 +682,85 @@ class StatusesEndpoint_Test extends Mastodon_API_TestCase {
 		$post_id = intval( $data->id );
 		$post = get_post( $post_id );
 		$this->assertNotNull( $post, 'A new post should have been created for the remote reply' );
-		$this->assertStringNotContainsString( 'activitypub/reply', $post->post_content, 'Post content should not contain activitypub/reply block' );
+		$this->assertStringContainsString( 'wp:activitypub/reply', $post->post_content, 'Post content should contain the activitypub/reply block' );
+		$this->assertStringContainsString( $remote_url, $post->post_content, 'The reply block should point at the remote status' );
 		$this->assertEquals( $remote_url, get_post_meta( $post_id, 'activitypub_in_reply_to', true ), 'Remote URL should be stored as activitypub_in_reply_to meta' );
+	}
+
+	public function test_submit_status_reply_to_remote_post_without_blocks() {
+		$this->app->set_disable_blocks( true );
+
+		$remote_url = 'https://remote.example/status/23456';
+		$numeric_id = Mastodon_API::remap_url( $remote_url );
+
+		$request = $this->api_request( 'POST', '/api/v1/statuses' );
+		$request->set_param( 'status', 'Reply to remote post' );
+		$request->set_param( 'in_reply_to_id', $numeric_id );
+		$response = $this->dispatch_authenticated( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$post_id = intval( $response->get_data()->id );
+		$post    = get_post( $post_id );
+		$this->assertStringNotContainsString( 'activitypub/reply', $post->post_content, 'An app that disabled blocks should not get one' );
+		$this->assertEquals( $remote_url, get_post_meta( $post_id, 'activitypub_in_reply_to', true ), 'Remote URL should be stored as activitypub_in_reply_to meta' );
+	}
+
+	public function test_submit_unlisted_status_is_published_quietly() {
+		$request = $this->api_request( 'POST', '/api/v1/statuses' );
+		$request->set_param( 'status', 'Not for the public timelines' );
+		$request->set_param( 'visibility', 'unlisted' );
+		$response = $this->dispatch_authenticated( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$post_id = intval( $response->get_data()->id );
+		$this->assertEquals( 'publish', get_post_status( $post_id ), 'An unlisted status still needs to federate' );
+		$this->assertEquals( 'quiet_public', get_post_meta( $post_id, 'activitypub_content_visibility', true ) );
+	}
+
+	public function test_submit_private_status_stays_private() {
+		$request = $this->api_request( 'POST', '/api/v1/statuses' );
+		$request->set_param( 'status', 'Just for my followers' );
+		$request->set_param( 'visibility', 'private' );
+		$response = $this->dispatch_authenticated( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$post_id = intval( $response->get_data()->id );
+		$this->assertEquals( 'private', get_post_status( $post_id ) );
+		$this->assertEquals( '', get_post_meta( $post_id, 'activitypub_content_visibility', true ) );
+	}
+
+	public function test_submit_multiline_status_with_mention_keeps_the_mention_in_the_content() {
+		$this->app->set_post_formats( 'standard' );
+		$this->app->set_create_post_format( 'standard' );
+		$this->app->set_create_post_type( 'post' );
+		$this->app->set_disable_blocks( true );
+
+		$request = $this->api_request( 'POST', '/api/v1/statuses' );
+		$request->set_param( 'status', '@doe@example.org' . PHP_EOL . 'What do you think?' );
+		$response = $this->dispatch_authenticated( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$p = get_post( $response->get_data()->id );
+		$this->assertEquals( '', $p->post_title, 'A mention must not end up in the post title' );
+		$this->assertStringContainsString( '@doe@example.org', $p->post_content );
+		$this->assertStringContainsString( 'What do you think?', $p->post_content );
+	}
+
+	public function test_submit_single_line_status_with_mention_and_media_keeps_the_mention_in_the_content() {
+		$this->app->set_post_formats( 'standard' );
+		$this->app->set_create_post_format( 'standard' );
+		$this->app->set_create_post_type( 'post' );
+		$this->app->set_disable_blocks( true );
+
+		$request = $this->api_request( 'POST', '/api/v1/statuses' );
+		$request->set_param( 'status', 'look at this @doe@example.org' );
+		$request->set_param( 'media_ids', array( (string) $this->friend_attachment_id ) );
+		$response = $this->dispatch_authenticated( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$p = get_post( $response->get_data()->id );
+		$this->assertEquals( '', $p->post_title, 'A mention must not end up in the post title' );
+		$this->assertStringContainsString( '@doe@example.org', $p->post_content );
 	}
 
 	public function test_get_multiple_statuses() {

--- a/tests/test-statuses-endpoint.php
+++ b/tests/test-statuses-endpoint.php
@@ -682,8 +682,12 @@ class StatusesEndpoint_Test extends Mastodon_API_TestCase {
 		$post_id = intval( $data->id );
 		$post = get_post( $post_id );
 		$this->assertNotNull( $post, 'A new post should have been created for the remote reply' );
-		$this->assertStringContainsString( 'wp:activitypub/reply', $post->post_content, 'Post content should contain the activitypub/reply block' );
-		$this->assertStringContainsString( $remote_url, $post->post_content, 'The reply block should point at the remote status' );
+		if ( defined( 'ACTIVITYPUB_PLUGIN_VERSION' ) ) {
+			$this->assertStringContainsString( 'wp:activitypub/reply', $post->post_content, 'Post content should contain the activitypub/reply block' );
+			$this->assertStringContainsString( $remote_url, $post->post_content, 'The reply block should point at the remote status' );
+		} else {
+			$this->assertStringNotContainsString( 'activitypub/reply', $post->post_content, 'Without the ActivityPub plugin there is no block to add' );
+		}
 		$this->assertEquals( $remote_url, get_post_meta( $post_id, 'activitypub_in_reply_to', true ), 'Remote URL should be stored as activitypub_in_reply_to meta' );
 	}
 


### PR DESCRIPTION
Part of #309: mentions written in a Mastodon app never reach the person they name, and replies do not show up on the Fediverse.

## Ownership boundary

The Mastodon API surface is EMA's; deciding who an activity is addressed to, and delivering it, stays entirely with the ActivityPub plugin. This PR is only about handing that plugin everything the app submitted, in the places it looks. It does not add any addressing or delivery logic of its own, and it does not change what happens when the ActivityPub plugin is not installed.

The remaining half of #309 belongs to the ActivityPub plugin and is raised there separately: its Enable Mastodon Apps integration rewrites `@user@domain` into `<a rel="mention">@user</a>` on `mastodon_api_submit_status_text`, before the post is stored, and its own federation-time mention extractor then scans the stored content for `@user@domain` and finds nothing. Until that lands, a mention still produces no `Mention` tag — the changes here are what makes the mention survive long enough for that fix to matter.

## Proposed changes

**An unlisted status became a private WordPress post.** Every visibility that was not `public` or `direct` fell through to `post_status = 'private'`, which ActivityPub never federates and which EMA's own timeline query (`post_status = 'publish'`) also filters out. Mastodon's `unlisted` is a public post that is merely kept out of the public timelines, so it is now published with `activitypub_content_visibility = quiet_public` — the same mapping the Friends plugin has been applying from the outside via `mastodon_api_submit_post_data`. Followers-only stays private and unfederated, as before: WordPress will not federate it and ActivityPub has no followers-only audience to map it onto. That is now stated in a comment rather than being an accident of the `default:` branch.

**A first line that mentioned somebody was split off into the post title.** ActivityPub works out whom to address from `post_content` and `post_excerpt`, never from `post_title`, so the account named on the first line was silently dropped from the audience. A status that mentions anybody now keeps all of its text in the content. The check runs against the text as the app submitted it, before `mastodon_api_submit_status_text`, because integrations rewrite mentions on that filter.

**A reply to a status on another server only carried its target in post meta.** EMA turns that meta into `inReplyTo` on `activitypub_activity_object_array`, which runs while the activity is being serialized — after the object's audience has already been decided, so the author being replied to was never added to `cc`. Replies now also carry an `activitypub/reply` block, which the ActivityPub plugin reads natively while it builds the object. The meta stays as the fallback for apps that have blocks disabled and for sites where blocks are unavailable.

**`ACTIVITYPUB_VERSION` does not exist.** The nodeinfo software string therefore never reported the ActivityPub version. It is `ACTIVITYPUB_PLUGIN_VERSION`.

## Testing instructions

With the ActivityPub plugin active, from a Mastodon app:

1. Post a status set to **unlisted**. It should appear as a published post and reach your followers, rather than becoming a private post that goes nowhere.
2. Point the app at a post type that supports titles (Settings → Enable Mastodon Apps → the app's "Create post type"), then post two lines with a mention on the first: `@someone@example.social` newline `What do you think?`. The post should keep both lines in its content and have no title.
3. Reply to a post from another server. The stored post should contain a `wp:activitypub/reply` block pointing at it, alongside the existing `activitypub_in_reply_to` meta.

## Verification

Run against a live site with ActivityPub 9.3.1, building the activity for each case and reading back what would be federated:

- `unlisted` → `post_status=publish`, `activitypub_content_visibility=quiet_public`; `private` → `post_status=private`, no visibility meta.
- A two-line status with a mention → empty `post_title`, both lines in `post_content`.
- With the mention left intact in the content, the object gains `tag: [{type: Mention, href: …}]` and the account appears in `cc`; without it, both are empty. This is what the ActivityPub-side fix restores.
- A reply block on its own, with no mention anywhere in the content, puts the replied-to author into `cc` — the meta alone does not.

`php -l` and `phpcs --standard=phpcs.xml.dist` are clean on the changed files, with no new warnings against the branch point. The PHPUnit suite was **not** run: there is no test database on this machine. Six tests are added or updated in `tests/test-statuses-endpoint.php` and want a CI run — including `test_submit_status_reply_to_remote_post`, whose "should not contain activitypub/reply block" assertion this change deliberately reverses.

- [x] Have you written new tests for your changes, if applicable?

https://claude.ai/code/session_01Lz9siENjr1dxjBK1eosc8a