### PR TITLE
Don't drop media attachments that lack dimensions

### DIFF
--- a/includes/entity/class-entity.php
+++ b/includes/entity/class-entity.php
@@ -119,7 +119,8 @@ abstract class Entity implements \JsonSerializable {
 			}
 
 			if ( preg_match( '/array\[([^\]]+)\]/', $object, $matches ) ) {
-				$object = $matches[1];
+				$object    = $matches[1];
+				$skippable = false;
 				if ( substr( $object, -1 ) === '?' ) {
 					$object    = rtrim( $object, '?' );
 					$skippable = true;
@@ -145,6 +146,8 @@ abstract class Entity implements \JsonSerializable {
 						$array[ $var ][ $key ] = $value->jsonSerialize();
 						if ( isset( $array[ $var ][ $key ]['error'] ) ) {
 							if ( $skippable ) {
+								// Not fatal for the entity as a whole, but record it so that it doesn't vanish without a trace.
+								Mastodon_API::set_last_error( get_class( $value ) . ' in ' . get_called_class() . '::$' . $var . ' was skipped: ' . $array[ $var ][ $key ]['error'] );
 								unset( $array[ $var ][ $key ] );
 								continue;
 							}

--- a/includes/entity/class-media-attachment.php
+++ b/includes/entity/class-media-attachment.php
@@ -84,53 +84,75 @@ class Media_Attachment extends Entity {
 	 */
 	public ?string $blurhash = null;
 
-	private function check_meta( $meta, $prepend = '' ) {
-		if ( ! isset( $meta['width'] ) || $meta['width'] <= 0 ) {
-			return new \WP_Error( 'invalid-meta-width', $prepend . 'Meta width must be a positive integer.' );
+	/**
+	 * Normalize a set of dimensions.
+	 *
+	 * @param mixed $meta The array that should carry width and height.
+	 *
+	 * @return array|null The array with consistent width, height, size and aspect, or null if there are no usable dimensions.
+	 */
+	private static function normalize_dimensions( $meta ) {
+		if ( ! is_array( $meta ) ) {
+			return null;
 		}
-		if ( ! isset( $meta['height'] ) || $meta['height'] <= 0 ) {
-			return new \WP_Error( 'invalid-meta-height', $prepend . 'Meta height must be a positive integer.' );
+
+		$width  = isset( $meta['width'] ) ? intval( $meta['width'] ) : 0;
+		$height = isset( $meta['height'] ) ? intval( $meta['height'] ) : 0;
+		if ( $width <= 0 || $height <= 0 ) {
+			return null;
 		}
-		if ( ! isset( $meta['size'] ) || ! is_string( $meta['size'] ) ) {
-			return new \WP_Error( 'invalid-meta-size', $prepend . 'Meta size must be a string.' );
+
+		$meta['width']  = $width;
+		$meta['height'] = $height;
+		$meta['size']   = $width . 'x' . $height;
+		$meta['aspect'] = $width / $height;
+
+		return $meta;
+	}
+
+	/**
+	 * Normalize the meta data, dropping dimensions we cannot use.
+	 *
+	 * Width and height are optional in ActivityStreams, so an attachment handed
+	 * to us by another plugin often has none, and other sources supply zeroes.
+	 * Those dimensions are dropped rather than treated as an error: an image
+	 * without a size hint still displays, an image dropped from the status does
+	 * not.
+	 *
+	 * @param mixed $meta The meta data.
+	 *
+	 * @return array The meta data without unusable dimensions.
+	 */
+	private static function normalize_meta( $meta ) {
+		if ( ! is_array( $meta ) ) {
+			return array();
 		}
-		if ( ! isset( $meta['aspect'] ) || ! is_numeric( $meta['aspect'] ) ) {
-			return new \WP_Error( 'invalid-meta-aspect', $prepend . 'Meta aspect must be a number.' );
+
+		foreach ( array( 'small', 'original' ) as $size ) {
+			if ( ! isset( $meta[ $size ] ) ) {
+				continue;
+			}
+			$dimensions = self::normalize_dimensions( $meta[ $size ] );
+			if ( null === $dimensions ) {
+				unset( $meta[ $size ] );
+			} else {
+				$meta[ $size ] = $dimensions;
+			}
+		}
+
+		if ( isset( $meta['width'] ) || isset( $meta['height'] ) ) {
+			$dimensions = self::normalize_dimensions( $meta );
+			if ( null === $dimensions ) {
+				unset( $meta['width'], $meta['height'], $meta['size'], $meta['aspect'] );
+			} else {
+				$meta = $dimensions;
+			}
 		}
 
 		return $meta;
 	}
 
 	public function validate( $key ) {
-		if ( 'meta' === $key ) {
-			if ( empty( $this->meta ) ) {
-				return new \WP_Error( 'invalid-meta', 'Meta must not be empty.' );
-			}
-			if ( ! is_array( $this->meta ) ) {
-				return new \WP_Error( 'invalid-meta', 'Meta must be an array.' );
-			}
-			if ( 'image' === $this->type ) {
-				if ( isset( $this->meta['small'] ) ) {
-					$meta = $this->check_meta( $this->meta['small'], 'small: ' );
-					if ( is_wp_error( $meta ) ) {
-						return $meta;
-					}
-				}
-				if ( isset( $this->meta['original'] ) ) {
-					$meta = $this->check_meta( $this->meta['original'], 'original: ' );
-					if ( is_wp_error( $meta ) ) {
-						return $meta;
-					}
-				}
-				if ( isset( $this->meta['width'] ) ) {
-					$meta = $this->check_meta( $this->meta );
-					if ( is_wp_error( $meta ) ) {
-						return $meta;
-					}
-				}
-			}
-		}
-
 		if ( 'preview_url' === $key ) {
 			if ( 'video' === $this->type ) {
 				if ( ! $this->preview_url || ! is_string( $this->preview_url ) ) {
@@ -144,6 +166,12 @@ class Media_Attachment extends Entity {
 	public function __get( $key ) {
 		if ( 'url' === $key || 'preview_url' === $key || 'remote_url' === $key ) {
 			return str_replace( ' ', '%20', $this->$key );
+		}
+		if ( 'meta' === $key ) {
+			$meta = self::normalize_meta( $this->meta );
+
+			// Mastodon documents meta as a hash, and an empty PHP array would be serialized as [].
+			return empty( $meta ) ? new \stdClass() : $meta;
 		}
 		return parent::__get( $key );
 	}

--- a/includes/handler/class-media-attachment.php
+++ b/includes/handler/class-media-attachment.php
@@ -26,6 +26,7 @@ class Media_Attachment extends Handler {
 		add_filter( 'mastodon_api_media_attachment', array( $this, 'video_attachment' ), 10, 2 );
 		add_filter( 'mastodon_api_status', array( $this, 'add_generic_image_attachments' ), 20 );
 		add_filter( 'mastodon_api_status', array( $this, 'add_generic_video_attachments' ), 20 );
+		add_filter( 'mastodon_api_status', array( $this, 'add_missing_image_dimensions' ), 30 );
 		add_action( 'mastodon_api_media_uploaded', array( $this, 'schedule_video_thumbnail_generation' ) );
 	}
 
@@ -238,25 +239,118 @@ class Media_Attachment extends Handler {
 			$attachment->preview_url = $block['src'];
 			$attachment->remote_url  = $block['src'];
 			if ( isset( $block['width'] ) && $block['width'] > 0 && isset( $block['height'] ) && $block['height'] > 0 ) {
-				$attachment->meta = array(
+				$attachment->meta             = array(
 					'width'  => intval( $block['width'] ),
 					'height' => intval( $block['height'] ),
 					'size'   => $block['width'] . 'x' . $block['height'],
 					'aspect' => (int) $block['width'] / (int) $block['height'],
 				);
-			} else {
-				$attachment->meta = array(
-					'width'  => 0,
-					'height' => 0,
-					'size'   => '0x0',
-					'aspect' => 1,
-				);
+				$attachment->meta['original'] = $attachment->meta;
 			}
-			$original                     = $attachment->meta;
-			$attachment->meta['original'] = $original;
-			$attachment->description      = '';
-			$status->media_attachments[]  = $attachment;
+			$attachment->description     = '';
+			$status->media_attachments[] = $attachment;
 		}
+		return $status;
+	}
+
+	/**
+	 * Get the dimensions of a locally hosted image, remembering them for the request.
+	 *
+	 * @param string $url The image URL.
+	 *
+	 * @return array|false An array with the width and the height, or false if they cannot be determined.
+	 */
+	private static function get_local_image_dimensions( string $url ) {
+		static $cache = array();
+		if ( isset( $cache[ $url ] ) ) {
+			return $cache[ $url ];
+		}
+
+		$cache[ $url ] = self::look_up_local_image_dimensions( $url );
+
+		return $cache[ $url ];
+	}
+
+	/**
+	 * Look up the dimensions of a locally hosted image.
+	 *
+	 * @param string $url The image URL.
+	 *
+	 * @return array|false An array with the width and the height, or false if they cannot be determined.
+	 */
+	private static function look_up_local_image_dimensions( string $url ) {
+		$uploads = \wp_get_upload_dir();
+		if ( empty( $uploads['baseurl'] ) || 0 !== strpos( $url, $uploads['baseurl'] ) ) {
+			return false;
+		}
+
+		// A resized file states its dimensions in its filename.
+		if ( preg_match( '/-(\d+)x(\d+)\.\w+$/', $url, $matches ) ) {
+			return array( intval( $matches[1] ), intval( $matches[2] ) );
+		}
+
+		$attachment_id = \attachment_url_to_postid( $url );
+		if ( ! $attachment_id ) {
+			return false;
+		}
+
+		$meta = \wp_get_attachment_metadata( $attachment_id );
+		if ( ! empty( $meta['width'] ) && ! empty( $meta['height'] ) ) {
+			return array( intval( $meta['width'] ), intval( $meta['height'] ) );
+		}
+
+		// The metadata was never generated, e.g. for an import; fall back to the file itself.
+		$file = \get_attached_file( $attachment_id );
+		if ( $file && file_exists( $file ) ) {
+			$size = \wp_getimagesize( $file );
+			if ( $size ) {
+				return array( $size[0], $size[1] );
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Add the dimensions of image attachments that arrived without them.
+	 *
+	 * Width and height are optional in ActivityStreams, so a status assembled
+	 * from an AS2 object -- as the ActivityPub plugin does for its own posts --
+	 * carries no dimensions at all. Clients use them to lay the image out
+	 * before it has loaded, so look them up when the image is one of our own.
+	 *
+	 * @param \Enable_Mastodon_Apps\Entity\Status $status The status object.
+	 *
+	 * @return \Enable_Mastodon_Apps\Entity\Status The status object with image dimensions added.
+	 */
+	public function add_missing_image_dimensions( $status ) {
+		if ( ! $status instanceof Status_Entity || empty( $status->media_attachments ) ) {
+			return $status;
+		}
+
+		foreach ( $status->media_attachments as $media_attachment ) {
+			if ( ! $media_attachment instanceof Media_Attachment_Entity || 'image' !== $media_attachment->type ) {
+				continue;
+			}
+			if ( ! empty( $media_attachment->meta['width'] ) || ! empty( $media_attachment->meta['original']['width'] ) ) {
+				continue;
+			}
+
+			$dimensions = self::get_local_image_dimensions( $media_attachment->url );
+			if ( ! $dimensions ) {
+				continue;
+			}
+
+			list( $width, $height ) = $dimensions;
+
+			$media_attachment->meta['original'] = array(
+				'width'  => $width,
+				'height' => $height,
+				'size'   => $width . 'x' . $height,
+				'aspect' => $height ? $width / $height : 0,
+			);
+		}
+
 		return $status;
 	}
 
@@ -308,13 +402,6 @@ class Media_Attachment extends Handler {
 					'height' => intval( $block['height'] ),
 					'size'   => $block['width'] . 'x' . $block['height'],
 					'aspect' => (int) $block['width'] / (int) $block['height'],
-				);
-			} else {
-				$attachment->meta = array(
-					'width'  => 0,
-					'height' => 0,
-					'size'   => '0x0',
-					'aspect' => 1,
 				);
 			}
 			$attachment->description     = '';

--- a/includes/handler/class-media-attachment.php
+++ b/includes/handler/class-media-attachment.php
@@ -26,7 +26,7 @@ class Media_Attachment extends Handler {
 		add_filter( 'mastodon_api_media_attachment', array( $this, 'video_attachment' ), 10, 2 );
 		add_filter( 'mastodon_api_status', array( $this, 'add_generic_image_attachments' ), 20 );
 		add_filter( 'mastodon_api_status', array( $this, 'add_generic_video_attachments' ), 20 );
-		add_filter( 'mastodon_api_status', array( $this, 'add_missing_image_dimensions' ), 30 );
+		add_filter( 'mastodon_api_status', array( get_called_class(), 'add_missing_image_dimensions' ), 30 );
 		add_action( 'mastodon_api_media_uploaded', array( $this, 'schedule_video_thumbnail_generation' ) );
 	}
 
@@ -323,7 +323,7 @@ class Media_Attachment extends Handler {
 	 *
 	 * @return \Enable_Mastodon_Apps\Entity\Status The status object with image dimensions added.
 	 */
-	public function add_missing_image_dimensions( $status ) {
+	public static function add_missing_image_dimensions( $status ) {
 		if ( ! $status instanceof Status_Entity || empty( $status->media_attachments ) ) {
 			return $status;
 		}

--- a/tests/test-media-attachment-meta.php
+++ b/tests/test-media-attachment-meta.php
@@ -114,28 +114,63 @@ class MediaAttachmentMeta_Test extends Mastodon_API_TestCase {
 		$this->assertArrayHasKey( 'focus', $meta );
 	}
 
-	public function test_missing_dimensions_are_looked_up_for_local_images() {
-		$status = $this->status_with_image( array(), wp_get_attachment_url( $this->friend_attachment_id ) );
-
-		// Documented in class-mastodon-api.php.
-		$status = apply_filters( 'mastodon_api_status', $status, $this->friend_post );
-		$data   = $status->jsonSerialize();
+	/**
+	 * Run the handler that adds missing dimensions over a status.
+	 *
+	 * The handler is called directly rather than through the mastodon_api_status
+	 * filter: the ActivityPub plugin hooks that filter at priority 9 and returns
+	 * a status of its own making, discarding the one passed in, so a status built
+	 * here would never reach the handler when that plugin is active.
+	 *
+	 * @param Status $status The status to run the handler over.
+	 *
+	 * @return array The serialized meta data of the first media attachment.
+	 */
+	private function add_missing_dimensions( Status $status ): array {
+		// The constructor registers hooks that are registered already.
+		$handler = ( new \ReflectionClass( \Enable_Mastodon_Apps\Handler\Media_Attachment::class ) )->newInstanceWithoutConstructor();
+		$data    = $handler->add_missing_image_dimensions( $status )->jsonSerialize();
 
 		$this->assertCount( 1, $data['media_attachments'] );
-		$meta = $data['media_attachments'][0]['meta'];
+
+		return (array) $data['media_attachments'][0]['meta'];
+	}
+
+	public function test_missing_dimensions_are_looked_up_for_local_images() {
+		$meta = $this->add_missing_dimensions( $this->status_with_image( array(), wp_get_attachment_url( $this->friend_attachment_id ) ) );
+
 		$this->assertSame( 1000, $meta['original']['width'] );
 		$this->assertSame( 1000, $meta['original']['height'] );
 		$this->assertSame( '1000x1000', $meta['original']['size'] );
 	}
 
+	public function test_missing_dimensions_are_taken_from_a_resized_filename() {
+		$url  = str_replace( 'ima ge.png', 'ima ge-300x200.png', wp_get_attachment_url( $this->friend_attachment_id ) );
+		$meta = $this->add_missing_dimensions( $this->status_with_image( array(), $url ) );
+
+		$this->assertSame( 300, $meta['original']['width'] );
+		$this->assertSame( 200, $meta['original']['height'] );
+	}
+
 	public function test_missing_dimensions_of_remote_images_are_left_alone() {
-		$status = $this->status_with_image( array(), 'https://remote.example/image.png' );
+		$meta = $this->add_missing_dimensions( $this->status_with_image( array(), 'https://remote.example/image.png' ) );
 
-		// Documented in class-mastodon-api.php.
-		$status = apply_filters( 'mastodon_api_status', $status, $this->friend_post );
-		$data   = $status->jsonSerialize();
+		$this->assertSame( array(), $meta );
+	}
 
-		$this->assertCount( 1, $data['media_attachments'] );
-		$this->assertEquals( '{}', wp_json_encode( $data['media_attachments'][0]['meta'] ) );
+	public function test_existing_dimensions_are_not_overwritten() {
+		$status = $this->status_with_image(
+			array(
+				'original' => array(
+					'width'  => 400,
+					'height' => 300,
+				),
+			),
+			wp_get_attachment_url( $this->friend_attachment_id )
+		);
+		$meta   = $this->add_missing_dimensions( $status );
+
+		$this->assertSame( 400, $meta['original']['width'] );
+		$this->assertSame( 300, $meta['original']['height'] );
 	}
 }

--- a/tests/test-media-attachment-meta.php
+++ b/tests/test-media-attachment-meta.php
@@ -9,6 +9,7 @@ namespace Enable_Mastodon_Apps;
 
 use Enable_Mastodon_Apps\Entity\Media_Attachment;
 use Enable_Mastodon_Apps\Entity\Status;
+use Enable_Mastodon_Apps\Handler\Media_Attachment as Media_Attachment_Handler;
 
 /**
  * Testcases for the media attachment meta data.
@@ -127,9 +128,7 @@ class MediaAttachmentMeta_Test extends Mastodon_API_TestCase {
 	 * @return array The serialized meta data of the first media attachment.
 	 */
 	private function add_missing_dimensions( Status $status ): array {
-		// The constructor registers hooks that are registered already.
-		$handler = ( new \ReflectionClass( \Enable_Mastodon_Apps\Handler\Media_Attachment::class ) )->newInstanceWithoutConstructor();
-		$data    = $handler->add_missing_image_dimensions( $status )->jsonSerialize();
+		$data = Media_Attachment_Handler::add_missing_image_dimensions( $status )->jsonSerialize();
 
 		$this->assertCount( 1, $data['media_attachments'] );
 

--- a/tests/test-media-attachment-meta.php
+++ b/tests/test-media-attachment-meta.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Class MediaAttachmentMeta_Test.
+ *
+ * @package Enable_Mastodon_Apps
+ */
+
+namespace Enable_Mastodon_Apps;
+
+use Enable_Mastodon_Apps\Entity\Media_Attachment;
+use Enable_Mastodon_Apps\Entity\Status;
+
+/**
+ * Testcases for the media attachment meta data.
+ */
+class MediaAttachmentMeta_Test extends Mastodon_API_TestCase {
+	/**
+	 * Create a status that carries a single image attachment.
+	 *
+	 * @param array  $meta The meta data of the attachment.
+	 * @param string $url  The URL of the attachment.
+	 *
+	 * @return Status The status entity.
+	 */
+	private function status_with_image( array $meta, string $url = 'https://example.org/image.png' ): Status {
+		$attachment              = new Media_Attachment();
+		$attachment->id          = '1';
+		$attachment->type        = 'image';
+		$attachment->url         = $url;
+		$attachment->preview_url = $url;
+		$attachment->meta        = $meta;
+
+		$status                    = new Status();
+		$status->id                = strval( $this->friend_post );
+		$status->created_at        = new \DateTime( '2023-01-04 00:00:00', new \DateTimeZone( 'UTC' ) );
+		$status->visibility        = 'public';
+		$status->uri               = 'https://example.org/?p=1';
+		$status->content           = 'A photo.';
+		$status->account           = apply_filters( 'mastodon_api_account', null, $this->friend );
+		$status->media_attachments = array( $attachment );
+
+		return $status;
+	}
+
+	public function test_attachment_without_meta_is_not_dropped() {
+		$data = $this->status_with_image( array() )->jsonSerialize();
+
+		$this->assertCount( 1, $data['media_attachments'] );
+		// Mastodon documents meta as a hash, so it must not serialize as [].
+		$this->assertEquals( '{}', wp_json_encode( $data['media_attachments'][0]['meta'] ) );
+	}
+
+	public function test_attachment_with_zero_dimensions_is_not_dropped() {
+		$data = $this->status_with_image(
+			array(
+				'original' => array(
+					'width'  => 0,
+					'height' => 0,
+					'size'   => '0x0',
+					'aspect' => 1,
+				),
+			)
+		)->jsonSerialize();
+
+		$this->assertCount( 1, $data['media_attachments'] );
+		$this->assertEquals( '{}', wp_json_encode( $data['media_attachments'][0]['meta'] ) );
+	}
+
+	public function test_incomplete_dimensions_are_completed() {
+		$data = $this->status_with_image(
+			array(
+				'focus'    => array(
+					'x' => 0.5,
+					'y' => -0.5,
+				),
+				'original' => array(
+					'width'  => '800',
+					'height' => '400',
+				),
+			)
+		)->jsonSerialize();
+
+		$this->assertCount( 1, $data['media_attachments'] );
+		$meta = $data['media_attachments'][0]['meta'];
+		$this->assertSame( 800, $meta['original']['width'] );
+		$this->assertSame( 400, $meta['original']['height'] );
+		$this->assertSame( '800x400', $meta['original']['size'] );
+		$this->assertSame( 2.0, $meta['original']['aspect'] );
+		$this->assertSame(
+			array(
+				'x' => 0.5,
+				'y' => -0.5,
+			),
+			$meta['focus']
+		);
+	}
+
+	public function test_unusable_dimensions_keep_the_rest_of_the_meta() {
+		$data = $this->status_with_image(
+			array(
+				'width'  => 0,
+				'height' => 0,
+				'focus'  => array(
+					'x' => 0.0,
+					'y' => 0.0,
+				),
+			)
+		)->jsonSerialize();
+
+		$meta = $data['media_attachments'][0]['meta'];
+		$this->assertArrayNotHasKey( 'width', $meta );
+		$this->assertArrayNotHasKey( 'height', $meta );
+		$this->assertArrayHasKey( 'focus', $meta );
+	}
+
+	public function test_missing_dimensions_are_looked_up_for_local_images() {
+		$status = $this->status_with_image( array(), wp_get_attachment_url( $this->friend_attachment_id ) );
+
+		// Documented in class-mastodon-api.php.
+		$status = apply_filters( 'mastodon_api_status', $status, $this->friend_post );
+		$data   = $status->jsonSerialize();
+
+		$this->assertCount( 1, $data['media_attachments'] );
+		$meta = $data['media_attachments'][0]['meta'];
+		$this->assertSame( 1000, $meta['original']['width'] );
+		$this->assertSame( 1000, $meta['original']['height'] );
+		$this->assertSame( '1000x1000', $meta['original']['size'] );
+	}
+
+	public function test_missing_dimensions_of_remote_images_are_left_alone() {
+		$status = $this->status_with_image( array(), 'https://remote.example/image.png' );
+
+		// Documented in class-mastodon-api.php.
+		$status = apply_filters( 'mastodon_api_status', $status, $this->friend_post );
+		$data   = $status->jsonSerialize();
+
+		$this->assertCount( 1, $data['media_attachments'] );
+		$this->assertEquals( '{}', wp_json_encode( $data['media_attachments'][0]['meta'] ) );
+	}
+}

--- a/tests/test-media-attachment-meta.php
+++ b/tests/test-media-attachment-meta.php
@@ -85,7 +85,8 @@ class MediaAttachmentMeta_Test extends Mastodon_API_TestCase {
 		$this->assertSame( 800, $meta['original']['width'] );
 		$this->assertSame( 400, $meta['original']['height'] );
 		$this->assertSame( '800x400', $meta['original']['size'] );
-		$this->assertSame( 2.0, $meta['original']['aspect'] );
+		// PHP returns an int from an evenly dividing division, so don't be strict about the type here.
+		$this->assertEquals( 2, $meta['original']['aspect'] );
 		$this->assertSame(
 			array(
 				'x' => 0.5,


### PR DESCRIPTION
Fixes #329.

An image without usable width and height was treated as an invalid `Media_Attachment`, and `Entity::jsonSerialize()` silently drops invalid elements of an `array[Media_Attachment?]` field. The photo therefore disappeared from the status between the object graph and the JSON, with no error anywhere — the status came back with `"media_attachments": []`.

That is the common case, not an edge case:

- `width` and `height` are optional in ActivityStreams, so a status assembled by the ActivityPub plugin from its own AS2 object (its `mastodon_api_status` callback runs at priority 9, ahead of ours) carries no dimensions at all.
- An `<img>` in post content often has no size attributes either. `add_generic_image_attachments()` filled in a `0x0` placeholder meta purely to satisfy the validation, and `0` fails the "must be a positive integer" check — so those were dropped too.

## Approach

Meta data we can't use is now dropped instead of the attachment. An image without a size hint still displays; an image dropped from the status does not.

- `Media_Attachment` normalizes `meta` when serializing: it keeps only the dimension subtrees that have a positive width and height, and derives `size` and `aspect` from them, so a partial or inconsistent set no longer invalidates anything. Empty meta serializes as `{}`, the hash Mastodon documents, rather than `[]`.
- `Media_Attachment` handler: new `add_missing_image_dimensions()` on `mastodon_api_status` fills in missing image dimensions from the local attachment when the URL is one of our own uploads, so clients can lay the image out before it loads. Resized URLs take their size from the filename; remote URLs are left alone. Lookups are cached per request.
- `Entity::jsonSerialize()` records a skipped element as the last error rather than discarding it without a trace, and no longer carries `$skippable` over from a previously serialized field.

## Verification

`php -l` and `phpcs --standard=phpcs.xml.dist includes/ tests/` are clean. The unit suite needs a database that isn't available locally, so the behaviour was exercised in a disposable WordPress (Playground) with a real 640×360 upload, running the same script against `main` and against this branch:

| case | before | after |
| --- | --- | --- |
| featured image through EMA's own handler | 1 attachment, full meta | identical |
| no dimensions, full-size upload URL | `[]` | 1, `original: 640x360` |
| no dimensions, resized upload URL | `[]` | 1, `original: 300x169` |
| no dimensions, remote URL | `[]` | 1, `meta: {}` |
| inline `<img>` with no size attributes | `[]` | 1, `meta: {}` |
| block image whose `src` doesn't match the attachment | `[]` | `[]` |

Six tests are added in `tests/test-media-attachment-meta.php` covering the same ground.

## Note on the ActivityPub side

With this in place EMA no longer depends on the ActivityPub plugin sending dimensions. Having ActivityPub emit `width`/`height` on its AS2 `attachment` objects would still be an improvement in its own right, for every consumer rather than just this one — but it is no longer needed to make the images appear.

props @elschnet